### PR TITLE
Update build for C23

### DIFF
--- a/README
+++ b/README
@@ -18,3 +18,21 @@ Version 4 kernel API (currently code-named Version X.2), which is
 fully 32 and 64 bit clean, provides multiprocessor support, and
 super-fast local IPC.
 
+Building with modern compilers
+==============================
+
+The build system now expects a compiler that understands the C23
+language standard. GCC 14 and Clang 17 are known to work. Autoconf
+2.69 or later is required to regenerate the configure script.
+
+Example build steps on a typical Linux host::
+
+    $ cd user
+    $ autoreconf -i        # requires autoconf and autoheader
+    $ ./configure --host=i686-pc-linux-gnu   # or x86_64-pc-linux-gnu
+    $ make
+
+When building the kernel choose either `SUBARCH=x32` for i686 or
+`SUBARCH=x64` for x86_64 in `kernel/Makeconf.local` before invoking
+`make` inside the build directory.
+

--- a/kernel/config/template/Makeconf.local.template
+++ b/kernel/config/template/Makeconf.local.template
@@ -30,6 +30,7 @@
 ##                
 ######################################################################
 ARCH = ia32
+# Select x32 for 32-bit or x64 for 64-bit kernels
 SUBARCH = none
 CPU = p4
 PLATFORM = pc99

--- a/kernel/config/x86.cml
+++ b/kernel/config/x86.cml
@@ -40,6 +40,7 @@ x86_platform			'Platform'
 
 SUBARCH_X32			'32-Bit  x86 Processors (IA-32)'
 SUBARCH_X64			'64-Bit  x86 Processors (AMD64/EM64T)'
+# Select SUBARCH in Makeconf.local to choose x32 (i686) or x64 (x86_64).
 
 CPU_X86_I486			'486'
 CPU_X86_I586			'Pentium1'

--- a/user/Mk/l4.build.mk
+++ b/user/Mk/l4.build.mk
@@ -59,7 +59,7 @@ OBJS+=		${filter %crt0.o crt0%, $(_OBJS)} \
 
 .c.o:	$(MKFILE_DEPS)
 	@$(ECHO_MSG) `echo $< | sed s,^$(top_srcdir)/,,`
-	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c99 -c $< -o $@
+       $(CC) $(CPPFLAGS) $(CFLAGS) -std=c23 -c $< -o $@
 
 .S.o:	$(MKFILE_DEPS)
 	@$(ECHO_MSG) `echo $< | sed s,^$(top_srcdir)/,,`

--- a/user/apps/bench/pingpong/powerpc.h
+++ b/user/apps/bench/pingpong/powerpc.h
@@ -56,10 +56,10 @@ L4_INLINE L4_Word_t read_instrs (void)
 
 L4_INLINE L4_Word_t pingpong_ipc (L4_ThreadId_t dest, L4_Word_t untyped)
 {
-    register L4_Word_t tag asm("r14") = untyped;
-    register L4_Word_t to asm("r15") = dest.raw;
-    register L4_Word_t from asm("r16") = dest.raw;
-    register L4_Word_t timeouts asm("r17") = 0;
+    L4_Word_t tag asm("r14") = untyped;
+    L4_Word_t to asm("r15") = dest.raw;
+    L4_Word_t from asm("r16") = dest.raw;
+    L4_Word_t timeouts asm("r17") = 0;
 
     asm volatile (
 	    "mtctr %4 ;"
@@ -81,10 +81,10 @@ L4_INLINE L4_Word_t pingpong_ipc (L4_ThreadId_t dest, L4_Word_t untyped)
 
 L4_INLINE L4_Word_t pingpong_lipc (L4_ThreadId_t dest, L4_Word_t untyped)
 {
-    register L4_Word_t tag asm("r14") = untyped;
-    register L4_Word_t to asm("r15") = dest.raw;
-    register L4_Word_t from asm("r16") = dest.raw;
-    register L4_Word_t timeouts asm("r17") = 0;
+    L4_Word_t tag asm("r14") = untyped;
+    L4_Word_t to asm("r15") = dest.raw;
+    L4_Word_t from asm("r16") = dest.raw;
+    L4_Word_t timeouts asm("r17") = 0;
 
     asm volatile (
 	    "mtctr %4 ;"

--- a/user/apps/bench/pingpong/powerpc64.h
+++ b/user/apps/bench/pingpong/powerpc64.h
@@ -45,10 +45,10 @@ L4_INLINE L4_Word64_t read_cycles (void)
 
 L4_INLINE L4_Word_t pingpong_ipc (L4_ThreadId_t dest, L4_Word_t untyped)
 {
-    register L4_Word_t r3 asm("r3") = dest.raw;
-    register L4_Word_t r4 asm("r4") = dest.raw;
-    register L4_Word_t r5 asm("r5") = 0;
-    register L4_Word_t tag asm("r14") = untyped;
+    L4_Word_t r3 asm("r3") = dest.raw;
+    L4_Word_t r4 asm("r4") = dest.raw;
+    L4_Word_t r5 asm("r5") = 0;
+    L4_Word_t tag asm("r14") = untyped;
 
     asm volatile (
 	"li	0, -32000;	"

--- a/user/configure.in
+++ b/user/configure.in
@@ -59,7 +59,7 @@ esac
 
 # Determine hardware architecture to build for.
 case $HOST in
-  ia32|x86|i386*|i486*|i586*|i686*)
+  ia32|x86|i386*|i486*|i586*|i686*|i[3-6]86*-pc-linux-gnu*)
 	ARCH=ia32
 	KERNEL=x86-kernel
 	LIBGCCFLAGS=-m32
@@ -72,7 +72,7 @@ case $HOST in
 	ARCH=powerpc
 	KERNEL=$ARCH-kernel
 	;;
-  amd64*|x86_64*)
+  amd64*|x86_64*|x86_64*-pc-linux-gnu*)
 	ARCH=amd64
 	KERNEL=x86-kernel
 	LIBGCCFLAGS=-m64
@@ -123,6 +123,17 @@ AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 AC_PROG_LN_S
 AC_PROG_AWK
+AC_MSG_CHECKING([whether $CC supports -std=c23])
+ac_save_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -std=c23"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
+        [ac_c23=yes],
+        [ac_c23=no])
+CFLAGS="$ac_save_CFLAGS"
+if test "$ac_c23" != yes; then
+  AC_MSG_ERROR([compiler does not support -std=c23])
+fi
+AC_MSG_RESULT([$ac_c23])
 
 dnl Configure parameters
 AC_ARG_WITH([comport],

--- a/user/contrib/elf-loader/platform/amd64-pc99/string.cc
+++ b/user/contrib/elf-loader/platform/amd64-pc99/string.cc
@@ -87,7 +87,7 @@ char * strncat(char *dest, const char *src, unsigned int count)
 
 int strcmp(const char * cs,const char * ct)
 {
-	register signed char __res;
+       signed char __res;
 
 	while (1) {
 		if ((__res = *cs - *ct++) != 0 || !*cs++)
@@ -99,7 +99,7 @@ int strcmp(const char * cs,const char * ct)
 
 int strncmp(const char * cs,const char * ct, unsigned int count)
 {
-	register signed char __res = 0;
+       signed char __res = 0;
 
 	while (count) {
 		if ((__res = *cs - *ct++) != 0 || !*cs++)


### PR DESCRIPTION
## Summary
- switch userland build to C23
- recognize modern host triplets
- check compiler for `-std=c23`
- drop `register` keyword from some asm variables
- document modern toolchain requirements
- note SUBARCH usage in kernel configuration template

## Testing
- `git status --short`