### PR TITLE
Add NX support to x86 mappings

### DIFF
--- a/kernel/src/arch/x86/pgent.h
+++ b/kernel/src/arch/x86/pgent.h
@@ -248,9 +248,9 @@ public:
     void set_entry (space_t * s, pgsize_e pgsize, paddr_t paddr,
 		    word_t rwx, word_t attrib, bool kernel)
 	{
-	    pgent.set_entry (paddr,
-			     (x86_pgent_t::pagesize_e) pgsize,
-			     (kernel ? X86_PAGE_KERNEL : X86_PAGE_USER) |
+            pgent.set_entry (paddr,
+                             (x86_pgent_t::pagesize_e) pgsize,
+                             (kernel ? X86_PAGE_KERNEL : X86_PAGE_USER) |
 #if defined(CONFIG_X86_PGE)
 			     (kernel ? X86_PAGE_GLOBAL : 0) |
 #endif
@@ -260,11 +260,14 @@ public:
 			     (attrib & 4 ?
 			      (1UL << (pgsize == size_4k ? 7 : 12)) : 0) |
 #endif
-			     (rwx & 2 ? X86_PAGE_WRITABLE : 0) |
+                             (rwx & 2 ? X86_PAGE_WRITABLE : 0) |
+                             X86_PAGE_VALID,
 #if defined(CONFIG_X86_NX)
-			     (rwx & 1 ? 0 : X86_PAGE_NX) |
+                             !(rwx & 1)
+#else
+                             false
 #endif
-			     X86_PAGE_VALID);
+                             );
 
 #if defined(CONFIG_X86_SMALL_SPACES_GLOBAL)
 	    if ((! kernel) && is_smallspace(s))

--- a/kernel/src/arch/x86/x32/ptab.h
+++ b/kernel/src/arch/x86/x32/ptab.h
@@ -117,14 +117,15 @@ public:
     void clear()
 	{ raw = 0; }
 
-    void set_entry(addr_t addr, pagesize_e size, u32_t attrib)
-	{ 
-	    if (size == size_4k)
-		raw = ((u32_t)(addr) & X86_PAGE_MASK) | (attrib & X86_PAGE_FLAGS_MASK);
-	    else
-		raw = ((u32_t)(addr) & X86_SUPERPAGE_MASK) | X86_PAGE_SUPER |
-		    (attrib & X86_SUPERPAGE_FLAGS_MASK);
-	}
+    void set_entry(addr_t addr, pagesize_e size, u32_t attrib, bool nx = false)
+        {
+            if (size == size_4k)
+                raw = ((u32_t)(addr) & X86_PAGE_MASK) | (attrib & X86_PAGE_FLAGS_MASK);
+            else
+                raw = ((u32_t)(addr) & X86_SUPERPAGE_MASK) | X86_PAGE_SUPER |
+                    (attrib & X86_SUPERPAGE_FLAGS_MASK);
+            (void)nx; /* NX ignored on 32-bit without PAE */
+        }
 
     void set_ptab_entry(addr_t addr, u32_t attrib)
 	{

--- a/kernel/src/arch/x86/x64/ptab.h
+++ b/kernel/src/arch/x86/x64/ptab.h
@@ -112,19 +112,20 @@ public:
 	{ raw = 0; }
 
     /* used to set an entry pointing to a physical page */
-    void set_entry(addr_t addr, pagesize_e size, u64_t attrib)
-	{ 
-	    if (size == size_4k){
-		raw = ((u64_t)(addr) & X86_PAGE_MASK);
-		raw |= (attrib & X86_PAGE_FLAGS_MASK);
-	    }
-	    else{
-		raw = ((u64_t)(addr) & X86_SUPERPAGE_MASK) | X86_PAGE_SUPER;
-		raw |= (attrib & X86_SUPERPAGE_FLAGS_MASK);
-		
-	    }
+    void set_entry(addr_t addr, pagesize_e size, u64_t attrib, bool nx = false)
+        {
+            if (size == size_4k) {
+                raw = ((u64_t)(addr) & X86_PAGE_MASK);
+                raw |= (attrib & X86_PAGE_FLAGS_MASK);
+            }
+            else {
+                raw = ((u64_t)(addr) & X86_SUPERPAGE_MASK) | X86_PAGE_SUPER;
+                raw |= (attrib & X86_SUPERPAGE_FLAGS_MASK);
 
-	}
+            }
+            if (nx)
+                raw |= X86_PAGE_NX;
+        }
 
     void set_cacheability (bool cacheable, pagesize_e size)
     {

--- a/kernel/src/glue/v4-x86/init.cc
+++ b/kernel/src/glue/v4-x86/init.cc
@@ -273,9 +273,9 @@ void setup_tracebuffer (void)
     {	
 	//TRACEF("add tbuf mapping %t -> %t\n", addr_offset(tracebuffer, p),
         //     virt_to_phys(addr_offset(tracebuffer, p)));
-	get_kernel_space()->add_mapping(addr_offset(tracebuffer, p),
+        get_kernel_space()->add_mapping(addr_offset(tracebuffer, p),
                                         (paddr_t) virt_to_phys(addr_offset(tracebuffer, p)),
-                                        PGSIZE_KERNEL, true, false, true);
+                                        PGSIZE_KERNEL, true, false, false, true);
     }
     get_kip()->memory_info.insert(memdesc_t::reserved, true, tracebuffer,
                                   addr_offset(tracebuffer, TRACEBUFFER_SIZE -1));

--- a/kernel/src/glue/v4-x86/space.h
+++ b/kernel/src/glue/v4-x86/space.h
@@ -106,8 +106,13 @@ public:
     /* generic page table walker */
     pgent_t * pgent (word_t num);
     pgent_t * pgent (word_t num, word_t cpu);
-    void add_mapping(addr_t vaddr, addr_t paddr, pgent_t::pgsize_e size, 
-		     bool writable, bool kernel, bool global, bool cacheable = true);
+    /*
+     * The NX bit is only programmed when CONFIG_X86_NX is defined and the CPU
+     * supports it.
+     */
+    void add_mapping(addr_t vaddr, addr_t paddr, pgent_t::pgsize_e size,
+                     bool writable, bool executable, bool kernel, bool global,
+                     bool cacheable = true);
     void remap_area(addr_t vaddr, addr_t paddr, pgent_t::pgsize_e pgsize, 
 		    word_t len, bool writable, bool kernel, bool global);
     bool lookup_mapping( addr_t vaddr, pgent_t ** r_pg, pgent_t::pgsize_e *r_size, cpuid_t cpu);
@@ -403,7 +408,7 @@ extern active_cpu_space_t active_cpu_space;
 
 INLINE void space_t::map_sigma0(addr_t addr)
 {
-    add_mapping(addr, addr, PGSIZE_SIGMA, true, false, false);
+    add_mapping(addr, addr, PGSIZE_SIGMA, true, false, false, false);
 }
 
 /**********************************************************************

--- a/kernel/src/glue/v4-x86/x32/space.cc
+++ b/kernel/src/glue/v4-x86/x32/space.cc
@@ -136,16 +136,16 @@ addr_t acpi_remap(addr_t addr)
     
     get_kernel_space()->add_mapping(
         addr_mask (vaddr, ~page_mask (ACPI_PGENTSZ)),
-	addr_mask (paddr, ~page_mask (ACPI_PGENTSZ)),
-	ACPI_PGENTSZ, true, true, false, false);
+        addr_mask (paddr, ~page_mask (ACPI_PGENTSZ)),
+        ACPI_PGENTSZ, true, false, true, false, false);
 
     vaddr = addr_offset(vaddr, page_size(ACPI_PGENTSZ));
     paddr = addr_offset(paddr, page_size(ACPI_PGENTSZ));
     
-    get_kernel_space()->add_mapping( 
-	addr_mask (vaddr, ~page_mask (ACPI_PGENTSZ)),
-	addr_mask (paddr, ~page_mask (ACPI_PGENTSZ)),
-	ACPI_PGENTSZ, true, true, false, false);
+    get_kernel_space()->add_mapping(
+        addr_mask (vaddr, ~page_mask (ACPI_PGENTSZ)),
+        addr_mask (paddr, ~page_mask (ACPI_PGENTSZ)),
+        ACPI_PGENTSZ, true, false, true, false, false);
     
     x86_mmu_t::flush_tlb();
     

--- a/kernel/src/glue/v4-x86/x64/space.cc
+++ b/kernel/src/glue/v4-x86/x64/space.cc
@@ -155,8 +155,9 @@ word_t space_t::space_control (word_t ctrl, fpage_t kip_area, fpage_t utcb_area,
 	   Copied from init. */
 	if (is_initialized())
 	{
-	    add_mapping(get_kip_page_area().get_base(), virt_to_phys((addr_t) x32::get_kip()), pgent_t::size_4k, 
-			false, false, false);
+            add_mapping(get_kip_page_area().get_base(),
+                        virt_to_phys((addr_t) x32::get_kip()), pgent_t::size_4k,
+                        false, false, false, false);
 	}
     }
 

--- a/kernel/src/platform/generic/intctrl-apic.cc
+++ b/kernel/src/platform/generic/intctrl-apic.cc
@@ -165,9 +165,9 @@ void intctrl_t::init_arch()
     if (rsdp == NULL)
     {
 	TRACE_INIT("\tAssuming local APIC defaults");
-	get_kernel_space()->add_mapping(addr_t(APIC_MAPPINGS_START),
-					addr_t(0xFEE00000),
-					APIC_PGENTSZ, true, true, true, false);
+        get_kernel_space()->add_mapping(addr_t(APIC_MAPPINGS_START),
+                                        addr_t(0xFEE00000),
+                                        APIC_PGENTSZ, true, false, true, true, false);
 	
 	if (local_apic.version() >= 0x20)
 	    panic("no local APIC found--system unusable");
@@ -230,8 +230,8 @@ void intctrl_t::init_arch()
     TRACE_INIT("  Mapping local APICs at %p to %p\n",
 	       _madt->local_apic_addr, APIC_MAPPINGS_START);
     get_kernel_space()->add_mapping(addr_t(APIC_MAPPINGS_START),
-				    addr_t(_madt->local_apic_addr),
-				    APIC_PGENTSZ, true, true, true, false);
+                                    addr_t(_madt->local_apic_addr),
+                                    APIC_PGENTSZ, true, false, true, true, false);
 
     // reserve in KIP
     get_kip()->memory_info.insert(memdesc_t::reserved, 0, false,
@@ -360,12 +360,13 @@ bool intctrl_t::init_io_apic(word_t idx, word_t id, word_t irq_base, addr_t padd
 	return false;
 
     get_kernel_space()->add_mapping(addr_t(IOAPIC_MAPPING(idx)),
-				    paddr,
-				    APIC_PGENTSZ,
-				    true, // writable
-				    true, // kernel
-				    true, // global
-				    false); // uncacheable
+                                    paddr,
+                                    APIC_PGENTSZ,
+                                    true, // writable
+                                    false, // executable
+                                    true, // kernel
+                                    true, // global
+                                    false); // uncacheable
 
     // reserve in KIP
     get_kip()->memory_info.insert(memdesc_t::reserved, 0, false, 


### PR DESCRIPTION
## Summary
- extend `space_t::add_mapping` with an executable flag
- program the NX bit when the CPU supports it
- ensure x86 page table helpers accept the NX parameter
- document when NX mappings are used

## Testing
- `make -n all`