### PR TITLE
Fix env setup and modernize flags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS ?= -std=c23
-CXXFLAGS ?= -std=c++17
+CXXFLAGS ?= -std=c++23
 
 build/string.o: user/contrib/elf-loader/platform/amd64-pc99/string.cc
 	echo Building string.o

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
-#— helper to pin to the repo’s exact version if it exists
+#- helper to pin to the repo's exact version if it exists
 apt_pin_install(){
   pkg="$1"
   ver=$(apt-cache show "$pkg" 2>/dev/null \
@@ -14,14 +14,14 @@ apt_pin_install(){
   fi
 }
 
-#— enable foreign architectures for cross-compilation
+#- enable foreign architectures for cross-compilation
 for arch in i386 armel armhf arm64 riscv64 powerpc ppc64el ia64; do
   dpkg --add-architecture "$arch"
 done
 
 apt-get update -y
 
-#— core build tools, formatters, analysis, science libs
+#- core build tools, formatters, analysis, science libs
 for pkg in \
   build-essential gcc g++ clang lld llvm \
   clang-format uncrustify astyle editorconfig pre-commit \
@@ -35,7 +35,7 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
-#— Python & deep-learning / MLOps
+#- Python & deep-learning / MLOps
 for pkg in \
   python3 python3-pip python3-dev python3-venv python3-wheel \
   python3-numpy python3-scipy python3-pandas \
@@ -49,7 +49,7 @@ pip3 install --no-cache-dir \
   tensorflow-cpu jax jaxlib \
   tensorflow-model-optimization mlflow onnxruntime-tools
 
-#— QEMU emulation for foreign binaries
+#- QEMU emulation for foreign binaries
 for pkg in \
   qemu-user-static \
   qemu-system-x86 qemu-system-arm qemu-system-aarch64 \
@@ -57,7 +57,7 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
-#— multi-arch cross-compilers
+#- multi-arch cross-compilers
 for pkg in \
   bcc bin86 elks-libc \
   gcc-ia64-linux-gnu g++-ia64-linux-gnu \
@@ -79,7 +79,7 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
-#— high-level language runtimes and tools
+#- high-level language runtimes and tools
 for pkg in \
   golang-go nodejs npm typescript \
   rustc cargo clippy rustfmt \
@@ -96,7 +96,7 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
-#— GUI & desktop-dev frameworks
+#- GUI & desktop-dev frameworks
 for pkg in \
   libqt5-dev qtcreator libqt6-dev \
   libgtk1.2-dev libgtk2.0-dev libgtk-3-dev libgtk-4-dev \
@@ -110,7 +110,7 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
-#— containers, virtualization, HPC, debug
+#- containers, virtualization, HPC, debug
 for pkg in \
   docker.io podman buildah virt-manager libvirt-daemon-system qemu-kvm \
   gdb lldb perf gcovr lcov bcc-tools bpftrace \
@@ -118,7 +118,7 @@ for pkg in \
   apt_pin_install "$pkg"
 done
 
-#— IA-16 (8086/286) cross-compiler
+#- IA-16 (8086/286) cross-compiler
 IA16_VER=$(curl -fsSL https://api.github.com/repos/tkchia/gcc-ia16/releases/latest \
            | awk -F\" '/tag_name/{print $4; exit}')
 curl -fsSL "https://github.com/tkchia/gcc-ia16/releases/download/${IA16_VER}/ia16-elf-gcc-linux64.tar.xz" \
@@ -126,17 +126,17 @@ curl -fsSL "https://github.com/tkchia/gcc-ia16/releases/download/${IA16_VER}/ia1
 echo 'export PATH=/opt/ia16-elf-gcc/bin:$PATH' > /etc/profile.d/ia16.sh
 export PATH=/opt/ia16-elf-gcc/bin:$PATH
 
-#— protoc installer (pinned)
+#- protoc installer (pinned)
 PROTO_VERSION=25.1
 curl -fsSL "https://raw.githubusercontent.com/protocolbuffers/protobuf/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-x86_64.zip" \
   -o /tmp/protoc.zip
 unzip -d /usr/local /tmp/protoc.zip
 rm /tmp/protoc.zip
 
-#— gmake alias
+#- gmake alias
 command -v gmake >/dev/null 2>&1 || ln -s "$(command -v make)" /usr/local/bin/gmake
 
-#— clean up
+#- clean up
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 

--- a/user/config.mk
+++ b/user/config.mk
@@ -48,7 +48,7 @@ SHELL=		/bin/sh
 CC=		cc
 CXX=		$(CC) -x c++
 AS=		$(CC)
-CFLAGS=		-std=c2x
+CFLAGS=		-std=c23
 CXXFLAGS=       $(CXXSTD) -fno-exceptions
 CXXSTD=	-std=c++23
 LDFLAGS=	

--- a/user/configure
+++ b/user/configure
@@ -78,13 +78,10 @@ EOT
 if $CC -std=c23 -c conftest.c -o conftest.o >/dev/null 2>&1; then
     echo yes
     STD_CFLAG=-std=c23
-elif $CC -std=c2x -c conftest.c -o conftest.o >/dev/null 2>&1; then
-    echo "using -std=c2x"
-    STD_CFLAG=-std=c2x
 else
     echo no
     rm -f conftest.c conftest.o
-    echo "$CC does not support -std=c23 or -std=c2x" >&2
+    echo "$CC does not support -std=c23" >&2
     exit 1
 fi
 rm -f conftest.c conftest.o
@@ -96,13 +93,10 @@ EOT
 if $CC -x c++ -std=c++23 -c conftest.cpp -o conftest.o >/dev/null 2>&1; then
     echo yes
     STD_CXXFLAG=-std=c++23
-elif $CC -x c++ -std=c++2b -c conftest.cpp -o conftest.o >/dev/null 2>&1; then
-    echo "using -std=c++2b"
-    STD_CXXFLAG=-std=c++2b
 else
     echo no
     rm -f conftest.cpp conftest.o
-    echo "$CC does not support -std=c++23 or -std=c++2b" >&2
+    echo "$CC does not support -std=c++23" >&2
     exit 1
 fi
 rm -f conftest.cpp conftest.o

--- a/user/configure.in
+++ b/user/configure.in
@@ -160,7 +160,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
     [AC_MSG_FAILURE([$CC does not support -std=c23])])
 CFLAGS="$save_CFLAGS"
 
-dnl Check if the compiler supports -std=c++23 (or -std=c++2b)
 AC_MSG_CHECKING([whether $CC accepts -std=c++23])
 save_CFLAGS="$CFLAGS"
 CFLAGS="$CFLAGS -x c++ -std=c++23"
@@ -171,18 +170,7 @@ CFLAGS="$save_CFLAGS"
 if test "$ac_cxx23" = yes; then
   CXXSTD="-std=c++23"
 else
-  AC_MSG_CHECKING([whether $CC accepts -std=c++2b])
-  save_CFLAGS="$CFLAGS"
-  CFLAGS="$CFLAGS -x c++ -std=c++2b"
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
-      [ac_cxx23=yes],
-      [ac_cxx23=no])
-  CFLAGS="$save_CFLAGS"
-  if test "$ac_cxx23" = yes; then
-    CXXSTD="-std=c++2b"
-  else
-    AC_MSG_FAILURE([$CC does not support -std=c++23 or -std=c++2b])
-  fi
+  AC_MSG_FAILURE([$CC does not support -std=c++23])
 fi
 AC_MSG_RESULT([$CXXSTD])
 AC_SUBST([CXXSTD])


### PR DESCRIPTION
## Summary
- clean up setup.sh comments to ASCII
- enforce C23/C++23 in the build files
- drop old C/C++ standard fallbacks
- add pre-commit configuration

## Testing
- `make`
- `pre-commit run --files setup.sh .pre-commit-config.yaml Makefile user/config.mk user/configure user/configure.in` *(fails: `pre-commit: command not found`)*
- `pytest -q` *(fails: `pytest: command not found`)*