### PR TITLE
Enable user-mode IPC fast path

### DIFF
--- a/src-userland/lib/Makefile
+++ b/src-userland/lib/Makefile
@@ -1,0 +1,18 @@
+CXXFLAGS ?= -std=c++23
+INCLUDES = -I../../user/include -I../../user/contrib/elf-loader/include
+
+LIB = libuseripc.a
+OBJS = user_ipc.o
+
+all: $(LIB)
+
+$(LIB): $(OBJS)
+	ar rcs $@ $(OBJS)
+
+user_ipc.o: ipc/user_ipc.cc ../../user/include/l4/ipc_user.h
+	g++ $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) $(LIB)
+
+.PHONY: all clean

--- a/src-userland/lib/ipc/user_ipc.cc
+++ b/src-userland/lib/ipc/user_ipc.cc
@@ -1,0 +1,18 @@
+#include <l4/ipc_user.h>
+#include <l4/ipc.h>
+
+extern "C" L4_MsgTag_t
+L4_UserIpc(L4_ThreadId_t to, L4_ThreadId_t FromSpecifier,
+           L4_Word_t Timeouts, L4_ThreadId_t *from)
+{
+    /* Fast path for self IPC without receive phase. */
+    if (L4_IsThreadEqual(to, L4_Myself()) && L4_IsNilThread(FromSpecifier)) {
+        if (from) {
+            *from = L4_nilthread;
+        }
+        return L4_MsgTag();
+    }
+
+    /* Fallback to kernel primitive. */
+    return L4_Ipc(to, FromSpecifier, Timeouts, from);
+}

--- a/src-userland/lib/ipc/user_ipc.h
+++ b/src-userland/lib/ipc/user_ipc.h
@@ -1,0 +1,26 @@
+#ifndef L4_USER_IPC_H
+#define L4_USER_IPC_H
+
+#include <l4/types.h>
+#include <l4/message.h>
+#include <l4/thread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Wrapper around the kernel IPC primitive. When the destination
+ * is the current thread and the call does not receive from another
+ * partner the operation can be satisfied in user mode.
+ */
+L4_MsgTag_t L4_UserIpc(L4_ThreadId_t to,
+                      L4_ThreadId_t FromSpecifier,
+                      L4_Word_t Timeouts,
+                      L4_ThreadId_t *from);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* L4_USER_IPC_H */

--- a/user/contrib/elf-loader/platform/amd64-pc99/string.cc
+++ b/user/contrib/elf-loader/platform/amd64-pc99/string.cc
@@ -89,8 +89,6 @@ int strcmp(const char * cs,const char * ct)
 {
         signed char __res;
 
-       signed char __res;
-
 	while (1) {
 		if ((__res = *cs - *ct++) != 0 || !*cs++)
 			break;
@@ -102,7 +100,6 @@ int strcmp(const char * cs,const char * ct)
 int strncmp(const char * cs,const char * ct, unsigned int count)
 {
         signed char __res = 0;
-       signed char __res = 0;
 
 	while (count) {
 		if ((__res = *cs - *ct++) != 0 || !*cs++)

--- a/user/include/l4/ipc.h
+++ b/user/include/l4/ipc.h
@@ -36,6 +36,7 @@
 #include __L4_INC_ARCH(syscalls.h)
 #include <l4/message.h>
 #include <l4/thread.h>
+#include <l4/ipc_user.h>
 
 
 /*
@@ -111,8 +112,8 @@ L4_INLINE L4_MsgTag_t L4_Call_Timeouts (L4_ThreadId_t to,
 					L4_Time_t RcvTimeout)
 {
     L4_ThreadId_t dummy;
-    return L4_Ipc (to, to, L4_Timeouts (SndTimeout, RcvTimeout),
-		   &dummy);
+    return L4_UserIpc (to, to, L4_Timeouts (SndTimeout, RcvTimeout),
+                   &dummy);
 }
 
 #if defined(__cplusplus)
@@ -131,7 +132,7 @@ L4_INLINE L4_MsgTag_t L4_Call (L4_ThreadId_t to)
 
 L4_INLINE L4_MsgTag_t L4_Send_Timeout (L4_ThreadId_t to, L4_Time_t SndTimeout)
 {
-    return L4_Ipc (to, L4_nilthread, (L4_Word_t)SndTimeout.raw << 16, (L4_ThreadId_t *) 0);
+    return L4_UserIpc (to, L4_nilthread, (L4_Word_t)SndTimeout.raw << 16, (L4_ThreadId_t *) 0);
 }
 
 #if defined(__cplusplus)
@@ -155,7 +156,7 @@ L4_INLINE L4_MsgTag_t L4_Receive_Timeout (L4_ThreadId_t from,
 					  L4_Time_t RcvTimeout)
 {
     L4_ThreadId_t dummy;
-    return L4_Ipc (L4_nilthread, from, (L4_Word_t)RcvTimeout.raw, &dummy);
+    return L4_UserIpc (L4_nilthread, from, (L4_Word_t)RcvTimeout.raw, &dummy);
 }
 
 #if defined(__cplusplus)
@@ -173,7 +174,7 @@ L4_INLINE L4_MsgTag_t L4_Receive (L4_ThreadId_t from)
 L4_INLINE L4_MsgTag_t L4_Wait_Timeout (L4_Time_t RcvTimeout,
 				       L4_ThreadId_t * from)
 {
-    return L4_Ipc (L4_nilthread, L4_anythread, (L4_Word_t)RcvTimeout.raw, from);
+    return L4_UserIpc (L4_nilthread, L4_anythread, (L4_Word_t)RcvTimeout.raw, from);
 }
 
 #if defined(__cplusplus)
@@ -192,8 +193,8 @@ L4_INLINE L4_MsgTag_t L4_ReplyWait_Timeout (L4_ThreadId_t to,
 					    L4_Time_t RcvTimeout,
 					    L4_ThreadId_t * from)
 {
-    return L4_Ipc (to, L4_anythread, L4_Timeouts (L4_ZeroTime, RcvTimeout),
-		   from);
+    return L4_UserIpc (to, L4_anythread, L4_Timeouts (L4_ZeroTime, RcvTimeout),
+                   from);
 }
 
 #if defined(__cplusplus)

--- a/user/include/l4/ipc_user.h
+++ b/user/include/l4/ipc_user.h
@@ -1,0 +1,26 @@
+#ifndef L4_USER_IPC_H
+#define L4_USER_IPC_H
+
+#include <l4/types.h>
+#include <l4/message.h>
+#include <l4/thread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Wrapper around the kernel IPC primitive. When the destination
+ * is the current thread and the call does not receive from another
+ * partner the operation can be satisfied in user mode.
+ */
+L4_MsgTag_t L4_UserIpc(L4_ThreadId_t to,
+                      L4_ThreadId_t FromSpecifier,
+                      L4_Word_t Timeouts,
+                      L4_ThreadId_t *from);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* L4_USER_IPC_H */


### PR DESCRIPTION
## Summary
- add header exposing `L4_UserIpc`
- compile small libuseripc providing user-mode IPC wrapper
- include new header from the public IPC API
- fix duplicate declarations in sample string implementation

## Testing
- `make`
- `make -C src-userland/lib`
- `make -C src-userland/lib clean && make -C src-userland/lib`
