### PR TITLE
Add CXXFLAGS and set language standards

### DIFF
--- a/kernel/Mk/Makeconf
+++ b/kernel/Mk/Makeconf
@@ -169,8 +169,11 @@ VFLAGS =
 
 # use optimization level of at least 1 - otherwise inlining will fail
 CCFLAGS += -fno-rtti -fno-builtin  -fomit-frame-pointer -fno-exceptions \
-	  -Wall -Wno-non-virtual-dtor -Wno-format   \
-	  $(CFLAGS_$(ARCH)) $(CFLAGS_$(CPU)) $(CFLAGS_$(PLATFORM)) 
+          -Wall -Wno-non-virtual-dtor -Wno-format   \
+          $(CFLAGS_$(ARCH)) $(CFLAGS_$(CPU)) $(CFLAGS_$(PLATFORM))
+
+# C++ compiler flags build on C compiler flags and set the C++ standard
+CXXFLAGS += $(CCFLAGS) -std=c++17
 
 ifeq ("$(CC_VERSION)", "4")
 CCFLAGS += -Wno-conversion
@@ -185,7 +188,7 @@ ifeq ("$(CONFIG_DEBUG_SYMBOLS)","y")
 CCFLAGS  += -g
 endif
 
-CFLAGS = -ffreestanding $(CCFLAGS)
+CFLAGS = -ffreestanding $(CCFLAGS) -std=c23
 
 # these for assembly files only
 ASMFLAGS += $(ASMFLAGS_$(PLATFORM)) $(ASMFLAGS_$(ARCH)) $(ASMFLAGS_$(CPU))
@@ -205,7 +208,7 @@ LDSCRIPT = $(SRCDIR)/src/platform/$(PLATFORM)/linker.lds
 %.o:	%.cc
 	@$(ECHO_MSG) $(subst $(SRCDIR)/,,$<)
 	@if [ ! -d $(dir $@) ]; then $(MKDIRHIER) $(dir $@); fi
-	cd $(dir $@) && $(CC) $(CPPFLAGS) $(CCFLAGS) $(CFLAGS_$*) -c $<
+       cd $(dir $@) && $(CC) $(CPPFLAGS) $(CXXFLAGS) $(CFLAGS_$*) -c $<
 
 
 # C files


### PR DESCRIPTION
## Summary
- define CXXFLAGS derived from CCFLAGS
- compile C code with C23 and C++ code with C++17
- use CXXFLAGS in the .cc build rule

## Testing
- `make -C kernel -n`