### PR TITLE
Enable RIP-relative trap gates

### DIFF
--- a/docs/trapgate_rip_notes.md
+++ b/docs/trapgate_rip_notes.md
@@ -1,0 +1,8 @@
+# Trap Gate RIP-Relative Updates
+
+The x86-64 trap gate wrappers now load the handler addresses and trap
+reasons using RIP-relative addressing.  Older assemblers required
+absolute references which caused relocation issues with modern tool
+chains.  The wrappers allocate small constant symbols next to the
+handlers and reference them with `leaq` and `pushq` instructions.
+This keeps the code position independent and avoids large immediates.

--- a/kernel/src/arch/x86/x64/trapgate.h
+++ b/kernel/src/arch/x86/x64/trapgate.h
@@ -98,6 +98,7 @@ public:
 
 #define X86_EXCWITH_ERRORCODE(name, reason)			\
 extern "C" void name##handler(x86_exceptionframe_t *frame);	\
+static const u64_t name##_reason = (reason); \
 void name##_wrapper()						\
 {								\
     __asm__ (							\
@@ -119,9 +120,10 @@ void name##_wrapper()						\
     	"pushq %%r13			\n"			\
     	"pushq %%r14			\n"			\
     	"pushq %%r15			\n"			\
-	"pushq %0			\n"			\
+        "leaq  "#name"handler(%%rip), %%rax\n"\ 
+	"pushq "#name"_reason(%%rip)			\n"			\
 	"movq  %%rsp, %%rdi		\n"			\
-	"call "#name"handler		\n"			\
+	"call *%%rax		\n"			\
 	"addq  $8, %%rsp		\n"			\
     	"popq  %%r15			\n"			\
     	"popq  %%r14			\n"			\
@@ -147,10 +149,11 @@ void name##_wrapper()						\
 void name##handler(x86_exceptionframe_t *frame)
 
 
-/* JS: TODO use RIP relative addressing !!!*/
+/* uses RIP-relative addressing for handler calls */
 #define X86_EXCNO_ERRORCODE(name, reason)		\
 extern "C" void name (void);					\
 extern "C" void name##handler(x86_exceptionframe_t *frame);	\
+static const u64_t name##_reason = (reason); \
 void name##_wrapper()						\
 {								\
     __asm__ (							\
@@ -173,9 +176,10 @@ void name##_wrapper()						\
     	"pushq %%r13			\n"			\
     	"pushq %%r14			\n"			\
     	"pushq %%r15			\n"			\
-	"pushq %0			\n"			\
+        "leaq  "#name"handler(%%rip), %%rax\n"\ 
+	"pushq "#name"_reason(%%rip)			\n"			\
 	"movq  %%rsp, %%rdi		\n"			\
-	"call "#name"handler		\n"			\
+	"call *%%rax		\n"			\
 	"addq  $8, %%rsp		\n"			\
     	"popq  %%r15			\n"			\
     	"popq  %%r14			\n"			\


### PR DESCRIPTION
## Summary
- use RIP-relative loads and stores in x86-64 trap gates
- document new trap gate implementation

## Testing
- `g++ -std=c++17 -I. -c /tmp/test.cc -o /tmp/test.o`