### PR TITLE
Add memory & scheduler server docs

### DIFF
--- a/README
+++ b/README
@@ -80,6 +80,18 @@ launch the `sigma0` memory manager run::
 transfers control to the resource manager.  Additional managers can be
 specified on the command line in the order they should be started.
 
+To boot with the example memory and scheduler servers first build
+them::
+
+    $ make -C user/serv/memory
+    $ make -C user/serv/scheduler
+
+Then launch them together with the kernel using `kickstart`::
+
+    $ user/util/kickstart/kickstart \
+          -roottask=user/serv/memory/memory \
+          user/serv/scheduler/scheduler
+
 
 Migration from the microkernel API
 ----------------------------------

--- a/docs/exokernel_migration.md
+++ b/docs/exokernel_migration.md
@@ -31,3 +31,39 @@ Functionality traditionally located in the microkernel will move to userland com
 
 By delegating these services the system gains flexibility: different applications may link against or communicate with specialised libraries that implement the policies best suited for their workload.
 
+## Memory Server
+
+The memory server replaces the kernel's built‑in pager.  It receives
+allocation and deallocation requests from applications and returns raw
+memory frames.  All higher level allocators build on top of this
+service.  The implementation in `user/serv/memory` is intentionally
+minimal to demonstrate how a user program can manage physical
+resources using only the kernel's IPC primitives.
+
+Build the server with::
+
+    $ make -C user/serv/memory
+
+Once compiled it can be started with `kickstart` together with the
+kernel image::
+
+    $ user/util/kickstart/kickstart -roottask=user/serv/memory/memory
+
+## Scheduler Server
+
+Scheduling policies are likewise moved out of the kernel.  The
+`user/serv/scheduler` example provides a rudimentary round‑robin
+scheduler that repeatedly calls `L4_ThreadSwitch` to hand the CPU to
+other threads.  More advanced policies can be implemented in the same
+way without enlarging the kernel.
+
+Compile the scheduler server via::
+
+    $ make -C user/serv/scheduler
+
+It may then be launched as an additional task using `kickstart`::
+
+    $ user/util/kickstart/kickstart \
+          -roottask=user/serv/memory/memory \
+          user/serv/scheduler/scheduler
+


### PR DESCRIPTION
## Summary
- document memory and scheduler servers in the exokernel migration guide
- show how to build and start the servers with kickstart
- provide README example of booting kernel with both managers

## Testing
- `git status --short`