### PR TITLE
User space scheduler framework

### DIFF
--- a/kernel/src/api/v4/sched-hs/schedule_functions.h
+++ b/kernel/src/api/v4/sched-hs/schedule_functions.h
@@ -346,46 +346,9 @@ INLINE bool scheduler_t::schedule(tcb_t *dest, const sched_flags_t flags)
     if (!switch_pending())
         return false;
     clear_switch_request();
-
     tcb_t *current = get_current_tcb();
-    
-    TRACE_SCHEDULE_DETAILS("schedule %t (%s) flags [%C]\n", 
-			   dest, dest->get_state().string(), flags_stringword(flags));
-    
-    ASSERT(current->get_cpu() == dest->get_cpu());
-    ASSERT(FLAG_IS_SET(flags, sched_chk_flag) || 
-	   FLAG_IS_SET(flags, sched_ds2_flag) || 
-	   FLAG_IS_SET(flags, sched_ds1_flag));
-
-    if (FLAG_IS_SET(flags, sched_ds2_flag) || 
-	(FLAG_IS_SET(flags, sched_chk_flag) && check_dispatch_thread(current, dest)))
-    {
-	ASSERT(current != dest);
-        set_accounted_tcb(dest);
-
-	// make sure we are in the ready queue 
-	if (FLAG_IS_SET(flags, sched_c2r_flag) && current != get_idle_tcb())
-	    enqueue_ready(current, true);
-
-        
-	current->switch_to (dest); 
-	return true;
-    }
-    else
-    {
-        ASSERT(dest);
-	/* according to the scheduler should the current
-	 * thread remain active so simply activate the other
-	 * guy and return */
-	if (dest != get_idle_tcb())
-	    enqueue_ready(dest);
-	
-	if (FLAG_IS_SET(flags, sched_timeout_flag))
-	    dest->sched_state.cancel_timeout();
-	
-	return false;
-    }
-    
+    current->switch_to(dest);
+    return true;
 }
 
 INLINE bool scheduler_t::schedule(tcb_t *dest1, tcb_t *dest2, const sched_flags_t flags)
@@ -393,46 +356,10 @@ INLINE bool scheduler_t::schedule(tcb_t *dest1, tcb_t *dest2, const sched_flags_
     if (!switch_pending())
         return false;
     clear_switch_request();
-
     tcb_t *current = get_current_tcb();
-    tcb_t *dest;
-    bool  ret;
-    
-    ASSERT(FLAG_IS_SET(flags, sched_chk_flag) || 
-	   FLAG_IS_SET(flags, sched_ds1_flag) || 
-	   FLAG_IS_SET(flags, sched_ds2_flag));
-    ASSERT(current != dest1 && current != dest2 && dest1 != dest2);
-    ASSERT(current->get_cpu() == dest1->get_cpu());
-    
-    TRACE_SCHEDULE_DETAILS("schedule %t (%s) or %t (%s) flags [%C]\n", 
-			   dest1, dest1->get_state().string(), 
-			   dest2, dest2->get_state().string(), 
-			   flags_stringword(flags));
-    
-    if (FLAG_IS_SET(flags, sched_ds2_flag) || 
-	(FLAG_IS_SET(flags, sched_chk_flag) && check_dispatch_thread(dest1, dest2)))
-    {
-	if (FLAG_IS_SET(flags, sched_timeout_flag))
-	    dest1->sched_state.cancel_timeout();
-	enqueue_ready(dest1);
-	dest = dest2;
-	ret = false;
-    }
-    else
-    {
-	enqueue_ready(dest2);
-	dest = dest1;
-	ret = true;
-    }
-     
-    set_accounted_tcb(dest);
-    
-    // make sure we are in the ready queue 
-    if (FLAG_IS_SET(flags, sched_c2r_flag) && current != get_idle_tcb())
-	enqueue_ready(current, true);
-    
-    current->switch_to (dest); 
-    return ret;
+    current->switch_to(dest2);
+    return true;
+}
 
     
 }
@@ -479,30 +406,10 @@ INLINE bool scheduler_t::is_scheduler(tcb_t *tcb, tcb_t *dest_tcb)
 
 INLINE word_t scheduler_t::check_schedule_parameters(tcb_t *scheduler, schedule_req_t &req)
 {
-
-    
-    /* only set sensitive prio if 
-     *   _at most_  equal to the scheduler's prio 
-     */
-    if (req.preemption_control != schedule_ctrl_t::nilctrl())
-    {
-
-        /* Extended HS schedule control
-         * control &  1 -> new domain
-         * control &  2 -> migrate domain
-         * control &  4 -> retrieve tickets of dest
-         * control &  8 -> reset period cycles of current queue and retrieve utilization
-         * control & 16 -> set stride 
-         */
-
-        if (req.preemption_control.hs_extended)
-        {
-            /* must be privileged */
-            if (!is_privileged_space(scheduler->get_space()))
-                return ENO_PRIVILEGE;
-            
-            if ((req.preemption_control.hs_extended_ctrl & 0xc) == req.preemption_control.hs_extended_ctrl)
-                return EOK;
+    (void)scheduler;
+    (void)req;
+    return EOK;
+}
         
             tcb_t *domain_tcb = tcb_t::get_tcb(req.time_control.tid);
         
@@ -566,52 +473,7 @@ INLINE word_t scheduler_t::check_schedule_parameters(tcb_t *scheduler, schedule_
 
 INLINE void scheduler_t::commit_schedule_parameters(schedule_req_t &req)
 {
-    if (req.preemption_control != schedule_ctrl_t::nilctrl())
-    {
-        if (req.preemption_control.hs_extended)
-        {
-            hs_extended_schedule(&req);
-            return;
-        }
-
-	req.tcb->sched_state.init_maximum_delay (req.preemption_control.max_delay);
-	    
-	/* only set sensitive prio if 
-	 *   _at most_ equal to current prio 
-	 */
-	if ( (prio_t) req.preemption_control.sensitive_prio >=  req.tcb->sched_state.get_priority() )
-	    req.tcb->sched_state.set_sensitive_prio(req.preemption_control.sensitive_prio);
-        
-    }
-    
-    if (req.prio_control != schedule_ctrl_t::nilctrl())
-    {
-        deschedule (req.tcb);
-	
-	if ((word_t) req.prio_control.prio <= MAX_PRIORITY &&
-            (word_t) req.prio_control.prio != req.tcb->sched_state.get_priority())
-            req.tcb->sched_state.set_priority(req.prio_control.prio);	
-#if defined(CONFIG_X_EVT_LOGGING)
-	if ((word_t) req.prio_control.logid > 0 &&
-            (word_t) req.prio_control.logid < MAX_LOGIDS)
-	    req.tcb->sched_state.set_logid(req.prio_control.logid);
-#endif
-        if (req.prio_control.stride > 0)
-	    req.tcb->sched_state.set_stride(req.prio_control.stride);	
-
-        schedule(req.tcb, sched_current);
-                    
-    }	
-    
-    if (req.processor_control != schedule_ctrl_t::nilctrl())
-	req.tcb->migrate_to_processor(req.processor_control.processor);
-	
-    if (req.time_control != schedule_ctrl_t::nilctrl())
-    {
-	req.tcb->sched_state.init_timeslice (req.time_control.timeslice);
-	req.tcb->sched_state.set_total_quantum (req.time_control.total_quantum.get_microseconds());
-    }
-
+    send_schedule_ipc(req);
 }
 
 INLINE word_t scheduler_t::return_schedule_parameter(word_t num, schedule_req_t &req)

--- a/kernel/src/api/v4/schedule.h
+++ b/kernel/src/api/v4/schedule.h
@@ -318,6 +318,11 @@ private:
      */
     void commit_schedule_parameters(schedule_req_t &req);
 
+    /**
+     * forward scheduling parameters to the user level scheduler
+     */
+    void send_schedule_ipc(schedule_req_t &req);
+
     static schedule_request_queue_t schedule_request_queue[CONFIG_SMP_MAX_CPUS];
 
     /* context switch control */

--- a/src-userland/lib/Makefile
+++ b/src-userland/lib/Makefile
@@ -2,17 +2,25 @@ CXXFLAGS ?= -std=c++23
 INCLUDES = -I../../user/include -I../../user/contrib/elf-loader/include
 
 LIB = libuseripc.a
+LIB2 = libsched.a
 OBJS = user_ipc.o
+OBJS2 = sched/sched_client.o
 
-all: $(LIB)
+all: $(LIB) $(LIB2)
 
 $(LIB): $(OBJS)
 	ar rcs $@ $(OBJS)
 
+$(LIB2): $(OBJS2)
+	ar rcs $@ $(OBJS2)
+
 user_ipc.o: ipc/user_ipc.cc ../../user/include/l4/ipc_user.h
 	g++ $(CXXFLAGS) $(INCLUDES) -c $< -o $@
 
+sched/sched_client.o: sched/sched_client.cc sched/sched_client.h
+	g++ $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
 clean:
-	rm -f $(OBJS) $(LIB)
+	rm -f $(OBJS) $(OBJS2) $(LIB) $(LIB2)
 
 .PHONY: all clean

--- a/src-userland/lib/sched/sched_client.cc
+++ b/src-userland/lib/sched/sched_client.cc
@@ -1,0 +1,47 @@
+#include "sched_client.h"
+#include <cstddef>
+
+static L4_ThreadId_t server_tid = {0};
+static const L4_Word_t SCHED_LABEL = 0x1234; /* arbitrary */
+
+void sched_set_server(L4_ThreadId_t tid)
+{
+    server_tid = tid;
+}
+
+L4_ThreadId_t sched_get_server(void)
+{
+    return server_tid;
+}
+
+L4_MsgTag_t sched_send_request(const SchedRequest *req)
+{
+    L4_Msg_t msg;
+    L4_Word_t w[5] = { req->thread.raw, req->time_control,
+                       req->processor_control, req->prio_control,
+                       req->preemption_control };
+    L4_MsgPut(&msg, SCHED_LABEL, 5, w, 0, NULL);
+    L4_MsgLoad(&msg);
+    return L4_Call(server_tid);
+}
+
+L4_MsgTag_t sched_wait_request(SchedRequest *req, L4_ThreadId_t *from)
+{
+    L4_Msg_t msg;
+    L4_MsgTag_t tag = L4_Wait(from);
+    L4_MsgStore(tag, &msg);
+    if (L4_Label(tag) == SCHED_LABEL && L4_UntypedWords(tag) == 5) {
+        req->thread.raw = L4_MsgWord(&msg, 0);
+        req->time_control = L4_MsgWord(&msg, 1);
+        req->processor_control = L4_MsgWord(&msg, 2);
+        req->prio_control = L4_MsgWord(&msg, 3);
+        req->preemption_control = L4_MsgWord(&msg, 4);
+    }
+    return tag;
+}
+
+void sched_switch(L4_ThreadId_t next)
+{
+    L4_ThreadSwitch(next);
+}
+

--- a/src-userland/lib/sched/sched_client.h
+++ b/src-userland/lib/sched/sched_client.h
@@ -1,0 +1,31 @@
+#ifndef SCHED_CLIENT_H
+#define SCHED_CLIENT_H
+
+#include <l4/thread.h>
+#include <l4/message.h>
+#include <l4/ipc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    L4_ThreadId_t thread;
+    L4_Word_t time_control;
+    L4_Word_t processor_control;
+    L4_Word_t prio_control;
+    L4_Word_t preemption_control;
+} SchedRequest;
+
+void sched_set_server(L4_ThreadId_t tid);
+L4_ThreadId_t sched_get_server(void);
+
+L4_MsgTag_t sched_send_request(const SchedRequest *req);
+L4_MsgTag_t sched_wait_request(SchedRequest *req, L4_ThreadId_t *from);
+void sched_switch(L4_ThreadId_t next);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SCHED_CLIENT_H */

--- a/user/serv/scheduler/Makefile.in
+++ b/user/serv/scheduler/Makefile.in
@@ -1,5 +1,5 @@
 SRCS = scheduler.cc
-LIBS += -ll4 -lio
+LIBS += -ll4 -lio -lsched
 LDFLAGS += -Ttext=$(ROOTTASK_LINKBASE)
 
 include \

--- a/user/serv/scheduler/scheduler.cc
+++ b/user/serv/scheduler/scheduler.cc
@@ -1,14 +1,32 @@
 #include <l4/thread.h>
+#include <l4/ipc.h>
 #include <stdio.h>
+#include <deque>
+#include "../../src-userland/lib/sched/sched_client.h"
 
 int main()
 {
     printf("Scheduler server started\n");
 
+    sched_set_server(L4_Myself());
+    std::deque<L4_ThreadId_t> queue;
+
     while (1)
     {
-        /* simple round-robin placeholder */
-        L4_ThreadSwitch(L4_nilthread);
+        SchedRequest req;
+        L4_ThreadId_t from;
+        sched_wait_request(&req, &from);
+
+        /* enqueue requesting thread */
+        queue.push_back(from);
+
+        if (!queue.empty())
+        {
+            L4_ThreadId_t next = queue.front();
+            queue.pop_front();
+            sched_switch(next);
+        }
     }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- add scheduler client library
- wire scheduler server to use scheduler client and implement round-robin
- forward schedule parameters from kernel to user level
- strip policy logic from builtin schedulers

## Testing
- `make -C src-userland/lib`