### PR TITLE
Add SUBARCH config notes

### DIFF
--- a/kernel/config/template/Makeconf.local.template
+++ b/kernel/config/template/Makeconf.local.template
@@ -30,6 +30,8 @@
 ##                
 ######################################################################
 ARCH = ia32
+# Select processor width for x86. Use 'x32' for i686 or
+# 'x64' for x86_64 kernels.
 SUBARCH = none
 CPU = p4
 PLATFORM = pc99

--- a/kernel/config/x86.cml
+++ b/kernel/config/x86.cml
@@ -39,7 +39,9 @@ x86_arch			'X86 Processor Architecture'
 x86_platform			'Platform'
 
 SUBARCH_X32			'32-Bit  x86 Processors (IA-32)'
+# Use this for building i686 (32-bit) kernels.
 SUBARCH_X64			'64-Bit  x86 Processors (AMD64/EM64T)'
+# Use this for x86_64 (64-bit) kernels.
 
 CPU_X86_I486			'486'
 CPU_X86_I586			'Pentium1'


### PR DESCRIPTION
## Summary
- document available SUBARCH choices in Makeconf.local.template
- add short notes in x86.cml explaining how to choose i686 vs x86_64

## Testing
- `gcc -m64 -nostdlib test.c -o test64 && gcc -m32 -nostdlib test.c -o test32 && ls -l test64 test32`
- `objdump -f test64 | head -n 5`
- `objdump -f test32 | head -n 5`
