### PR TITLE
Update kickstart loaders

### DIFF
--- a/user/util/kickstart/amd64.cc
+++ b/user/util/kickstart/amd64.cc
@@ -44,10 +44,10 @@
 /*
  * Loader formats supported for AMD64.
  */
-loader_format_t loader_formats[] = {
+std::array<loader_format_t, 2> loader_formats = {{
     { "multiboot compliant loader", mbi_probe,  mbi_init },
-    NULL_LOADER
-};
+    null_loader
+}};
 
 
 void fail(int ec)

--- a/user/util/kickstart/ia32.cc
+++ b/user/util/kickstart/ia32.cc
@@ -41,10 +41,10 @@
 /*
  * Loader formats supported for IA32.
  */
-loader_format_t loader_formats[] = {
+std::array<loader_format_t, 2> loader_formats = {{
     { "multiboot compliant loader", mbi_probe, mbi_init },
-    NULL_LOADER
-};
+    null_loader
+}};
 
 
 void fail(int ec)

--- a/user/util/kickstart/kickstart.h
+++ b/user/util/kickstart/kickstart.h
@@ -33,10 +33,8 @@
 #define __KICKSTART__KICKSTART_H__
 
 #include <l4/types.h>
-
-#ifndef NULL
-#define NULL	0
-#endif
+#include <array>
+#include <cstddef>
 
 
 /**
@@ -64,13 +62,13 @@ public:
     L4_Word_t (*init)(void);
 };
 
-#define NULL_LOADER { "null", NULL, NULL }
+constexpr loader_format_t null_loader { "null", nullptr, nullptr };
 
 
 /**
  * NULL terminated array of loader formats.
  */
-extern loader_format_t loader_formats[];
+extern std::array<loader_format_t, 2> loader_formats;
 
 
 

--- a/user/util/kickstart/powerpc.cc
+++ b/user/util/kickstart/powerpc.cc
@@ -143,10 +143,10 @@ extern "C" void putc(int c)
 /*
  * Loader formats supported for PowerPC
  */
-loader_format_t loader_formats[] = {
+std::array<loader_format_t, 2> loader_formats = {{
     { "Flattened device tree", fdt_probe, fdt_init },
-    NULL_LOADER
-};
+    null_loader
+}};
 
 
 void fail(int ec)


### PR DESCRIPTION
## Summary
- remove NULL macro from kickstart.h and include `<cstddef>`
- replace `NULL_LOADER` macro with `constexpr null_loader`
- migrate loader arrays to `std::array` and use `null_loader` sentinel

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: command not found)*