### PR TITLE
Add clang-tidy integration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: '-*,readability-*,modernize-*'
+WarningsAsErrors: ''

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -18,12 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        linter:
-          - { id: "shellcheck", cmd: "shellcheck -f gcc $(git ls-files '*.sh')" }
-          - { id: "black",       cmd: "black --check --diff ." }
-          - { id: "golangci",    cmd: "golangci-lint run --out-format=checkstyle" }
-          - { id: "ruff",        cmd: "ruff --output-format=github ." }
+        matrix:
+          linter:
+            - { id: "shellcheck", cmd: "shellcheck -f gcc $(git ls-files '*.sh')" }
+            - { id: "black",       cmd: "black --check --diff ." }
+            - { id: "golangci",    cmd: "golangci-lint run --out-format=checkstyle" }
+            - { id: "ruff",        cmd: "ruff --output-format=github ." }
+            - { id: "clang-tidy",  cmd: "clang-tidy $(git ls-files '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hpp') --quiet" }
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
@@ -32,7 +33,7 @@ jobs:
     - name: Install linter runtime deps
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y shellcheck
+        sudo apt-get install -y shellcheck clang-tidy
 
     - name: Run ${{ matrix.linter.id }} & feed Reviewdog
       uses: reviewdog/reviewdog@v0.20.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,4 +21,11 @@ repos:
     rev: v1.55.2
     hooks:
       - id: golangci-lint
+  - repo: local
+    hooks:
+      - id: clang-tidy
+        name: clang-tidy
+        entry: clang-tidy
+        language: system
+        files: \.(c|cc|cpp|cxx|h|hpp)$
 

--- a/README
+++ b/README
@@ -122,3 +122,11 @@ formatters and linters such as **black**, **ruff**, **shellcheck** and
 With the hooks installed, each commit will automatically format and
 lint changed files.
 
+Running clang-tidy
+------------------
+The tree includes a `.clang-tidy` configuration enabling the modernize
+and readability checks. The pre-commit hook runs the tool on modified
+C/C++ sources. To invoke it manually on a file::
+
+    $ clang-tidy path/to/file.cc
+

--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,7 @@ if [ "$HAVE_NET" -eq 1 ]; then
 #- core build tools, formatters, analysis, science libs
 for pkg in \
   build-essential gcc g++ clang lld llvm \
-  clang-format uncrustify astyle editorconfig pre-commit \
+  clang-format clang-tidy uncrustify astyle editorconfig pre-commit \
   make bmake ninja-build cmake meson \
   autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip \


### PR DESCRIPTION
## Summary
- install clang-tidy in `setup.sh`
- create a basic `.clang-tidy` configuration
- run clang-tidy in pre-commit hooks
- annotate clang-tidy output in CI
- document how to run clang-tidy

## Testing
- `python3 -m unittest tests/test_subdomain.py`
- ❌ `pip install pytest` *(fails: Could not connect to proxy)*