### PR TITLE
Raise C++ standard to C++23

### DIFF
--- a/README
+++ b/README
@@ -26,7 +26,7 @@ Building with modern compilers
 
 The build system now expects compilers that understand modern
 language standards: C sources require C23 while C++ sources require at
-least C++17. GCC 14 and Clang 17 are known to work. Autoconf 2.69 or
+least C++23. GCC 14 and Clang 17 are known to work. Autoconf 2.69 or
 later is required to regenerate the configure script.
 
 Example build steps on a typical Linux host::
@@ -44,7 +44,7 @@ When building the kernel choose either `SUBARCH=x32` for i686 or
 Requirements
 ------------
 Pistachio requires a C compiler with C23 support and a C++ compiler
-that implements at least the C++17 standard. The minimum versions
+that implements at least the C++23 standard. The minimum versions
 known to work are GCC 14 and Clang 17.
 
 Building on i686 and x86_64 hosts

--- a/doc/misc/announce-0.1.txt
+++ b/doc/misc/announce-0.1.txt
@@ -16,7 +16,7 @@ found in:
 
 L4Ka::Pistachio is built from ground up incorporating the research
 results of the last seven years of microkernel and multi-server
-research.  The code is written in C++ with a strong focus on
+research.  The code is written in C++23 with a strong focus on
 performance and portability.  The first release includes support for
 many of today's widely used commodity architectures:
 

--- a/doc/whitepaper/whitepaper.tex
+++ b/doc/whitepaper/whitepaper.tex
@@ -36,8 +36,8 @@ encourages custom resource managers that implement scheduling and
 memory policies outside the kernel.
 
 The first release implements most of the core
-functionality of the API.  The kernel is written in C++ with a
-significant focus on performance, portability, and reusability.
+functionality of the API.  The kernel is written in modern C++\@ (currently
+C++23) with a significant focus on performance, portability, and reusability.
 \Pistachio supports most existing mainstream hardware architectures,
 in particular Intel's IA32\footnote{Pentium and higher}, and
 IA64\footnote{Itanium1 and SKI}, PowerPC 32bit, Alpha 21164, and MIPS

--- a/docs/exokernel_migration.md
+++ b/docs/exokernel_migration.md
@@ -2,6 +2,9 @@
 
 This document sketches the high level plan for transforming Pistachio's existing microkernel into a more minimal exokernel. The intent is to keep the kernel as small as possible while still supplying enough hooks to implement system functionality in user space.
 
+The source tree uses modern language features.  All C++ code now targets the
+C++23 standard.
+
 ## Goals
 
 - Reduce kernel complexity by stripping all but the most fundamental mechanisms from the trusted computing base.

--- a/kernel/Mk/Makeconf
+++ b/kernel/Mk/Makeconf
@@ -173,7 +173,7 @@ CCFLAGS += -fno-rtti -fno-builtin  -fomit-frame-pointer -fno-exceptions \
           $(CFLAGS_$(ARCH)) $(CFLAGS_$(CPU)) $(CFLAGS_$(PLATFORM))
 
 # C++ compiler flags build on C compiler flags and set the C++ standard
-CXXFLAGS += $(CCFLAGS) -std=c++17
+CXXFLAGS += $(CCFLAGS) -std=c++23
 
 ifeq ("$(CC_VERSION)", "4")
 CCFLAGS += -Wno-conversion

--- a/user/configure.in
+++ b/user/configure.in
@@ -160,20 +160,31 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
     [AC_MSG_FAILURE([$CC does not support -std=c23])])
 CFLAGS="$save_CFLAGS"
 
-dnl Check if the compiler supports -std=c++17
-AC_MSG_CHECKING([whether $CC accepts -std=c++17])
+dnl Check if the compiler supports -std=c++23 (or -std=c++2b)
+AC_MSG_CHECKING([whether $CC accepts -std=c++23])
 save_CFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS -x c++ -std=c++17"
+CFLAGS="$CFLAGS -x c++ -std=c++23"
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
-    [ac_cxx17=yes],
-    [ac_cxx17=no])
+    [ac_cxx23=yes],
+    [ac_cxx23=no])
 CFLAGS="$save_CFLAGS"
-if test "$ac_cxx17" = yes; then
-  CXXSTD="-std=c++17"
+if test "$ac_cxx23" = yes; then
+  CXXSTD="-std=c++23"
 else
-  CXXSTD=""
+  AC_MSG_CHECKING([whether $CC accepts -std=c++2b])
+  save_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS -x c++ -std=c++2b"
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
+      [ac_cxx23=yes],
+      [ac_cxx23=no])
+  CFLAGS="$save_CFLAGS"
+  if test "$ac_cxx23" = yes; then
+    CXXSTD="-std=c++2b"
+  else
+    AC_MSG_FAILURE([$CC does not support -std=c++23 or -std=c++2b])
+  fi
 fi
-AC_MSG_RESULT([$ac_cxx17])
+AC_MSG_RESULT([$CXXSTD])
 AC_SUBST([CXXSTD])
 
 


### PR DESCRIPTION
## Summary
- document that the project now uses C++23
- note the C++23 requirement in docs
- check for C++23 in `user/configure.in`
- update kernel compile flags

## Testing
- `autoconf` *(fails: command not found)*