### PR TITLE
Fix PPC spinlock barriers

### DIFF
--- a/kernel/src/arch/powerpc/sync.h
+++ b/kernel/src/arch/powerpc/sync.h
@@ -49,8 +49,6 @@ public: // to allow initializers
 #define DECLARE_SPINLOCK(name) extern spinlock_t name;
 #define DEFINE_SPINLOCK(name) spinlock_t name = {_lock: 0}
 
-// TODO: do I satisfy synchronization criteria for PowerPC?
-// TODO: should i eieio when grabbing the lock?
 
 INLINE void spinlock_t::lock()
 {
@@ -64,17 +62,17 @@ INLINE void spinlock_t::lock()
 	bne-	1b		/* Retry the lock. */\n\
 	stwcx.	%2, 0, %1	/* Try to store the new lock. */\n\
 	bne-	1b		/* Retry if we failed to store. */\n\
-	isync\n"
 	: "=&r" (old_val)
 	: "r" (&this->_lock), "r" (1)
 	: "cr0", "memory"
 	);
+    isync();
 }
 
 INLINE void spinlock_t::unlock()
 {
     // Ensure memory ordering before we unlock.
-    asm volatile ("eieio" : : : "memory");
+    asm volatile ("sync" : : : "memory");
 
     this->_lock = 0;
 }

--- a/kernel/src/arch/powerpc64/sync.h
+++ b/kernel/src/arch/powerpc64/sync.h
@@ -48,8 +48,6 @@ public: // to allow initializers
 #define DECLARE_SPINLOCK(name) extern spinlock_t name;
 #define DEFINE_SPINLOCK(name) spinlock_t name = ((spinlock_t) {{_lock: 0}})
 
-// TODO: do I satisfy synchronization criteria for PowerPC?
-// TODO: should i eieio when grabbing the lock?
 
 INLINE void spinlock_t::lock()
 {
@@ -67,12 +65,13 @@ INLINE void spinlock_t::lock()
 	: "r" (&this->_lock), "r" (1)
 	: "cr0", "memory"
 	);
+    isync();
 }
 
 INLINE void spinlock_t::unlock()
 {
     // Ensure memory ordering before we unlock.
-    asm volatile ("eieio" : : : "memory");
+    asm volatile ("sync" : : : "memory");
 
     this->_lock = 0;
 }


### PR DESCRIPTION
## Summary
- enforce proper memory barriers for PowerPC spinlocks
- drop outdated TODO comments about barriers

## Testing
- `pre-commit` *(fails: no config)*