### PR TITLE
Fix autobuild interpreter

### DIFF
--- a/tools/autobuild
+++ b/tools/autobuild
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Usage: tools/autobuild <configuration>
 # must be run from top level pistachio directory.


### PR DESCRIPTION
## Summary
- use bash in the `tools/autobuild` script

## Testing
- `./tools/autobuild nosuchconfig`
- `pytest -q` *(fails: `pytest: command not found`)*