### PR TITLE
Update timer setup to use irq_manager

### DIFF
--- a/kernel/src/generic/Makeconf
+++ b/kernel/src/generic/Makeconf
@@ -30,8 +30,9 @@
 ##                
 ######################################################################
 SOURCES+=	src/generic/lib.cc \ 
-                src/generic/user_mem.cc
-		src/generic/kmemory.cc
+	src/generic/user_mem.cc \
+	src/generic/kmemory.cc \
+	src/generic/irq_manager.cc
 
 ifeq ("$(CONFIG_ACPI)","y")
 SOURCES+=	src/generic/acpi.cc

--- a/kernel/src/generic/irq_manager.cc
+++ b/kernel/src/generic/irq_manager.cc
@@ -1,0 +1,3 @@
+#include <irq_manager.h>
+
+irq_manager_t irq_manager;

--- a/kernel/src/generic/irq_manager.h
+++ b/kernel/src/generic/irq_manager.h
@@ -1,0 +1,23 @@
+#ifndef __IRQ_MANAGER_H__
+#define __IRQ_MANAGER_H__
+
+#include INC_GLUE(idt.h)
+#include INC_GLUE(intctrl.h)
+
+class irq_manager_t {
+public:
+    void register_irq(word_t hwirq, word_t prio, void (*handler)())
+    {
+        /* priority currently unused */
+        idt.add_gate(0x20 + hwirq, idt_t::interrupt, handler);
+    }
+
+    void unmask(word_t hwirq)
+    {
+        get_interrupt_ctrl()->unmask(hwirq);
+    }
+};
+
+extern irq_manager_t irq_manager;
+
+#endif /* __IRQ_MANAGER_H__ */

--- a/kernel/src/glue/v4-x86/timer.cc
+++ b/kernel/src/glue/v4-x86/timer.cc
@@ -34,6 +34,7 @@
 #include INC_PLAT(rtc.h)
 #include INC_GLUE(intctrl.h)
 #include INC_GLUE(timer.h)
+#include <irq_manager.h>
 
 #include INC_API(schedule.h)
 
@@ -74,8 +75,7 @@ X86_EXCNO_ERRORCODE(timer_interrupt, IRQLINE)
 
 void SECTION (".init") timer_t::init_global()
 {
-    /* TODO: Should be irq_manager.register(hwirq, 8, &timer_interrupt); */
-    idt.add_gate(0x20+IRQLINE, idt_t::interrupt, timer_interrupt);
+    irq_manager.register_irq(IRQLINE, 8, timer_interrupt);
 
     rtc_t<0x70> rtc;
 
@@ -92,8 +92,7 @@ void SECTION (".init") timer_t::init_global()
     /* read(0x0c) clears all interrupts in RTC */
     rtc.read(0x0c);
 
-    /* TODO: Should this become irq_manager.unmask(hwirq, 8) ? */
-    get_interrupt_ctrl()->unmask(IRQLINE);
+    irq_manager.unmask(IRQLINE);
 }
 
 


### PR DESCRIPTION
## Summary
- add new irq_manager abstraction
- hook timer interrupts via irq_manager API
- include irq_manager source in build

## Testing
- `make BUILDDIR=/workspace/pistachio/build SUBARCH=x32` *(fails: recipe commences before first target)*