### PR TITLE
Implement kernel memory server IPC

### DIFF
--- a/kernel/src/api/v4/thread.cc
+++ b/kernel/src/api/v4/thread.cc
@@ -1578,10 +1578,14 @@ void SECTION(".init") init_root_servers()
 	panic ("Sigma0's memory region is empty, "
 	       "system will not be functional.  Halting.\n");
 
-    threadid_t sigma0, sigma1, root_server;
+    threadid_t sigma0, sigma1, root_server, memory_server;
     sigma0.set_global_id(ubase, ROOT_VERSION);
     sigma1.set_global_id(ubase+1, ROOT_VERSION);
     root_server.set_global_id(ubase+2, ROOT_VERSION);
+    memory_server.set_global_id(ubase+3, ROOT_VERSION);
+
+    extern "C" void set_memory_server_id(threadid_t id);
+    set_memory_server_id(memory_server);
     
     TRACE_INIT ("Creating sigma0 (%t)\n", TID(sigma0));
     tcb = create_root_server(

--- a/kernel/src/generic/user_mem.cc
+++ b/kernel/src/generic/user_mem.cc
@@ -1,17 +1,63 @@
 #include <types.h>
+#include INC_API(tcb.h)
+#include INC_API(kernelinterface.h)
+#include INC_API(ipc.h)
+#include <l4/memory.h>
 
 /* Default memory server thread ID: user task after root server */
 static threadid_t memory_server_id;
 
+extern "C" void set_memory_server_id(threadid_t id)
+{
+    memory_server_id = id;
+}
+
+static void SECTION(".init") init_default_memory_server(void)
+{
+    threadid_t tid;
+    tid.set_global_id(get_kip()->thread_info.get_user_base()+3, ROOT_VERSION);
+    set_memory_server_id(tid);
+}
+
 extern "C" void *user_mem_alloc(word_t size)
 {
-    (void)size;
-    /* TODO: perform IPC to memory_server_id and return allocated pointer */
-    return nullptr;
+    tcb_t *current = get_current_tcb();
+
+    mem_request req;
+    req.op = MEM_ALLOC;
+    req.size = size;
+    req.addr = 0;
+
+    msg_tag_t tag;
+    tag.set(0, 4, 0);
+    current->set_tag(tag);
+    current->set_mr(1, 0);
+    current->set_mr(2, req.op);
+    current->set_mr(3, req.size);
+    current->set_mr(4, req.addr);
+
+    tag = current->do_ipc(memory_server_id, memory_server_id, timeout_t::never());
+    if (tag.is_error())
+        return nullptr;
+    return (void*)current->get_mr(1);
 }
 
 extern "C" void user_mem_free(void *addr, word_t size)
 {
-    (void)addr; (void)size;
-    /* TODO: send free request to memory_server_id */
+    tcb_t *current = get_current_tcb();
+
+    mem_request req;
+    req.op = MEM_FREE;
+    req.size = size;
+    req.addr = (word_t)addr;
+
+    msg_tag_t tag;
+    tag.set(0, 4, 0);
+    current->set_tag(tag);
+    current->set_mr(1, 0);
+    current->set_mr(2, req.op);
+    current->set_mr(3, req.size);
+    current->set_mr(4, req.addr);
+
+    current->do_ipc(memory_server_id, memory_server_id, timeout_t::never());
 }


### PR DESCRIPTION
## Summary
- wire up kernel IPC to a user-level memory server
- track the memory server thread ID during initialization

## Testing
- `make all`