### PR TITLE
Add pre-commit config and docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,4 +5,20 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff
+  - repo: https://github.com/koalaman/shellcheck
+    rev: v0.9.0
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.55.2
+    hooks:
+      - id: golangci-lint
 

--- a/README
+++ b/README
@@ -109,3 +109,15 @@ resource managers via IPC.  Replace direct invocations of the old
 paging and scheduling interfaces with RPC stubs to the appropriate
 manager to ensure compatibility with the exokernel.
 
+
+Development workflow
+--------------------
+The repository uses [pre-commit](https://pre-commit.com) to run
+formatters and linters such as **black**, **ruff**, **shellcheck** and
+**golangci-lint**.  Install the hooks once after cloning::
+
+    $ pre-commit install
+
+With the hooks installed, each commit will automatically format and
+lint changed files.
+


### PR DESCRIPTION
## Summary
- add common lint hooks to `.pre-commit-config.yaml`
- document how to install pre-commit

## Testing
- `pre-commit run --files README .pre-commit-config.yaml` *(fails: pre-commit not installed)*
- `sudo apt-get update` *(fails: network unreachable)*