### PR TITLE
Update README with build instructions

### DIFF
--- a/README
+++ b/README
@@ -18,3 +18,30 @@ Version 4 kernel API (currently code-named Version X.2), which is
 fully 32 and 64 bit clean, provides multiprocessor support, and
 super-fast local IPC.
 
+
+Requirements
+------------
+Pistachio requires a compiler with C23 support.
+The minimum versions known to work are GCC 14 and Clang 17.
+
+Building on i686 and x86_64 hosts
+--------------------------------
+If you obtained this tree from version control, run the following in
+`user/` before configuring:
+
+    autoheader
+    autoconf
+
+Create a build directory and configure the system:
+
+    mkdir build && cd build
+    ../configure --host=i686 \
+                 --with-comport=0 \
+                 --with-comspeed=115200 \
+                 --with-kerneldir=/path/to/kernel
+
+For 64-bit machines use `--host=amd64`.  Additional link-base options
+(e.g. `--with-kickstart-linkbase`, `--with-s0-linkbase`,
+`--with-roottask-linkbase`) may be supplied as required.
+After configuration run `make` and optionally `make install`.
+


### PR DESCRIPTION
## Summary
- document minimum GCC and Clang versions with C23 support
- add instructions for configuring i686 and x86_64 builds
- note `--with-comport`, `--with-comspeed` and `--with-kerneldir` options

## Testing
- `git log -1 --stat`