### PR TITLE
Fix CXX build flags

### DIFF
--- a/kernel/Mk/Makeconf
+++ b/kernel/Mk/Makeconf
@@ -205,7 +205,7 @@ LDSCRIPT = $(SRCDIR)/src/platform/$(PLATFORM)/linker.lds
 %.o:	%.cc
 	@$(ECHO_MSG) $(subst $(SRCDIR)/,,$<)
 	@if [ ! -d $(dir $@) ]; then $(MKDIRHIER) $(dir $@); fi
-	cd $(dir $@) && $(CC) $(CPPFLAGS) $(CCFLAGS) $(CFLAGS_$*) -c $<
+	cd $(dir $@) && $(CC) $(CPPFLAGS) $(CXXFLAGS) $(CFLAGS_$*) -c $<
 
 
 # C files


### PR DESCRIPTION
## Summary
- use `$(CXXFLAGS)` for kernel `.cc` builds

## Testing
- `make -k`
- `pre-commit` *(fails: command not found)*