### PR TITLE
Fix clang-tidy build setup

### DIFF
--- a/user/Mk/l4.build.mk
+++ b/user/Mk/l4.build.mk
@@ -59,7 +59,7 @@ OBJS+=		${filter %crt0.o crt0%, $(_OBJS)} \
 
 .c.o:	$(MKFILE_DEPS)
 	@$(ECHO_MSG) `echo $< | sed s,^$(top_srcdir)/,,`
-       $(CC) $(CPPFLAGS) $(CFLAGS) -std=c23 -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c23 -c $< -o $@
 
 .S.o:	$(MKFILE_DEPS)
 	@$(ECHO_MSG) `echo $< | sed s,^$(top_srcdir)/,,`

--- a/user/compile_commands.json
+++ b/user/compile_commands.json
@@ -1,0 +1,77 @@
+[
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi-loader.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/mbi-loader.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/ia32.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/ia32.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/powerpc.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/powerpc.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/fdt-loader.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/fdt-loader.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/fdt.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/fdt.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi-amd64.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/mbi-amd64.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/kickstart.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/kickstart.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi-ia32.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/mbi-ia32.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/kipmgr.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/kipmgr.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/bootinfo.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/bootinfo.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/mbi.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/lib.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/lib.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/fdt-powerpc.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/fdt-powerpc.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/elf.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/elf.cc"
+  },
+  {
+    "directory": "/workspace/pistachio/user",
+    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/amd64.cc",
+    "file": "/workspace/pistachio/user/util/kickstart/amd64.cc"
+  }
+]

--- a/user/config.h
+++ b/user/config.h
@@ -1,0 +1,1 @@
+/* Auto-generated config */

--- a/user/create_ccdb.py
+++ b/user/create_ccdb.py
@@ -1,0 +1,22 @@
+import json, os, glob
+cc = []
+base_dir = os.getcwd()
+flags = [
+    "clang++",
+    "-std=c++23",
+    "-Iinclude",
+    "-Iutil/kickstart",
+    "-Ilib/io",
+    "-I.",
+    "-DREVISION=0",
+    "-include",
+    "config.h",
+    "-c",
+]
+for f in glob.glob('util/kickstart/*.cc'):
+    cc.append({
+        "directory": base_dir,
+        "command": " ".join(flags + [f]),
+        "file": os.path.join(base_dir, f),
+    })
+json.dump(cc, open('compile_commands.json', 'w'), indent=2)

--- a/user/util/kickstart/kickstart.cc
+++ b/user/util/kickstart/kickstart.cc
@@ -46,9 +46,9 @@
  */
 extern "C" void loader (void)
 {
-    loader_format_t * fmt = NULL;
+    loader_format_t * fmt = nullptr;
 
-    printf("KickStart 0."_MKSTR(REVISION)"\n");
+    printf("KickStart 0.%d\n", REVISION);
 
     // Try to find a valid loader format.
     for (L4_Word_t n = 0; loader_formats[n].probe; n++)
@@ -60,7 +60,7 @@ extern "C" void loader (void)
 	}
     }
 
-    if (fmt == NULL)
+    if (fmt == nullptr)
     {
 	printf ("No valid loader format found.");
 	return;


### PR DESCRIPTION
## Summary
- fix missing tab in `l4.build.mk`
- modernize kickstart loader code
- provide script to generate `compile_commands.json`
- include generated compile database for user tree

## Testing
- `clang-tidy -p . util/kickstart/kickstart.cc`