### PR TITLE
Fix ofppc device mapping and remove glue dependency

### DIFF
--- a/kernel/src/generic/device_area.h
+++ b/kernel/src/generic/device_area.h
@@ -1,0 +1,15 @@
+#ifndef __GENERIC__DEVICE_AREA_H__
+#define __GENERIC__DEVICE_AREA_H__
+
+#include <types.h>
+
+INLINE addr_t device_area_start()
+{
+#ifdef DEVICE_AREA_START
+    return (addr_t)DEVICE_AREA_START;
+#else
+    return 0;
+#endif
+}
+
+#endif /* !__GENERIC__DEVICE_AREA_H__ */


### PR DESCRIPTION
## Summary
- add generic `device_area_start()` helper
- use `device_area_start()` in ofppc OpenPIC driver
- drop glue BAT helpers and forward-declare SMP handler

## Testing
- `make BUILDDIR=$(pwd)/build.ofppc -C kernel` *(fails: build directory not configured)*