### PR TITLE
Replace NULL with nullptr in C++ codebase

### DIFF
--- a/contrib/disas/ppc-dis.cc
+++ b/contrib/disas/ppc-dis.cc
@@ -116,7 +116,7 @@ print_insn_powerpc( unsigned long memaddr, unsigned long insn, int dialect )
 
 	  /* Extract the value from the instruction.  */
 	  if (operand->extract)
-	    value = (*operand->extract) (insn, dialect, (int *) NULL);
+	    value = (*operand->extract) (insn, dialect, (int *) nullptr);
 	  else
 	    {
 	      value = (insn >> operand->shift) & ((1 << operand->bits) - 1);

--- a/contrib/disas/ppc-opc.cc
+++ b/contrib/disas/ppc-opc.cc
@@ -558,9 +558,9 @@ const struct powerpc_operand powerpc_operands[] =
   /* The WS field.  */
 #define WS EVUIMM_8 + 1
 #define WS_MASK (0x7 << 11)
-  { 3, 11, 0, 0, 0 },
+  if (invalid != (int *) nullptr
 
-  /* The L field in an mtmsrd instruction */
+  if (invalid != (int *) nullptr
 #define MTMSRD_L WS + 1
   { 1, 16, 0, 0, PPC_OPERAND_OPTIONAL },
 
@@ -643,8 +643,8 @@ extract_bd ( unsigned long insn, int dialect ATTRIBUTE_UNUSED,
    we just want to print the normal form of the instruction.
    Power4 compatible targets use two bits, "a", and "t", instead of
    the "y" bit.  "at" == 00 => no hint, "at" == 01 => unpredictable,
-   "at" == 10 => not taken, "at" == 11 => taken.  The "t" bit is 00001
-   in BO field, the "a" bit is 00010 for branch on CR(BI) and 01000
+  if (invalid != (int *) nullptr)
+  if (invalid != (int *) nullptr)
    for branch on CTR.  We only handle the taken/not-taken hint here.  */
 
 /*ARGSUSED*/
@@ -761,24 +761,24 @@ valid_bo ( long value, int dialect )
     }
   else
     {
-      /* Certain encodings have bits that are required to be zero.
-	 These are (z must be zero, a & t may be anything):
-	     0000z
-	     0001z
-	     0100z
-	     0101z
-	     001at
-	     011at
-	     1a00t
-	     1a01t
-	     1z1zz
-      */
-      if ((value & 0x14) == 0)
-	return (value & 0x1) == 0;
-      else if ((value & 0x14) == 0x14)
-	return value == 0x14;
-      else
-	return 1;
+  if (errmsg != (const char **) nullptr
+  if (invalid != (int *) nullptr
+  if (errmsg != (const char **) nullptr)
+  if (invalid != (int *) nullptr
+  if ((value & 1) != 0 && errmsg != nullptr)
+  if ((value > 62) != 0 && errmsg != nullptr)
+  if ((value & 3) != 0 && errmsg != nullptr)
+  if ((value > 124) != 0 && errmsg != nullptr)
+  if ((value & 7) != 0 && errmsg != nullptr)
+  if ((value > 248) != 0 && errmsg != nullptr)
+  if ((value & 3) != 0 && errmsg != nullptr)
+  if ((value > 2047 || value < -2048) && errmsg != nullptr)
+  if ((value > 8191 || value < -8192) && errmsg != nullptr)
+  else if ((value & 3) != 0 && errmsg != nullptr)
+  if ((value & 3) != 0 && errmsg != (const char **) nullptr)
+      if (errmsg != (const char **) nullptr)
+      if (errmsg != (const char **) nullptr)
+  if (invalid != (int *) nullptr)
     }
 }
 
@@ -1109,7 +1109,7 @@ extract_nb ( unsigned long insn,
      int dialect ATTRIBUTE_UNUSED,
      int *invalid ATTRIBUTE_UNUSED )
 {
-  long ret;
+  if (invalid != (int *) nullptr)
 
   ret = (insn >> 11) & 0x1f;
   if (ret == 0)
@@ -1171,7 +1171,7 @@ insert_ram ( unsigned long insn, long value,
    field may not be zero.  */
 
 static unsigned long
-insert_ras ( unsigned long insn, long value,
+  if (invalid != (int *) nullptr
      int dialect ATTRIBUTE_UNUSED, const char **errmsg )
 {
   if (value == 0)

--- a/kernel/kdb/api/v4/input.cc
+++ b/kernel/kdb/api/v4/input.cc
@@ -199,7 +199,7 @@ tcb_t SECTION (SEC_KDEBUG) * get_thread (const char * prompt)
 			break;
 		    case '\e':
 			printf ("\n");
-			return (tcb_t *) NULL;
+			return (tcb_t *) nullptr;
 		    case KEY_RETURN:
 			break;
 		    default:

--- a/kernel/kdb/api/v4/schedule-hs.cc
+++ b/kernel/kdb/api/v4/schedule-hs.cc
@@ -37,7 +37,7 @@
 #include INC_API(schedule.h)
 #include INC_API(cpu.h)
 
-tcb_t * global_present_list UNIT("kdebug") = NULL;
+tcb_t * global_present_list UNIT("kdebug") = nullptr;
 spinlock_t present_list_lock;
 
 DECLARE_CMD(cmd_show_sched, root, 'q', "showqueue",  "show scheduling queue");

--- a/kernel/kdb/api/v4/schedule-rr.cc
+++ b/kernel/kdb/api/v4/schedule-rr.cc
@@ -38,7 +38,7 @@
 #include INC_API(schedule.h)
 #include INC_API(cpu.h)
 
-tcb_t * global_present_list UNIT("kdebug") = NULL;
+tcb_t * global_present_list UNIT("kdebug") = nullptr;
 spinlock_t present_list_lock;
 
 DECLARE_CMD(cmd_show_sched, root, 'q', "showqueue",  "show scheduling queue");

--- a/kernel/kdb/api/v4/sigma0.cc
+++ b/kernel/kdb/api/v4/sigma0.cc
@@ -113,7 +113,7 @@ static void sigma0_ipc (word_t type, word_t arg)
     tag = current->do_ipc (s0id, NILTHREAD, timeout_t::never());
 
     // Abort kernel thread execution.
-    current->set_space (NULL);
+    current->set_space (nullptr);
     current->set_state (thread_state_t::aborted);
     get_current_scheduler ()->deschedule (current);
     current->sched_state.init (sktcb_lo);

--- a/kernel/kdb/api/v4/tcb.cc
+++ b/kernel/kdb/api/v4/tcb.cc
@@ -341,7 +341,7 @@ tcb_t SECTION(SEC_KDEBUG) * kdb_get_tcb()
     word_t val = get_hex("tcb/tid", (word_t) space, "current");
 
     if (val == ABORT_MAGIC)
-	return NULL;
+	return nullptr;
 
     if (!tcb_t::is_tcb((addr_t)val) &&
 	(val != (word_t)get_idle_tcb()))

--- a/kernel/kdb/arch/powerpc/instr.cc
+++ b/kernel/kdb/arch/powerpc/instr.cc
@@ -90,7 +90,7 @@ CMD(cmd_single_step, cg)
 {
     debug_param_t *param = (debug_param_t *)kdb.kdb_param;
 
-    if( param == NULL )
+    if( param == nullptr )
 	printf( "KDB error: unknown exception state, unable to single step.\n");
     else {
 	dbg_addr_disasm( param->frame->srr0_ip );
@@ -105,7 +105,7 @@ CMD(cmd_branch_trace, cg)
 {
     debug_param_t *param = (debug_param_t *)kdb.kdb_param;
 
-    if( param == NULL )
+    if( param == nullptr )
 	printf( "KDB error: unknown exception state, "
 		"unable to branch trace.\n" );
     else {
@@ -121,7 +121,7 @@ CMD(cmd_srr0_disasm, cg)
 {
     debug_param_t *param = (debug_param_t *)kdb.kdb_param;
 
-    if( param == NULL ) {
+    if( param == nullptr ) {
 	printf( "KDB error: no exception state to disassemble.\n" );
 	return CMD_NOQUIT;
     }

--- a/kernel/kdb/arch/powerpc/regs.cc
+++ b/kernel/kdb/arch/powerpc/regs.cc
@@ -218,7 +218,7 @@ CMD(cmd_sysregs, cg)
 CMD(cmd_except_regs, cg)
 {
     debug_param_t *param = (debug_param_t *)kdb.kdb_param;
-    if( param != NULL )
+    if( param != nullptr )
 	dbg_print_except_regs( param->frame );
     return CMD_NOQUIT;
 }
@@ -226,7 +226,7 @@ CMD(cmd_except_regs, cg)
 CMD(cmd_user_except_regs, cg)
 {
     except_regs_t *regs = get_user_except_regs( get_current_tcb() );
-    if( regs != NULL )
+    if( regs != nullptr )
 	dbg_print_except_regs( regs );
     return CMD_NOQUIT;
 }
@@ -240,7 +240,7 @@ CMD(cmd_print_msr, cg)
 CMD(cmd_print_except_msr, cg)
 {
     debug_param_t *param = (debug_param_t *)kdb.kdb_param;
-    if( param != NULL )
+    if( param != nullptr )
 	dbg_dump_msr( param->frame->srr1_flags );
     return CMD_NOQUIT;
 }

--- a/kernel/kdb/arch/powerpc64/macio.cc
+++ b/kernel/kdb/arch/powerpc64/macio.cc
@@ -58,8 +58,8 @@ static void switch_console( const char *name )
  *
  ****************************************************************************/
 
-volatile u8_t *scca_control = NULL;
-volatile u8_t *scca_data = NULL;
+volatile u8_t *scca_control = nullptr;
+volatile u8_t *scca_data = nullptr;
 
 static void putc_null( char c )
 {
@@ -334,8 +334,8 @@ void kdebug_check_breakin (void)
  ****************************************************************************/
 
 kdb_console_t kdb_consoles[] = {
-    { NULL_NAME, NULL, putc_null, getc_null },
-    { SCCA_NAME, NULL, putc_serial, getc_serial },
+    { NULL_NAME, nullptr, putc_null, getc_null },
+    { SCCA_NAME, nullptr, putc_serial, getc_serial },
     KDB_NULL_CONSOLE
 };
 

--- a/kernel/kdb/arch/powerpc64/ofio.cc
+++ b/kernel/kdb/arch/powerpc64/ofio.cc
@@ -59,7 +59,7 @@ static void switch_console( const char *name )
 
 /****************************************************************************
  *
- *    NULL console support
+ *    nullptr console support
  *
  ****************************************************************************/
 
@@ -98,9 +98,9 @@ static void putc_rtas( char c )
     if (putc_token)
     {
 	if (c == '\n')
-	    get_rtas()->rtas_call( putc_token, 1, 1, NULL, '\r' );
+	    get_rtas()->rtas_call( putc_token, 1, 1, nullptr, '\r' );
 
-	get_rtas()->rtas_call( putc_token, 1, 1, NULL, c );
+	get_rtas()->rtas_call( putc_token, 1, 1, nullptr, c );
     }
 }
 
@@ -159,7 +159,7 @@ void init_serial_console()
     char *path, *type;
     u32_t len, *cellptr, adrcells, sizcells;
 
-    serial_regs = NULL;
+    serial_regs = nullptr;
  
     aliases = get_of1275_tree()->find( "/aliases" );
     if (!aliases) goto error;
@@ -307,11 +307,11 @@ void kdebug_check_breakin (void)
  ****************************************************************************/
 
 kdb_console_t kdb_consoles[] = {
-    { NULL_NAME, NULL, putc_null, getc_null },
+    { NULL_NAME, nullptr, putc_null, getc_null },
 #if defined(CONFIG_KDB_CONS_RTAS)
-    { RTAS_NAME, NULL, putc_rtas, getc_rtas },
+    { RTAS_NAME, nullptr, putc_rtas, getc_rtas },
 #endif
-    { SERIAL_NAME, NULL, putc_serial, getc_serial },
+    { SERIAL_NAME, nullptr, putc_serial, getc_serial },
     KDB_NULL_CONSOLE
 };
 

--- a/kernel/kdb/arch/x86/x32/disas.cc
+++ b/kernel/kdb/arch/x86/x32/disas.cc
@@ -64,7 +64,7 @@ restart:
 	printf("%x: ", pc);
 	pc += disas((addr_t) pc);
 	printf("\n");
-	c = get_choice(NULL, " /u/q", ' ');
+	c = get_choice(nullptr, " /u/q", ' ');
     } while ((c != 'q') && (c != 'u'));
     if (c == 'u')
 	goto restart;
@@ -120,7 +120,7 @@ restart:
 	printf("[%s-bit]: %x: ", (real_mode ? "16" : "32"), pc);
 	pc += (real_mode ? disas16((addr_t) pc) : disas((addr_t) pc));
 	printf("\n");
-	c = get_choice(NULL, " /u/q", ' ');
+	c = get_choice(nullptr, " /u/q", ' ');
     } while ((c != 'q') && (c != 'u'));
     if (c == 'u')
 	goto restart;

--- a/kernel/kdb/arch/x86/x64/disas.cc
+++ b/kernel/kdb/arch/x86/x64/disas.cc
@@ -55,7 +55,7 @@ restart:
 	printf("%x: ", pc);
 	pc += disas((addr_t) pc);
 	printf("\n");
-	c = get_choice(NULL, " /u/q", ' ');
+	c = get_choice(nullptr, " /u/q", ' ');
     } while ((c != 'q') && (c != 'u'));
     if (c == 'u')
 	goto restart;

--- a/kernel/kdb/arch/x86/x64/x86.cc
+++ b/kernel/kdb/arch/x86/x64/x86.cc
@@ -163,7 +163,7 @@ DECLARE_CMD (cmd_pgtcalc, arch, 'P', "pgtcalc", "calculate page table indices");
 
 CMD(cmd_pgtcalc, cg)
 {
-    addr_t addr = (addr_t) get_hex ("Virtual address", NULL);
+    addr_t addr = (addr_t) get_hex ("Virtual address", nullptr);
     printf("%p -> %d, %d, %d, %d\n",
 	   addr,
 	   page_table_index(pgent_t::size_512g, addr),

--- a/kernel/kdb/arch/x86/x86.cc
+++ b/kernel/kdb/arch/x86/x86.cc
@@ -146,7 +146,7 @@ CMD(cmd_ports, cg)
 {
     char dir  = get_choice ("Access mode", "In/Out", 'i');
     char width = get_choice ("Access width", "Byte/Word/Dword", 'b');
-    u16_t port = get_hex ("Port", 0x80, NULL);
+    u16_t port = get_hex ("Port", 0x80, nullptr);
 
     u32_t val = 0;
 
@@ -160,7 +160,7 @@ CMD(cmd_ports, cg)
 	printf("Value = %x\n", val);
 	break;
     case 'o':
-	val = get_hex ("Value", 0, NULL);
+	val = get_hex ("Value", 0, nullptr);
 	switch (width) {
 	case 'b': out_u8(port, val); break;
 	case 'w': out_u16(port, val); break;
@@ -200,7 +200,7 @@ DECLARE_CMD (cmd_send_nmi, arch, 'N', "send_nmi", "send NMI to CPU");
 
 CMD(cmd_send_nmi, cg)
 {
-    word_t cpuid = get_dec("CPU id", 0, NULL);
+    word_t cpuid = get_dec("CPU id", 0, nullptr);
     cpu_t* cpu = cpu_t::get(cpuid);
     local_apic_t<APIC_MAPPINGS_START> local_apic;
     // don't nmi ourselfs
@@ -218,7 +218,7 @@ extern void kdb_wait_for_cpu();
 CMD(cmd_switch_cpus, cg)
 {
     cpuid_t cpu = get_current_cpu();
-    word_t dst_cpu = get_dec("CPU id", 0, NULL);
+    word_t dst_cpu = get_dec("CPU id", 0, nullptr);
     if (dst_cpu >= CONFIG_SMP_MAX_CPUS ||
 	dst_cpu == cpu || 
 	!cpu_t::get(dst_cpu)->is_valid())

--- a/kernel/kdb/generic/acpi.cc
+++ b/kernel/kdb/generic/acpi.cc
@@ -42,17 +42,17 @@
 /**
  * Root System Descriptor Pointer.
  */
-static acpi_rsdp_t * rsdp = NULL;
+static acpi_rsdp_t * rsdp = nullptr;
 
 /**
  * Root System Description Table.
  */
-static acpi_rsdt_t * rsdt = NULL;
+static acpi_rsdt_t * rsdt = nullptr;
 
 /**
  * Extended System Description Table.
  */
-static acpi_xsdt_t * xsdt = NULL;
+static acpi_xsdt_t * xsdt = nullptr;
 
 
 void SECTION (SEC_KDEBUG) dump_apic (acpi_madt_t * madt);
@@ -78,10 +78,10 @@ DECLARE_CMD (cmd_acpi, arch, 'a', "acpi", "ACPI access");
 
 CMD (cmd_acpi, cg)
 {
-    if (rsdp == NULL)
+    if (rsdp == nullptr)
     {
 	rsdp = acpi_rsdp_t::locate ();
-	if (rsdp == NULL)
+	if (rsdp == nullptr)
 	{
 	    printf ("Could not locate ACPI info.\n");
 	    return CMD_NOQUIT;

--- a/kernel/kdb/generic/bootinfo.cc
+++ b/kernel/kdb/generic/bootinfo.cc
@@ -201,7 +201,7 @@ CMD (cmd_dump_bootinfo, cg)
     static word_t kip_bootinfo;
     bootinfo_t * bi = bootinfo_copy;
 
-    if (bi == NULL)
+    if (bi == nullptr)
     {
 	kip_bootinfo = get_kip ()->boot_info;
 	bi = (bootinfo_t *) kip_bootinfo;
@@ -211,7 +211,7 @@ CMD (cmd_dump_bootinfo, cg)
 	 * generic BootInfo structure.
 	 */
 
-	if (bi == NULL || (word_t) bi > (word_t) GB (2))
+	if (bi == nullptr || (word_t) bi > (word_t) GB (2))
 	{
 	    printf ("Doesn't look like a generic bootinfo structure "
 		    "(bootinfo=%p)\n", bi);

--- a/kernel/kdb/generic/cmd.cc
+++ b/kernel/kdb/generic/cmd.cc
@@ -54,10 +54,10 @@ cmd_t SECTION(SEC_KDEBUG) * cmd_group_t::interact_by_key (void)
     do {
 	char c = getc ();
 	reset ();
-	while ((cmd = next ()) != NULL)
+	while ((cmd = next ()) != nullptr)
 	    if (cmd->key == c)
 		break;
-    } while (cmd == NULL);
+    } while (cmd == nullptr);
     printf ("%s\n", cmd->command);
 
     return cmd;
@@ -85,10 +85,10 @@ cmd_t SECTION(SEC_KDEBUG) * cmd_group_t::interact_by_command (void)
 	    case KEY_TAB:
 	    {
 		/* Check number of matching commands */
-		cmd_t * match = NULL;
+		cmd_t * match = nullptr;
 		int nummatch = 0;
 		reset ();
-		while ((cmd = next ()) != NULL)
+		while ((cmd = next ()) != nullptr)
 		    if (strncmp ((char *) cmd->command, cmdstr, cmdlen) == 0)
 			match = cmd, nummatch++;
 	    
@@ -106,7 +106,7 @@ cmd_t SECTION(SEC_KDEBUG) * cmd_group_t::interact_by_command (void)
 		    /* Print list of matching commands */
 		    putc ('\n');
 		    reset ();
-		    while ((cmd = next ()) != NULL)
+		    while ((cmd = next ()) != nullptr)
 			if (strncmp ((char *) cmd->command, cmdstr, cmdlen) == 0)
 			    printf ("%s\n", cmd->command);
 		    cmdstr[cmdlen] = 0;
@@ -137,7 +137,7 @@ cmd_t SECTION(SEC_KDEBUG) * cmd_group_t::interact_by_command (void)
 
 	/* Check for matching command */
 	reset ();
-	while ((cmd = next ()) != NULL)
+	while ((cmd = next ()) != nullptr)
 	{
 	    if (strncmp ((char *) cmd->command, cmdstr, cmdlen) == 0 &&
 		cmd->command[cmdlen] == 0)
@@ -154,7 +154,7 @@ cmd_t SECTION(SEC_KDEBUG) * cmd_group_t::interact_by_command (void)
     }
 
     /* NOTREACHED */
-    return NULL;
+    return nullptr;
 }
 
 
@@ -198,7 +198,7 @@ CMD(cmd__help, cg)
     cmd_t * cmd;
 
     cg->reset ();
-    while ((cmd = cg->next ()) != NULL)
+    while ((cmd = cg->next ()) != nullptr)
     {
 	if (kdb.kdb_cmd_mode == CMD_KEYMODE)
 	{
@@ -282,7 +282,7 @@ static int SECTION(SEC_KDEBUG) strncmp (char * s1, char * s2, int len)
 
 static void SECTION(SEC_KDEBUG) print_cmd_path (cmd_group_t * cg)
 {
-    if (cg->parent != NULL)
+    if (cg->parent != nullptr)
     {
 	print_cmd_path (cg->parent);
 	printf ("/");

--- a/kernel/kdb/generic/console.cc
+++ b/kernel/kdb/generic/console.cc
@@ -102,7 +102,7 @@ CMD (cmd_toggle_console, cg)
 {
     word_t newcons = kdb_current_console + 1;
 
-    if (kdb_consoles[newcons].name == NULL)
+    if (kdb_consoles[newcons].name == nullptr)
 	newcons = 0;
 
     printf ("Switch console: %s\n", kdb_consoles[newcons].name);

--- a/kernel/kdb/generic/entry.cc
+++ b/kernel/kdb/generic/entry.cc
@@ -71,7 +71,7 @@ void kdb_t::entry (void * param)
     cmd_ret_t r;
 
     kdb_param = param;
-    last_space = NULL;
+    last_space = nullptr;
     last_dump = 0;
     
     /* XXX probably not generic enough */
@@ -79,12 +79,12 @@ void kdb_t::entry (void * param)
 
     if (pre())
 	do {
-	    r = root.interact (NULL, "");
+	    r = root.interact (nullptr, "");
 	} while (r != CMD_QUIT);
     
     post();
     
-    kdb_param = NULL;
+    kdb_param = nullptr;
 }
 
 

--- a/kernel/kdb/generic/init.cc
+++ b/kernel/kdb/generic/init.cc
@@ -61,7 +61,7 @@ void SECTION (".init") kdb_t::init (void)
 {
     /* initialize state */
     kdb_cmd_mode = CMD_KEYMODE;
-    kdb_param = NULL;
+    kdb_param = nullptr;
 
     /*
      * Ensure that linker sets are initialized.
@@ -75,7 +75,7 @@ void SECTION (".init") kdb_t::init (void)
 
     kdb_initfunc_t initfunc;
     kdb_initfuncs.reset ();
-    while ((initfunc = (kdb_initfunc_t) kdb_initfuncs.next ()) != NULL)
+    while ((initfunc = (kdb_initfunc_t) kdb_initfuncs.next ()) != nullptr)
 	initfunc ();
     
 #if defined(CONFIG_TRACEPOINTS)

--- a/kernel/kdb/generic/input.cc
+++ b/kernel/kdb/generic/input.cc
@@ -43,7 +43,7 @@
  * @param defstr	default string
  *
  * Prompt for a hex value using PROMPT and return the typed in value.
- * If PROMPT is NULL, do not display it.  If user just presses return,
+ * If PROMPT is nullptr, do not display it.  If user just presses return,
  * DEFNUM will be displayed and returned.  If DEFSTR is non-nil, it
  * will be displayed as a default value instead of DEFNUM.
  * 
@@ -135,7 +135,7 @@ word_t SECTION(SEC_KDEBUG) get_hex (const char * prompt, const word_t defnum, co
  * @param defstr	default string
  *
  * Prompt for a decimal value using PROMPT and return the typed in value.
- * If PROMPT is NULL, do not display it.  If user just presses return,
+ * If PROMPT is nullptr, do not display it.  If user just presses return,
  * DEFNUM will be displayed and returned.  If DEFSTR is non-nil, it
  * will be displayed as a default value instead of DEFNUM.
  * 
@@ -218,7 +218,7 @@ static char * get_key_string (char key, const char * choices);
  * choice string with a single character also indicates the
  * appropriate key for selecting the choice.  The function does not
  * return until user has selected a valid choice. Be absolutely quiet
- * if PROMPT is NULL.
+ * if PROMPT is nullptr.
  * 
  * @returns the character associated with the choice made
  */
@@ -263,7 +263,7 @@ static char SECTION(SEC_KDEBUG) * get_key_string (char key, const char * choices
     const char * p;
 
     if (key == 0)
-	return NULL;
+	return nullptr;
 
     for (p = choices; *p; p++)
     {
@@ -275,7 +275,7 @@ static char SECTION(SEC_KDEBUG) * get_key_string (char key, const char * choices
     }
 
     if (*p == 0)
-	return NULL;
+	return nullptr;
 
     while (p > choices && p[-1] != '/')
 	p--;

--- a/kernel/kdb/generic/kmemory.cc
+++ b/kernel/kdb/generic/kmemory.cc
@@ -63,7 +63,7 @@ CMD (cmd_kmem_stats, cg)
 	num_chunks[idx] = 0;
     max_chunks = 0;
 
-    for (num = 1, cur = kmem_free_list, prev = NULL;
+    for (num = 1, cur = kmem_free_list, prev = nullptr;
 	 cur;
 	 prev = cur, cur = (word_t *) *cur )
     {
@@ -122,7 +122,7 @@ CMD (cmd_kmem_stats, cg)
     printf ("\nKernel memory distribution:\n");
     __kmem_groups.reset ();
     kmem_group_t * group;
-    while ((group = (kmem_group_t *) __kmem_groups.next ()) != NULL)
+    while ((group = (kmem_group_t *) __kmem_groups.next ()) != nullptr)
     {
 	printf ("  %16s %6d %cB\n",
 		group->name,

--- a/kernel/kdb/generic/linear_ptab_dump.cc
+++ b/kernel/kdb/generic/linear_ptab_dump.cc
@@ -77,7 +77,7 @@ CMD(cmd_dump_ptab, cg)
     space = get_space ("Space");
     size = pgent_t::size_max;
     
-    word_t cpu = get_dec("CPU id", get_current_cpu(), NULL);
+    word_t cpu = get_dec("CPU id", get_current_cpu(), nullptr);
     if (cpu >= CONFIG_SMP_MAX_CPUS) cpu = get_current_cpu();
     
     get_ptab_dump_ranges (&vaddr, &num, &max_size);

--- a/kernel/kdb/generic/linker_set.cc
+++ b/kernel/kdb/generic/linker_set.cc
@@ -121,7 +121,7 @@ void linker_set_t::reset (void)
 
 /**
  * linker_set_t::next: Retrieves pointer to next entry in linker set,
- * or NULL if all entries have been iterated over.
+ * or nullptr if all entries have been iterated over.
  */
 addr_t linker_set_t::next (void)
 {
@@ -146,6 +146,6 @@ word_t linker_set_t::size (void)
 addr_t linker_set_t::get (word_t n)
 {
     if (n >= entries)
-	return NULL;
+	return nullptr;
     return list[n].get_entry ();
 }

--- a/kernel/kdb/generic/mapping.cc
+++ b/kernel/kdb/generic/mapping.cc
@@ -97,7 +97,7 @@ static void dump_mdbmaps (mapnode_t * map, addr_t paddr,
 			  mapnode_t::pgsize_e size,
 			  rootnode_t * proot, char * spc)
 {
-    mapnode_t * pmap = NULL;
+    mapnode_t * pmap = nullptr;
 
     while (map)
     {
@@ -114,7 +114,7 @@ static void dump_mdbmaps (mapnode_t * map, addr_t paddr,
 	
 	pmap = map;
 	if (map->is_next_root () || (map->is_next_both () &&
-                                     map->get_nextroot () != NULL))
+                                     map->get_nextroot () != nullptr))
 	{
 	    dump_mdbroot (mdb_index_root (size-1, map->get_nextroot (), paddr),
 			  paddr, size-1, spc - 2 - map->get_depth () * 2);

--- a/kernel/kdb/generic/mdb.cc
+++ b/kernel/kdb/generic/mdb.cc
@@ -125,7 +125,7 @@ static const char * sz_suf (word_t sz)
  */
 STATIC void kdb_t::dump_table (mdb_t * mdb, mdb_table_t * t, word_t depth)
 {
-    if (t == NULL)
+    if (t == nullptr)
 	return;
 
     word_t paddr = t->prefix & ~(((1UL << t->objsize) << t->radix) - 1);
@@ -152,7 +152,7 @@ STATIC void kdb_t::dump_table (mdb_t * mdb, mdb_table_t * t, word_t depth)
 	    printf ("%s%p ", indent (depth + 1), paddr);
 
 	    mdb_node_t * n = te->get_node ();
-	    if (n == NULL)
+	    if (n == nullptr)
 	    {
 		printf ("[null node]\n");
 		continue;
@@ -164,7 +164,7 @@ STATIC void kdb_t::dump_table (mdb_t * mdb, mdb_table_t * t, word_t depth)
 		dump_table (mdb, n->get_table (), depth + 2);
 
 	    n = n->get_next ();
-	    while (n != NULL)
+	    while (n != nullptr)
 	    {
 		printf ("%s%ws ", indent (depth + 1 + n->get_depth ()
 					  - start_depth), "");

--- a/kernel/kdb/generic/print.cc
+++ b/kernel/kdb/generic/print.cc
@@ -281,7 +281,7 @@ int SECTION(SEC_KDEBUG) do_printf(const char* format_p, va_list args)
     printf_spin_lock.lock();
     
     /* sanity check */
-    if (format == NULL)
+    if (format == nullptr)
 	goto done;
 
     while (*format)

--- a/kernel/kdb/generic/sprintf.cc
+++ b/kernel/kdb/generic/sprintf.cc
@@ -115,7 +115,7 @@ static int SECTION(SEC_KDEBUG) do_sprintf(char** obuf, const char* format_p, va_
 #define arg(x) va_arg(args, x)
 
     /* sanity check */
-    if (format == NULL)
+    if (format == nullptr)
 	return 0;
 
     while (*format)

--- a/kernel/kdb/generic/tid_format.cc
+++ b/kernel/kdb/generic/tid_format.cc
@@ -73,7 +73,7 @@ CMD(cmd_tid_format, cg)
 	do {
 	    printf ("    Add separator before <n> lower-most bits of thread number (0-%lu) [0]: ",
 		    L4_GLOBAL_THREADNO_BITS - 1);
-	    kdb_tid_format.X.sep = get_dec (NULL, 0, NULL);
+	    kdb_tid_format.X.sep = get_dec (nullptr, 0, nullptr);
 	} while (kdb_tid_format.X.sep >= L4_GLOBAL_THREADNO_BITS);
     } else
 	kdb_tid_format.X.value = TID_FORMAT_VALUE_TCB;

--- a/kernel/kdb/generic/tracebuffer.cc
+++ b/kernel/kdb/generic/tracebuffer.cc
@@ -146,12 +146,12 @@ private:
     
     bool id_pass(tracerecord_t *t)
 	{
-	    if (id[0] == NULL || ((word_t) id[0] == t->id))
+	    if (id[0] == nullptr || ((word_t) id[0] == t->id))
 		return true;
 	    
 	    for (word_t i=1; i < max_filters; i++)
 	    {
-		if (id[i] == NULL)
+		if (id[i] == nullptr)
 		    return false;
 		if ((word_t) id[i] == t->id)
 		    return true;
@@ -167,14 +167,14 @@ private:
 		? addr_to_tcb((addr_t) t->thread)
 		: tcb_t::get_tcb(threadid (t->thread));
 
-	    if (tcb[0] == NULL || (tcb[0] == rtcb))
+	    if (tcb[0] == nullptr || (tcb[0] == rtcb))
 		return true;
 	    
 	    for (word_t i=1; i < max_filters; i++)
 	    {
 		if (tcb[i] == rtcb)
 		    return true;
-		if (tcb[i] == NULL)
+		if (tcb[i] == nullptr)
 		    return false;
 	    }
 	    return false;
@@ -190,8 +190,8 @@ public:
 	{
 	    for (word_t i=0; i < max_filters; i++)
 	    {
-		id[i] = NULL;
-		tcb[i] = NULL;
+		id[i] = nullptr;
+		tcb[i] = nullptr;
 	    }
 	    cpumask = typemask = ~0UL;
 	    tsc = 0;
@@ -211,7 +211,7 @@ public:
 	    printf("\tTracepoints: \n");
 	    for (word_t i=0; i < max_filters; i++)
 	    {
-		if (id[i] == NULL)
+		if (id[i] == nullptr)
 		    break;
 		printf("\t\t%2d: %8d %s\n", i, id[i], tp_list.get(id[i]-1)->name);
 	    }    
@@ -219,7 +219,7 @@ public:
 	    printf("\tTCBs: \n");
 	    for (word_t i=0; i < max_filters; i++)
 	    {
-		if (tcb[i] == NULL)
+		if (tcb[i] == nullptr)
 		    break;
 		printf("\t\t%2d: %8t\n", i, (tcb_t *) tcb[i]);
 	    }    
@@ -888,7 +888,7 @@ DECLARE_CMD (cmd_tb_tcb, tracebuf, 'T', "tcbfilter", "TCB display filter");
 CMD(cmd_tb_tcb, cg) 
 {
     for (word_t i=0; i < tbuf_handler_t::max_filters; i++)
-	tbuf_handler.set_tcb(i, NULL);
+	tbuf_handler.set_tcb(i, nullptr);
     
     for (word_t i=0; i < tbuf_handler_t::max_filters; i++)
     {

--- a/kernel/kdb/generic/tracepoints.cc
+++ b/kernel/kdb/generic/tracepoints.cc
@@ -60,7 +60,7 @@ void init_tracepoints()
 {
     tracepoint_t * tp;
     word_t id = 1;
-    while ((tp = tp_list.next ()) != NULL)
+    while ((tp = tp_list.next ()) != nullptr)
 	tp->id = id++;
 }
 
@@ -116,7 +116,7 @@ CMD(cmd_tp_list, cg)
 #endif
 
     tp_list.reset ();
-    for (int i = 0; (tp = tp_list.next ()) != NULL; i++)
+    for (int i = 0; (tp = tp_list.next ()) != nullptr; i++)
     {
 	printf ("%3d   %28s  %c    %c ",
 		i+1, tp->name, tp->enabled ? 'y' : 'n',
@@ -208,7 +208,7 @@ CMD(cmd_tp_enable_all, cg)
     tracepoint_t * tp;
 
     tp_list.reset ();
-    while ((tp = tp_list.next ()) != NULL)
+    while ((tp = tp_list.next ()) != nullptr)
     {
 	tp->enabled = ~0UL;
 	tp->enter_kdb = 0;
@@ -230,7 +230,7 @@ CMD(cmd_tp_disable_all, cg)
     tracepoint_t * tp;
 
     tp_list.reset ();
-    while ((tp = tp_list.next ()) != NULL)
+    while ((tp = tp_list.next ()) != nullptr)
 	tp->enabled = tp->enter_kdb = 0;
 
     return CMD_NOQUIT;
@@ -247,7 +247,7 @@ CMD(cmd_tp_reset, cg)
     tracepoint_t * tp;
 
     tp_list.reset ();
-    while ((tp = tp_list.next ()) != NULL)
+    while ((tp = tp_list.next ()) != nullptr)
 	tp->reset_counter();
     
     return CMD_NOQUIT;

--- a/kernel/kdb/glue/v4-powerpc/prepost.cc
+++ b/kernel/kdb/glue/v4-powerpc/prepost.cc
@@ -75,7 +75,7 @@ bool kdb_t::pre()
 	    char *debug_msg;
 
 	    space_t *space = get_current_space();
-	    if( EXPECT_FALSE(space == NULL) )
+	    if( EXPECT_FALSE(space == nullptr) )
 		space = get_kernel_space();
 
 	    instr = space->get_from_user( (addr_t)(param->frame->srr0_ip + 4) );

--- a/kernel/kdb/glue/v4-x86/addrtranslation.cc
+++ b/kernel/kdb/glue/v4-x86/addrtranslation.cc
@@ -47,9 +47,9 @@ DECLARE_CMD( cmd_virt_to_phys, root, 'i', "virt_to_phys", "Translate virtual add
 CMD( cmd_virt_to_phys, cg )
 {
     threadid_t space_id;
-    space_id.set_raw( get_hex("Space:", 0, NULL ) );
-    addr_t vaddr = (addr_t)get_hex("Virtual Address", 0, NULL );
-    cpuid_t cpu = (cpuid_t)get_dec("CPU", 0, NULL );
+    space_id.set_raw( get_hex("Space:", 0, nullptr ) );
+    addr_t vaddr = (addr_t)get_hex("Virtual Address", 0, nullptr );
+    cpuid_t cpu = (cpuid_t)get_dec("CPU", 0, nullptr );
     
     space_t * space;
     if ( space_id.get_raw() == 0x0 )

--- a/kernel/kdb/glue/v4-x86/ipc.cc
+++ b/kernel/kdb/glue/v4-x86/ipc.cc
@@ -40,7 +40,7 @@ const char* ctrlxfer_item_idname[ctrlxfer_item_t::id_max] =
 const char* ctrlxfer_item_hwregname[ctrlxfer_item_t::id_max][16] = 
 {
     {  "eip", "efl", "edi", "esi", "ebp", "esp", "ebx", "edx", "ecx", "eax" },
-    {  NULL },
+    {  nullptr },
 #if defined(CONFIG_X_X86_HVM)
     { "cr0", "cr0_rd", "cr0_msk", "cr2", "cr3", "cr4", "cr4_rd", "cr4_msk"},
     { "dr0", "dr1", "dr2", "dr3", "dr6", "dr7", },

--- a/kernel/kdb/glue/v4-x86/prepost.cc
+++ b/kernel/kdb/glue/v4-x86/prepost.cc
@@ -251,7 +251,7 @@ bool kdb_t::pre()
 	    if (! readmem(space, addr_offset(addr, 2), &c) )
 		break;
 
-	    addr_t user_addr = NULL;
+	    addr_t user_addr = nullptr;
 	    bool mapped = false;
             
 	    if (c == 0xb8)

--- a/kernel/kdb/glue/v4-x86/readmem.cc
+++ b/kernel/kdb/glue/v4-x86/readmem.cc
@@ -34,7 +34,7 @@
 #include <linear_ptab.h>
 #include INC_API(tcb.h)
 
-space_t *current_disas_space = NULL;
+space_t *current_disas_space = nullptr;
  
 // callback for the disassembler to access user mem
 extern "C" int SECTION(".kdebug") kdb_disas_readmem(char * s, char * d)

--- a/kernel/kdb/platform/efi/memmap.cc
+++ b/kernel/kdb/platform/efi/memmap.cc
@@ -65,7 +65,7 @@ CMD(cmd_efi_memmap, cg)
     printf ("EFI memory map:\n");
 
     efi_memmap.reset ();
-    while ((desc = efi_memmap.next ()) != NULL)
+    while ((desc = efi_memmap.next ()) != nullptr)
     {
 	// Name
 	int n = 30 - printf ("  %s", maptypes[desc->type ()]);

--- a/kernel/kdb/platform/efi/reset.cc
+++ b/kernel/kdb/platform/efi/reset.cc
@@ -46,7 +46,7 @@ CMD(cmd_reset, cg)
     efi_runtime_services->reset_system
 	(efi_runtime_services_t::warm,
 	 efi_runtime_services_t::success,
-	 0, NULL);
+	 0, nullptr);
 #endif
 
     /* NOTREACHED */

--- a/kernel/kdb/platform/ofppc/io.cc
+++ b/kernel/kdb/platform/ofppc/io.cc
@@ -111,7 +111,7 @@ static char getc_of1275( bool block )
  ****************************************************************************/
 
 #if defined(CONFIG_KDB_CONS_PSIM_COM)
-static char *com_registers = NULL;
+static char *com_registers = nullptr;
 
 void init_psim_com_console( void )
 {
@@ -121,13 +121,13 @@ void init_psim_com_console( void )
     word_t len;
 
     dev = get_of1275_tree()->find( "/aliases" );
-    if( dev == NULL )
+    if( dev == nullptr )
 	return;
     if( !dev->get_prop("com", &alias, &len) )
 	return;
  
     dev = get_of1275_tree()->find( alias );
-    if( dev == NULL )
+    if( dev == nullptr )
 	return;
     if( !dev->get_prop("reg", (char **)&reg, &len) )
 	return;

--- a/kernel/kdb/platform/ofppc/of1275.cc
+++ b/kernel/kdb/platform/ofppc/of1275.cc
@@ -71,7 +71,7 @@ void of1275_client_interface_t::init( word_t entry )
 
 word_t of1275_client_interface_t::ci( void *params )
 {
-    if( this->entry == NULL )
+    if( this->entry == nullptr )
 	return (word_t)-1;
 
     return get_of1275_space()->execute_of1275( this->entry, params );
@@ -281,7 +281,7 @@ void of1275_client_interface_t::quiesce()
     this->ci( &this->args.simple );
 
     // Prevent any further invocations of Open Firmware.
-    this->entry = NULL;
+    this->entry = nullptr;
 
     this->ci_lock.unlock();
 }

--- a/kernel/kdb/platform/ofppc/ofppc.cc
+++ b/kernel/kdb/platform/ofppc/ofppc.cc
@@ -220,7 +220,7 @@ word_t of1275_space_t::execute_of1275( word_t (*func)(void *), void *param )
     // large stack with sufficient space for Open Firmware.  The boot stack
     // is mapped by a bat, and rather large.
     if( this->using_of1275_stack() )
-	sp = NULL;
+	sp = nullptr;
     else
     {
 	sp = (word_t *)(this->of1275_stack_top-16);

--- a/kernel/kdb/platform/pc99/io.cc
+++ b/kernel/kdb/platform/pc99/io.cc
@@ -86,7 +86,7 @@ kdb_console_t kdb_consoles[] = {
     { "serial", &init_serial, &putc_serial, &getc_serial },
 #endif 
 #if defined(CONFIG_KDB_CONS_KBD)
-    { "screen", NULL, &putc_screen, &getc_screen },
+    { "screen", nullptr, &putc_screen, &getc_screen },
 #endif 
     KDB_NULL_CONSOLE
 };
@@ -466,7 +466,7 @@ CMD (cmd_dump_iospace, cg)
 {
     space_t * space = get_space("Address space of IO space");
     vrt_t * iospace = space->get_io_space ();
-    if (iospace == NULL)
+    if (iospace == nullptr)
 	return CMD_NOQUIT;
 
     printf ("IO space %p (space %p):\n", iospace, space);

--- a/kernel/src/api/v4/generic-archfpage.h
+++ b/kernel/src/api/v4/generic-archfpage.h
@@ -74,12 +74,12 @@ public:
      * @return base address of the fpage
      * get_base does not size-align the address
      */
-    addr_t get_base() {  return NULL; }
+    addr_t get_base() {  return nullptr; }
 
     /**
      * @return size aligned address of the fpage
      */
-    addr_t get_address() {  return NULL; }
+    addr_t get_address() {  return nullptr; }
     
     /**
      * @return size of the flexpage

--- a/kernel/src/api/v4/interrupt.cc
+++ b/kernel/src/api/v4/interrupt.cc
@@ -151,7 +151,7 @@ void handle_interrupt(word_t irq)
      * other CPU */
     if ( !irq_tcb->is_local_cpu() )
     {
-	xcpu_request( irq_tcb->get_cpu(), do_xcpu_interrupt, NULL, irq );
+	xcpu_request( irq_tcb->get_cpu(), do_xcpu_interrupt, nullptr, irq );
 	return;
     }
 #endif

--- a/kernel/src/api/v4/ipc.cc
+++ b/kernel/src/api/v4/ipc.cc
@@ -274,7 +274,7 @@ SYS_IPC (threadid_t to_tid, threadid_t from_tid, timeout_t timeout)
 #ifdef SYS_IPC_PREAMBLE
     SYS_IPC_PREAMBLE
 #endif
-    tcb_t * to_tcb = NULL;
+    tcb_t * to_tcb = nullptr;
     tcb_t * from_tcb;
     tcb_t * current = get_current_tcb();
     scheduler_t * scheduler = get_current_scheduler();
@@ -496,7 +496,7 @@ send_path:
 	    to_tcb->unlock();
 	    // make sure we are running before potentially exiting to user
 	    current->set_state(thread_state_t::running);
-	    to_tcb = NULL;
+	    to_tcb = nullptr;
 	} else
 	    to_tcb->unlock();
 #endif
@@ -510,8 +510,8 @@ send_path:
 	/* this case is entered on:
 	 *   - send-only case
 	 *   - both descriptors set to nil id 
-	 * in the SMP case to_tcb is always NULL! */
-	if (to_tcb != NULL)
+	 * in the SMP case to_tcb is always nullptr! */
+	if (to_tcb != nullptr)
 	{
 	    ASSERT(to_tcb->is_local_cpu());
 
@@ -568,7 +568,7 @@ send_path:
 	{
 	    /* anylocal */
 	    tcb_t *head = current->send_head;
-	    from_tcb = NULL;
+	    from_tcb = nullptr;
 
 #if defined(CONFIG_SMP)
 	    TRACEF("from == anylocal requires SMP sanity check");
@@ -593,7 +593,7 @@ send_path:
 	 * no partner || partner is not polling || 
 	 * partner doesn't poll on me
 	 */
-	if( EXPECT_TRUE ( (from_tcb == NULL) || 
+	if( EXPECT_TRUE ( (from_tcb == nullptr) || 
 			  (!from_tcb->get_state().is_polling()) ||
 			  ( (from_tcb->get_partner() != current->get_global_id()) &&
 			    (from_tcb->get_partner() != current->myself_local) )) )
@@ -614,7 +614,7 @@ send_path:
 		    current->unlock();
 		    /* zero timeout and partner not ready --> 
 		     * we have to perform timeslice donation */
-		    if (to_tcb != NULL)
+		    if (to_tcb != nullptr)
 			scheduler->schedule(to_tcb, sched_rcverr);
 		    return_ipc(NILTHREAD);
 		}	
@@ -630,7 +630,7 @@ send_path:
 	    /* VU: should we convert to a global id here??? */
 	    current->set_partner(from_tid);
 
-	    if (EXPECT_FALSE(to_tcb == NULL)) 
+	    if (EXPECT_FALSE(to_tcb == nullptr)) 
 		to_tcb = get_idle_tcb();
 	    else
 		to_tcb->set_state(thread_state_t::running);
@@ -676,7 +676,7 @@ send_path:
 		 * from the wakeup queue to make sure the IPC does not 
 		 * timeout meanwhile... 
 		 */
-		if ( to_tcb != NULL)
+		if ( to_tcb != nullptr)
 		{
 		    to_tcb->set_state( thread_state_t::running );
 		    scheduler->schedule(from_tcb, to_tcb, sched_rplywt);

--- a/kernel/src/api/v4/kernelinterface.cc
+++ b/kernel/src/api/v4/kernelinterface.cc
@@ -163,7 +163,7 @@ procdesc_t processor_descriptors[CONFIG_SMP_MAX_CPUS] UNIT (KIP_SECTION ".pdesc"
 
 procdesc_t * processor_info_t::get_procdesc (word_t num)
 {
-    return num < CONFIG_SMP_MAX_CPUS ? &processor_descriptors[num] : NULL;
+    return num < CONFIG_SMP_MAX_CPUS ? &processor_descriptors[num] : nullptr;
 }
 
 /*
@@ -186,12 +186,12 @@ extern "C" {
  *
  * @param num	the descritor number to return
  *
- * @return pointer to memory descriptor, or NULL if NUM is out of range
+ * @return pointer to memory descriptor, or nullptr if NUM is out of range
  */
 memdesc_t * memory_info_t::get_memdesc (word_t num)
 {
     if (num >= n)
-	return NULL;
+	return nullptr;
     return &KIP_MEMDESCS[num];
 }
 

--- a/kernel/src/api/v4/queueing.h
+++ b/kernel/src/api/v4/queueing.h
@@ -34,7 +34,7 @@
 
 #define ENQUEUE_LIST_TAIL(head, tcb, list)	\
 do {						\
-    if (head == NULL)				\
+    if (head == nullptr)				\
     {						\
 	head = tcb;				\
 	tcb->list.next = tcb->list.prev = tcb;	\
@@ -50,7 +50,7 @@ do {						\
 
 #define ENQUEUE_LIST_HEAD(head, tcb, list)	\
 do {						\
-    if (head == NULL)				\
+    if (head == nullptr)				\
 	tcb->list.next = tcb->list.prev = tcb;	\
     else					\
     {						\
@@ -66,7 +66,7 @@ do {						\
 do {							\
     if (tcb->list.next == tcb)				\
     {							\
-	head = NULL;					\
+	head = nullptr;					\
     }							\
     else						\
     {							\
@@ -75,7 +75,7 @@ do {							\
 	(tcb->list.next)->list.prev = tcb->list.prev;	\
 	(tcb->list.prev)->list.next = tcb->list.next;	\
     }							\
-    tcb->list.next = tcb->list.prev = NULL;		\
+    tcb->list.next = tcb->list.prev = nullptr;		\
 } while(0)
     
 #endif /* !__API__V4__QUEUEING_H__ */

--- a/kernel/src/api/v4/sched-hs/schedule.cc
+++ b/kernel/src/api/v4/sched-hs/schedule.cc
@@ -47,8 +47,8 @@ prio_queue_t * prio_queue_t::add_prio_domain(schedule_ctrl_t prio_control)
     // Allocate dummy tcbs for the scheduling domain.
     whole_tcb_t *domain_tcbs = (whole_tcb_t *)kmem.alloc( kmem_sched, sizeof(whole_tcb_t) * num_cpus );
     
-    if( domain_tcbs == NULL )
-        return NULL;
+    if( domain_tcbs == nullptr )
+        return nullptr;
     
     // Initialize a dummy tcb for the domain, which serves as a schedulable entity.
     for( cpuid_t cpu = 0; cpu < num_cpus; cpu++ )
@@ -123,7 +123,7 @@ prio_queue_t *prio_queue_t::domain_partner( cpuid_t cpu )
     }
     return partner_queue;
 #endif
-    return NULL;
+    return nullptr;
     
 }
 
@@ -166,9 +166,9 @@ tcb_t * scheduler_t::find_next_thread(prio_queue_t * prio_queue)
     for (s16_t prio = MAX_PRIORITY; prio >= 0; prio--)
     {
 	// Proportional share stride scheduling search.
-	tcb_t *search_tcb = NULL;
+	tcb_t *search_tcb = nullptr;
 	tcb_t *tcb = prio_queue->get(prio);
-	tcb_t *return_tcb = NULL;
+	tcb_t *return_tcb = nullptr;
 	
 	while( tcb && !search_tcb )
 	{
@@ -188,14 +188,14 @@ tcb_t * scheduler_t::find_next_thread(prio_queue_t * prio_queue)
 		    tcb = tcb->sched_state.ready_list.next;
                     
 		    if( tcb == prio_queue->get(prio) )
-			tcb = NULL; // We wrapped around the list.
+			tcb = nullptr; // We wrapped around the list.
 		}
 		else 
 		{
 		    // Dequeue a blocked thread.
 		    tcb_t *next_tcb = tcb->sched_state.ready_list.next;
 		    prio_queue->dequeue(tcb);
-		    tcb = (tcb == next_tcb) ? NULL : next_tcb;
+		    tcb = (tcb == next_tcb) ? nullptr : next_tcb;
 		}
                 
 	    }
@@ -215,7 +215,7 @@ tcb_t * scheduler_t::find_next_thread(prio_queue_t * prio_queue)
 		    prio_queue->dequeue(search_tcb);
 
 		    // Prepare to restart the search at the current prio.
-		    search_tcb = NULL;
+		    search_tcb = nullptr;
 		    tcb = prio_queue->get(prio);
 		}
 		else
@@ -266,9 +266,9 @@ static void do_xcpu_domain_stride(cpu_mb_entry_t * entry)
 
 void hs_scheduler_t::policy_scheduler_init()
 {
-    wakeup_list = NULL;
-    scheduled_tcb = NULL;
-    scheduled_queue = NULL;
+    wakeup_list = nullptr;
+    scheduled_tcb = nullptr;
+    scheduled_queue = nullptr;
     cpuid_t cpu = get_current_cpu();
     
     root_prio_queue.init(get_on_cpu(cpu, get_idle_tcb()));
@@ -336,7 +336,7 @@ void hs_scheduler_t::hs_extended_schedule(schedule_req_t *req)
             ASSERT(queue->get_domain_tcb());
             cpuid_t cpu = queue->get_domain_tcb()->get_cpu();
             if( cpu != get_current_cpu() )
-                xcpu_request( cpu, do_xcpu_domain_reset_period, NULL, (word_t) queue );
+                xcpu_request( cpu, do_xcpu_domain_reset_period, nullptr, (word_t) queue );
             queue = queue->cpu_link;
         } while( queue != queue->cpu_head );
 #endif /* defined(CONFIG_SMP)*/
@@ -509,7 +509,7 @@ void hs_scheduler_t::smp_requeue(bool holdlock)
     if (!rq->is_empty() || holdlock)
     {
         rq->lock.lock();
-        tcb_t *tcb = NULL;
+        tcb_t *tcb = nullptr;
 
         while (!rq->is_empty()) 
         {
@@ -519,7 +519,7 @@ void hs_scheduler_t::smp_requeue(bool holdlock)
             if (tcb->sched_state.requeue_callback) 
             {
                 tcb->sched_state.requeue_callback(tcb);
-                tcb->sched_state.requeue_callback = NULL;
+                tcb->sched_state.requeue_callback = nullptr;
             }
             else
             {
@@ -605,7 +605,7 @@ void scheduler_t::move_tcb(tcb_t *tcb, cpuid_t cpu)
 
 
     smp_requeue(true);
-    ASSERT(tcb->sched_state.requeue == NULL);
+    ASSERT(tcb->sched_state.requeue == nullptr);
 
     if (tcb->get_space())
         tcb->get_space()->move_tcb(tcb, get_current_cpu(), cpu);

--- a/kernel/src/api/v4/sched-hs/schedule.h
+++ b/kernel/src/api/v4/sched-hs/schedule.h
@@ -173,7 +173,7 @@ public:
         {
    
             for( int i = 0; i < MAX_PRIORITY; i++ )
-                prio_queue[i] = NULL;
+                prio_queue[i] = nullptr;
             
             global_pass = 0;
             max_prio = -1;
@@ -182,7 +182,7 @@ public:
             depth = 0;
 	    count = 0;
 	    
-            ON_CONFIG_SMP(cpu_link = cpu_head = NULL);
+            ON_CONFIG_SMP(cpu_link = cpu_head = nullptr);
             reset_period_cycles(get_cpu_cycles());
         }
 
@@ -223,7 +223,7 @@ public:
     spinlock_t lock;
     char cache_pad1[CACHE_LINE_SIZE - sizeof(spinlock_t)];
 	
-    volatile bool is_empty() { return (tcb_list == NULL); }
+    volatile bool is_empty() { return (tcb_list == nullptr); }
 	
     void enqueue_head(tcb_t *tcb)
 	{
@@ -244,7 +244,7 @@ public:
  
 	    tcb_t * tcb = tcb_list;
 	    tcb_list = tcb->sched_state.requeue;
-	    tcb->sched_state.requeue = NULL;
+	    tcb->sched_state.requeue = nullptr;
 		
 	    TRACE_SCHEDULE_DETAILS("smp_requeue:dequeue_head %t (s=%s) cpu %d (head %t)", 
                                    tcb, tcb->get_state().string(), tcb->get_cpu(), tcb_list);

--- a/kernel/src/api/v4/sched-hs/schedule_functions.h
+++ b/kernel/src/api/v4/sched-hs/schedule_functions.h
@@ -53,11 +53,11 @@ INLINE void hs_sched_ktcb_t::set_prio_queue( prio_queue_t *q )
             prio_queue_t *queue = old->cpu_head;
 #if defined(CONFIG_SMP)
             do {
-                queue->get_domain_tcb()->sched_state.prio_queue = NULL;
+                queue->get_domain_tcb()->sched_state.prio_queue = nullptr;
                 queue = queue->cpu_link;
             } while( queue != old->cpu_head );
 #else
-            queue->get_domain_tcb()->sched_state.prio_queue = NULL;
+            queue->get_domain_tcb()->sched_state.prio_queue = nullptr;
 #endif
             kmem.free(kmem_sched, (addr_t)old->cpu_head->get_domain_tcb(),
                       sizeof(whole_tcb_t) * cpu_t::count);
@@ -164,7 +164,7 @@ INLINE void sched_ktcb_t::init(sktcb_type_e type)
     set_stride(DEFAULT_STRIDE);
     
 #if defined(CONFIG_SMP)
-    requeue = NULL;
+    requeue = nullptr;
 #endif
 #if defined(CONFIG_X_EVT_LOGGING)
     /* set domain */
@@ -439,7 +439,7 @@ INLINE word_t scheduler_t::check_schedule_parameters(tcb_t *scheduler, schedule_
             /* Target and domain must be different. */
 
             if( domain_tcb->get_global_id() != req.time_control.tid ||
-                domain_tcb->sched_state.get_prio_queue() == NULL)
+                domain_tcb->sched_state.get_prio_queue() == nullptr)
                 return EINVALID_THREAD;
 
             prio_queue_t *domain_queue = domain_tcb->sched_state.get_prio_queue();

--- a/kernel/src/api/v4/sched-rr/schedule.cc
+++ b/kernel/src/api/v4/sched-rr/schedule.cc
@@ -244,7 +244,7 @@ void rr_scheduler_t::end_of_timeslice (tcb_t * tcb)
     tsched_state->renew_timeslice(tsched_state->get_timeslice_length());
 
     /* clear the accounted TCB */
-    prio_queue->set_timeslice_tcb(NULL);
+    prio_queue->set_timeslice_tcb(nullptr);
 }
 
 #if defined(CONFIG_SMP)
@@ -257,7 +257,7 @@ void rr_scheduler_t::smp_requeue(bool holdlock)
     if (!rq->is_empty() || holdlock)
     {
 	rq->lock.lock();
-	tcb_t *tcb = NULL;
+	tcb_t *tcb = nullptr;
 
 	while (!rq->is_empty()) 
 	{
@@ -267,7 +267,7 @@ void rr_scheduler_t::smp_requeue(bool holdlock)
 	    if (tcb->sched_state.requeue_callback) 
 	    {
 		tcb->sched_state.requeue_callback(tcb);
-		tcb->sched_state.requeue_callback = NULL;
+		tcb->sched_state.requeue_callback = nullptr;
 	    }
             else
             {
@@ -352,7 +352,7 @@ void scheduler_t::move_tcb(tcb_t *tcb, cpuid_t cpu)
 
 
     smp_requeue(true);
-    ASSERT(tcb->sched_state.requeue == NULL);
+    ASSERT(tcb->sched_state.requeue == nullptr);
 
     if (tcb->get_space())
 	tcb->get_space()->move_tcb(tcb, get_current_cpu(), cpu);

--- a/kernel/src/api/v4/sched-rr/schedule.h
+++ b/kernel/src/api/v4/sched-rr/schedule.h
@@ -64,7 +64,7 @@ public:
 	{
 	    /* prio queues */
 	    for(int i = 0; i <= MAX_PRIORITY; i++)
-		prio_queue[i] = (tcb_t *)NULL;
+		prio_queue[i] = (tcb_t *)nullptr;
 	    max_prio = -1;
 	}
 
@@ -93,7 +93,7 @@ public:
     spinlock_t lock;
     char cache_pad1[CACHE_LINE_SIZE - sizeof(spinlock_t)];
 	
-    volatile bool is_empty() { return (tcb_list == NULL); }
+    volatile bool is_empty() { return (tcb_list == nullptr); }
 	
     void enqueue_head(tcb_t *tcb)
 	{
@@ -114,7 +114,7 @@ public:
  
 	    tcb_t * tcb = tcb_list;
 	    tcb_list = tcb->sched_state.requeue;
-	    tcb->sched_state.requeue = NULL;
+	    tcb->sched_state.requeue = nullptr;
 		
 	    TRACE_SCHEDULE_DETAILS("smp_requeue:dequeue_head %t (s=%s) cpu %d (head %t)", 
 	    	    tcb, tcb->get_state().string(), tcb->get_cpu(), tcb_list);
@@ -201,7 +201,7 @@ protected:
     void policy_scheduler_init()
 	{
 	    /* wakeup list */
-	    wakeup_list = NULL;
+	    wakeup_list = nullptr;
             root_prio_queue.init();
 
 	}

--- a/kernel/src/api/v4/sched-rr/schedule_functions.h
+++ b/kernel/src/api/v4/sched-rr/schedule_functions.h
@@ -62,7 +62,7 @@ INLINE void sched_ktcb_t::init(sktcb_type_e type)
     set_sensitive_prio(priority);
     set_maximum_delay (0);
 #if defined(CONFIG_SMP)
-    requeue = NULL;
+    requeue = nullptr;
 #endif
 }
 

--- a/kernel/src/api/v4/schedule.cc
+++ b/kernel/src/api/v4/schedule.cc
@@ -217,7 +217,7 @@ word_t scheduler_t::add_schedule_request(schedule_req_t &req)
     
     cpuid_t cpu = get_current_cpu();
     cpuid_t reqcpu = req.tcb->get_cpu();
-    schedule_req_t *qreq = NULL;
+    schedule_req_t *qreq = nullptr;
 
 
     if (req.tcb->flags.is_set(tcb_t::schedule_in_progress))

--- a/kernel/src/api/v4/schedule.h
+++ b/kernel/src/api/v4/schedule.h
@@ -102,7 +102,7 @@ public:
 	    if ( ((first_free + 1) % schedule_queue_len) == first_alloc )
 	    {
 		lock.unlock();
-		return NULL;
+		return nullptr;
 	    }
 	    word_t idx = first_free;
 	    first_free = (first_free + 1) % schedule_queue_len;
@@ -308,7 +308,7 @@ private:
      * 
      * @return next thread to be scheduled
      */
-    tcb_t * find_next_thread(policy_sched_next_thread_t *p=NULL);
+    tcb_t * find_next_thread(policy_sched_next_thread_t *p=nullptr);
     
     
     /**

--- a/kernel/src/api/v4/smp.cc
+++ b/kernel/src/api/v4/smp.cc
@@ -131,7 +131,7 @@ void cpu_mb_t::walk_mailbox()
     {
 	lock.lock();
 	cpu_mb_entry_t entry = entries[first_alloc];
-	entries[first_alloc].handler = NULL;
+	entries[first_alloc].handler = nullptr;
 	first_alloc = (first_alloc + 1) % MAX_MAILBOX_ENTRIES;
 	lock.unlock();
 	ASSERT(entry.handler);
@@ -148,7 +148,7 @@ void cpu_mb_t::dump_mailbox(word_t cpu)
     for (word_t e=0; e < MAX_MAILBOX_ENTRIES; e++)
     {
         cpu_mb_entry_t entry = entries[e];
-	if (entry.handler != NULL)
+	if (entry.handler != nullptr)
             printf("\tXCPU-entry %d\n\t\thandler:%t,"
 		   "tcb %t\n\t\tparams %x:%x:%x:%x:%x:%x:%x:%x\n",
                    cpu, e, entry.handler, entry.tcb,

--- a/kernel/src/api/v4/smp.h
+++ b/kernel/src/api/v4/smp.h
@@ -48,7 +48,7 @@ template<typename T> INLINE T *get_on_cpu(cpuid_t cpu, T *item)
         return (T *) addr_offset(phys_to_virt((addr_t)pgent->address(kspace, pgsize)),
                                  addr_mask(item, page_mask (pgsize)));
     else 
-        return NULL;
+        return nullptr;
     
 #else
     return item;
@@ -132,7 +132,7 @@ public:
 	    if ( ((first_free + 1) % MAX_MAILBOX_ENTRIES) == first_alloc )
 	    {
 		lock.unlock();
-		return NULL;
+		return nullptr;
 	    }
 	    unsigned idx = first_free;
 	    first_free = (first_free + 1) % MAX_MAILBOX_ENTRIES;
@@ -186,7 +186,7 @@ INLINE cpu_mb_t * get_cpu_mailbox (cpuid_t dst)
 }
 
 INLINE void xcpu_request(cpuid_t dstcpu, xcpu_handler_t handler, 
-			 tcb_t * tcb = NULL, 
+			 tcb_t * tcb = nullptr, 
 			 word_t param0 = 0, word_t param1 = 0, 
 			 word_t param2 = 0 )
 {
@@ -263,7 +263,7 @@ public:
 };
 
 void sync_xcpu_request(cpuid_t dstcpu, xcpu_handler_t handler,
-		       tcb_t * tcb = NULL, word_t param0 = 0, 
+		       tcb_t * tcb = nullptr, word_t param0 = 0, 
 		       word_t param1 = 0, word_t param2 = 0);
 
 #endif /* CONFIG_SMP_SYNC_REQUEST */

--- a/kernel/src/api/v4/tcb.h
+++ b/kernel/src/api/v4/tcb.h
@@ -101,9 +101,9 @@ public:
     bool migrate_to_processor(cpuid_t processor);
     
     bool exists() 
-	{ return space != NULL; }
+	{ return space != nullptr; }
     bool is_activated()
-	{ return utcb != NULL; }
+	{ return utcb != nullptr; }
 
     void unwind (unwind_reason_e reason);
     

--- a/kernel/src/api/v4/thread.cc
+++ b/kernel/src/api/v4/thread.cc
@@ -171,8 +171,8 @@ void tcb_t::init(threadid_t dest, sktcb_type_e type)
     ASSERT(this);
     
     /* clear utcb and space */
-    utcb = NULL;
-    space = NULL;
+    utcb = nullptr;
+    space = nullptr;
 
     tcb_lock.init();
 
@@ -191,7 +191,7 @@ void tcb_t::init(threadid_t dest, sktcb_type_e type)
 
     /* queue initialization */
     queue_state.init();
-    send_head = NULL;
+    send_head = nullptr;
 
 #if defined(CONFIG_SMP)
     /* initially assign to this CPU */
@@ -396,7 +396,7 @@ delete_tcb_retry:
 	resources.free(this);
 	
 	// free UTCB
-	this->utcb = NULL;
+	this->utcb = nullptr;
 
 	// make sure that we don't get accounted anymore
 	if (sched->get_accounted_tcb() == this)
@@ -410,7 +410,7 @@ delete_tcb_retry:
     this->myself_global = NILTHREAD;
     this->myself_local = ANYLOCALTHREAD;
 
-    this->set_space(NULL);
+    this->set_space(nullptr);
     this->set_state(thread_state_t::aborted);
     dequeue_present();
 }

--- a/kernel/src/arch/powerpc/pghash.h
+++ b/kernel/src/arch/powerpc/pghash.h
@@ -290,7 +290,7 @@ INLINE ppc_translation_t * ppc_htab_t::locate_pte( word_t virt, word_t vsid,
     word_t api = ppc_translation_t::virt_to_api( virt );
     if( (pte->x.v == 1) && (pte->x.vsid == vsid) && (pte->x.api == api) )
 	return pte;
-    return NULL;
+    return nullptr;
 }
 
 #endif	/* !ASSEMBLY */

--- a/kernel/src/arch/powerpc/softhvm.cc
+++ b/kernel/src/arch/powerpc/softhvm.cc
@@ -139,18 +139,18 @@ word_t *ppc_softhvm_t::get_spr(int spr, bool read)
     case 0x1a: return &this->srr0;
     case 0x1b: return &this->srr1;
     case 0x30: return &this->pid;
-    case 0x36: return read ? NULL : &this->decar;
+    case 0x36: return read ? nullptr : &this->decar;
     case 0x3a: return &this->csrr0;
     case 0x3b: return &this->csrr1;
     case 0x3d: return &this->dear;
     case 0x3e: return &this->esr;
     case 0x3f: return &this->ivpr;
     case 0x110 ... 0x117: return &this->sprg[spr - 0x110];
-    case 0x11c: return read ? NULL : &this->tbl;
-    case 0x11d: return read ? NULL : &this->tbu;
-    case 0x11e: return read ? &this->pir : NULL;
-    case 0x11f: return read ? &this->pvr : NULL;
-    case 0x130: return read ? &this->dbsr : NULL;
+    case 0x11c: return read ? nullptr : &this->tbl;
+    case 0x11d: return read ? nullptr : &this->tbu;
+    case 0x11e: return read ? &this->pir : nullptr;
+    case 0x11f: return read ? &this->pvr : nullptr;
+    case 0x130: return read ? &this->dbsr : nullptr;
     case 0x134 ... 0x136: return &this->dbcr[spr - 0x134];
     case 0x138 ... 0x13b: return &this->iac[spr - 0x138];
     case 0x13c ... 0x13d: return &this->dac[spr - 0x13c];
@@ -168,14 +168,14 @@ word_t *ppc_softhvm_t::get_spr(int spr, bool read)
     case 0x394 ... 0x397: return &this->dtv[spr - 0x394];
     case 0x398: return &this->dvlim;
     case 0x399: return &this->ivlim;
-    case 0x39b: return read ? &this->rstcfg : NULL;
-    case 0x39c ... 0x39d: return read ? &this->dcdbt[spr - 0x39c] : NULL;
-    case 0x39e ... 0x39f: return read ? &this->icdbt[spr - 0x39c] : NULL;
+    case 0x39b: return read ? &this->rstcfg : nullptr;
+    case 0x39c ... 0x39d: return read ? &this->dcdbt[spr - 0x39c] : nullptr;
+    case 0x39e ... 0x39f: return read ? &this->icdbt[spr - 0x39c] : nullptr;
     case 0x3b2: return &this->mmucr.raw;
     case 0x3b3: return &this->ccr0;
     case 0x3d3: return &this->icdbdr;
     case 0x3f3: return &this->dbdr;
-    default: return NULL;
+    default: return nullptr;
     }
 }
 

--- a/kernel/src/arch/powerpc/string.cc
+++ b/kernel/src/arch/powerpc/string.cc
@@ -181,6 +181,6 @@ char *strchr( char *s, char c)
 	    return s;
 	s++;
     }
-    return NULL;
+    return nullptr;
 }
 

--- a/kernel/src/arch/powerpc64/1275tree.cc
+++ b/kernel/src/arch/powerpc64/1275tree.cc
@@ -100,7 +100,7 @@ of1275_device_t * of1275_tree_t::find( const char *name )
 {
     of1275_device_t *dev = this->first();
     if( !dev )
-	return NULL;
+	return nullptr;
 
     while( dev->is_valid() )
     {
@@ -109,14 +109,14 @@ of1275_device_t * of1275_tree_t::find( const char *name )
 	dev = dev->next();
     }
 
-    return NULL;
+    return nullptr;
 }
 
 of1275_device_t * of1275_tree_t::find_handle( word_t handle )
 {
     of1275_device_t *dev = this->first();
     if( !dev )
-	return NULL;
+	return nullptr;
 
     while( dev->is_valid() )
     {
@@ -125,28 +125,28 @@ of1275_device_t * of1275_tree_t::find_handle( word_t handle )
 	dev = dev->next();
     }
 
-    return NULL;
+    return nullptr;
 }
 
 of1275_device_t * of1275_tree_t::get_parent( of1275_device_t *dev )
 {
-    char *slash = NULL;
+    char *slash = nullptr;
     int cnt, depth;
 
     if( !dev || !this->first() )
-	return NULL;
+	return nullptr;
 
     // Do we have any parents?
     depth = dev->get_depth();
     if( depth <= 1 )
-	return NULL;
+	return nullptr;
 
     // Locate the last slash in the name.
     for( char *c = dev->get_name(); *c; c++ )
 	if( *c == '/' )
 	    slash = c;
-    if( slash == NULL )
-	return NULL;
+    if( slash == nullptr )
+	return nullptr;
 
     // Count the offset of the last slash.
     cnt = 0;
@@ -163,7 +163,7 @@ of1275_device_t * of1275_tree_t::get_parent( of1275_device_t *dev )
 	parent = parent->next();
     }
 
-    return NULL;
+    return nullptr;
 }
 
 of1275_device_t * of1275_tree_t::find_device_type( const char *device_type )
@@ -174,7 +174,7 @@ of1275_device_t * of1275_tree_t::find_device_type( const char *device_type )
 
     dev = this->first();
     if( !dev )
-	return NULL;
+	return nullptr;
 
     while( dev->is_valid() )
     {
@@ -184,7 +184,7 @@ of1275_device_t * of1275_tree_t::find_device_type( const char *device_type )
 	dev = dev->next();
     }
 
-    return NULL;
+    return nullptr;
 }
 
 of1275_device_t *of1275_device_t::next_by_type( const char *device_type )
@@ -194,7 +194,7 @@ of1275_device_t *of1275_device_t::next_by_type( const char *device_type )
     char *type;
 
     if( !dev )
-	return NULL;
+	return nullptr;
 
     while( dev->is_valid() )
     {
@@ -203,5 +203,5 @@ of1275_device_t *of1275_device_t::next_by_type( const char *device_type )
 		return dev;
 	dev = dev->next();
     }
-    return NULL;
+    return nullptr;
 }

--- a/kernel/src/arch/powerpc64/pghash.h
+++ b/kernel/src/arch/powerpc64/pghash.h
@@ -374,7 +374,7 @@ INLINE ppc64_pte_t* ppc64_htab_t::locate_pte( word_t virt, word_t vsid,
     if( (pte->x.v == 1) && (pte->x.vsid == vsid) && (pte->x.api == api) )
 	return pte;
 
-    return NULL;
+    return nullptr;
 }
 
 #endif	/* !ASSEMBLY */

--- a/kernel/src/arch/powerpc64/rtas.cc
+++ b/kernel/src/arch/powerpc64/rtas.cc
@@ -190,7 +190,7 @@ word_t rtas_t::rtas_call( u32_t token, u32_t nargs, u32_t nret, word_t *outputs,
 
     this->lock.unlock();
 
-    if (nret > 1 && outputs != NULL)
+    if (nret > 1 && outputs != nullptr)
         for (word_t i = 0; i < nret-1; ++i)
 	    outputs[i] = rtas_args.get_ret(i+1);
 
@@ -222,7 +222,7 @@ void rtas_t::machine_restart( void )
     u32_t reboot_token;
 
     get_token( "system-reboot", &reboot_token );
-    rtas_call( reboot_token, 0, 1, NULL );
+    rtas_call( reboot_token, 0, 1, nullptr );
 
     /* We should never get here */
     asm volatile (".long 0x00000000;");
@@ -233,7 +233,7 @@ void rtas_t::machine_power_off( void )
     u32_t poweroff_token;
 
     get_token( "power-off", &poweroff_token );
-    rtas_call( poweroff_token, 0, 1, NULL );
+    rtas_call( poweroff_token, 0, 1, nullptr );
 
     /* We should never get here */
     asm volatile (".long 0x00000000;");
@@ -244,7 +244,7 @@ void rtas_t::machine_halt( void )
     u32_t poweroff_token;
 
     get_token( "power-off", &poweroff_token );
-    rtas_call( poweroff_token, 0, 1, NULL );
+    rtas_call( poweroff_token, 0, 1, nullptr );
 
     /* We should never get here */
     asm volatile (".long 0x00000000;");

--- a/kernel/src/arch/powerpc64/vsid_asid.h
+++ b/kernel/src/arch/powerpc64/vsid_asid.h
@@ -90,7 +90,7 @@ INLINE void vsid_asid_cache_t::init( space_t *kernel_space )
     for ( word_t i = 0; i < ( ASID_MAX ); i++ )
     {
 	cache[i].asid = ASID_INVALID;
-	cache[i].space = NULL;
+	cache[i].space = nullptr;
     }
     cache[0].asid = 0;
     cache[0].space = kernel_space;

--- a/kernel/src/arch/x86/vmx.h
+++ b/kernel/src/arch/x86/vmx.h
@@ -1255,7 +1255,7 @@ INLINE bool vmcs_t::load ()
     if (EXPECT_TRUE (is_loaded()))
 	return true;
 
-    current_vmcs = NULL;
+    current_vmcs = nullptr;
     
     ASSERT (this != 0);
     ASSERT (((word_t) this & ~X86_PAGE_MASK) == 0);
@@ -1273,7 +1273,7 @@ INLINE bool vmcs_t::unload ()
 {
     if (is_loaded ())
     {
-	current_vmcs = NULL;
+	current_vmcs = nullptr;
 	return (x86_vmsucceed (x86_vmclear ((word_t) this)));
     }
     else

--- a/kernel/src/arch/x86/x32/vmx.cc
+++ b/kernel/src/arch/x86/x32/vmx.cc
@@ -95,13 +95,13 @@ vmcs_t *vmcs_t::alloc_vmcs ()
 {
     // Kernel Memory Allocator gives WB memory.
     if (get_vmcs_access_mode() != wb)
-	return NULL;
+	return nullptr;
 
     // Allocate VMCS Region, must be aligned to page boundary
     word_t sz = X86_PAGE_SIZE;
     addr_t vmcs = kmem.alloc(kmem_vmcs, sz);
     if (!vmcs)
-	return NULL;
+	return nullptr;
 
     // Set Revision.
     u32_t *ptr = (u32_t *) vmcs;

--- a/kernel/src/generic/acpi.cc
+++ b/kernel/src/generic/acpi.cc
@@ -45,7 +45,7 @@ acpi_madt_hdr_t* acpi_madt_t::find(u8_t type, int index)
 	}
 	i += h->len;
     };
-    return NULL;
+    return nullptr;
 }
 
 acpi_madt_lapic_t* acpi_madt_t::lapic(int index)

--- a/kernel/src/generic/acpi.h
+++ b/kernel/src/generic/acpi.h
@@ -253,7 +253,7 @@ template<typename T> class acpi__sdt_t {
 public:
     /* find table with a given signature */
     acpi_thead_t* find(const char sig[4], addr_t myself_phys) {
-	acpi_thead_t *head = NULL;
+	acpi_thead_t *head = nullptr;
 	for (word_t i = 0; i < ((header.len-sizeof(header))/sizeof(ptrs[0])) && !head; i++)
 	{
 	    acpi_thead_t* t= (acpi_thead_t*)(acpi_remap((addr_t)(word_t)ptrs[i]));
@@ -296,7 +296,7 @@ class acpi_rsdp_t {
     u8_t	_rsvd_33[3];
 private:
 public:
-    static acpi_rsdp_t* locate(addr_t addr = NULL);
+    static acpi_rsdp_t* locate(addr_t addr = nullptr);
 
     acpi_rsdt_t* rsdt() {
 	/* verify checksum */
@@ -304,20 +304,20 @@ public:
 	for (int i = 0; i < 20; i++)
 	    csum += ((char*)this)[i];
 	if (csum != 0)
-	    return NULL;
+	    return nullptr;
 	return (acpi_rsdt_t*) (word_t)rsdt_ptr;
     };
     acpi_xsdt_t* xsdt() {
 	/* check version - only ACPI 2.0 knows about an XSDT */
 	if (rev != 2)
-	    return NULL;
+	    return nullptr;
 	/* verify checksum
 	   hopefully it's wrong if there's no xsdt pointer*/
 	u8_t csum = 0;
 	for (int i = 0; i < 36; i++)
 	    csum += ((char*)this)[i];
 	if (csum != 0)
-	    return NULL;
+	    return nullptr;
 	return (acpi_xsdt_t*) (word_t)xsdt_ptr;
     };
 

--- a/kernel/src/generic/asid.h
+++ b/kernel/src/generic/asid.h
@@ -83,11 +83,11 @@ public:
 
     void init(word_t start, word_t end)
 	{
-	    free_list = NULL;
+	    free_list = nullptr;
 	    timestamp = 0;
 
 	    for (word_t asid = 0; asid <= SIZE; asid++)
-		asid_user[asid] = NULL;
+		asid_user[asid] = nullptr;
 
 	    for (word_t asid = start; asid <= end; asid++)
 		free_asid(asid);

--- a/kernel/src/generic/linear_ptab_walker.cc
+++ b/kernel/src/generic/linear_ptab_walker.cc
@@ -103,7 +103,7 @@ void space_t::map_fpage (fpage_t snd_fp, word_t base,
     word_t offset, f_num, t_num, f_off;
     pgent_t *fpg, *tpg;
     pgent_t::pgsize_e f_size, t_size, pgsize;
-    mapnode_t *newmap, *map = NULL;
+    mapnode_t *newmap, *map = nullptr;
     addr_t f_addr, t_addr;
    
     pgent_t * r_fpg[pgent_t::size_max];
@@ -744,10 +744,10 @@ void space_t::map_fpage (fpage_t snd_fp, word_t base,
     Next_sender_entry:
 
 #if defined(CONFIG_NEW_MDB)
-	if (grant && map != NULL)
+	if (grant && map != nullptr)
 	{
 	    mdb_mem.flush (map);
-	    map = NULL;
+	    map = nullptr;
 	}
 #endif
 	f_addr = addr_offset (f_addr, page_size (f_size));

--- a/kernel/src/generic/mapping.cc
+++ b/kernel/src/generic/mapping.cc
@@ -63,11 +63,11 @@ void SECTION (".init") init_mdb (void)
     mdb_lock.lock();
 
     // Frame table for the complete address space.
-    dual = mdb_create_dual (NULL, mdb_create_roots (mapnode_t::size_max));
+    dual = mdb_create_dual (nullptr, mdb_create_roots (mapnode_t::size_max));
 
     // Let sigma0 own the whole address space.
     sigma0_mapnode = &__sigma0_mapnode;
-    sigma0_mapnode->set_backlink ((mapnode_t *) NULL, (pgent_t *) NULL);
+    sigma0_mapnode->set_backlink ((mapnode_t *) nullptr, (pgent_t *) nullptr);
     sigma0_mapnode->set_space ((space_t *) 0);
     sigma0_mapnode->set_depth (0);
     sigma0_mapnode->set_next (dual);
@@ -250,7 +250,7 @@ mapnode_t * mdb_map (mapnode_t * f_map, pgent_t * f_pg,
 	return newmap;
     }
 
-    root = NULL;
+    root = nullptr;
 
     while (f_pgsize > t_pgsize)
     {
@@ -362,7 +362,7 @@ word_t mdb_flush (mapnode_t * f_map, pgent_t * f_pg,
 					     Bit 0 cleared indicates root. */
     rcnt = 0;
     startdepth = f_map->get_depth ();
-    root = NULL;
+    root = nullptr;
 
     if (unmap_self)
     {
@@ -381,7 +381,7 @@ word_t mdb_flush (mapnode_t * f_map, pgent_t * f_pg,
 	f_map->set_rwx (0);
 	f_pg->reset_reference_bits (space, f_hwpgsize);
 
-	parent_pg = NULL;
+	parent_pg = nullptr;
     }
     else
     {
@@ -418,11 +418,11 @@ word_t mdb_flush (mapnode_t * f_map, pgent_t * f_pg,
 	//
 	//   f_map - the current mapping node
 	//   f_pg  - the current pgent node
-	//   pmap  - the previous mapping node (or NULL if prev is root)
-	//   proot - the previous root node (or NULL if prev is map)
-	//   nmap  - the next mapping node (may be NULL)
-	//   dual  - next dual node (or NULL if no such node)
-	//   root  - Current root array pointer (or NULL)
+	//   pmap  - the previous mapping node (or nullptr if prev is root)
+	//   proot - the previous root node (or nullptr if prev is map)
+	//   nmap  - the next mapping node (may be nullptr)
+	//   dual  - next dual node (or nullptr if no such node)
+	//   root  - Current root array pointer (or nullptr)
 
 //	printf("New: f_map=%p  dual=%p  nmap=%p  pmap=%p  proot=%p  "
 //	       "fsize=%d   tsize=%d  root=%p\n",
@@ -455,7 +455,7 @@ word_t mdb_flush (mapnode_t * f_map, pgent_t * f_pg,
 		f_pg->reset_reference_bits (space, f_hwpgsize);
 		f_pg->flush (space, f_hwpgsize, false, vaddr);
 		pmap = f_map;
-		proot = NULL;
+		proot = nullptr;
 	    }
 
 	    // We might have to flush some TLB entries
@@ -467,9 +467,9 @@ word_t mdb_flush (mapnode_t * f_map, pgent_t * f_pg,
 	{
 	    f_pg->reset_reference_bits (space, f_hwpgsize);
 	    pmap = f_map;
-	    proot = NULL;
+	    proot = nullptr;
 	}
-	f_map = NULL;
+	f_map = nullptr;
 
 	// Variables `f_map' and `f_pg' are no longer valid here
 
@@ -529,7 +529,7 @@ word_t mdb_flush (mapnode_t * f_map, pgent_t * f_pg,
 		rcnt  = r_rcnt[f_pgsize];
 		if (r_prev[f_pgsize] & 1)
 		{
-		    proot = NULL;
+		    proot = nullptr;
 		    pmap = (mapnode_t *) (r_prev[f_pgsize] & ~1UL);
 		    if (f_map)
 			f_pg = f_map->get_pgent (pmap);
@@ -537,7 +537,7 @@ word_t mdb_flush (mapnode_t * f_map, pgent_t * f_pg,
 		else
 		{
 		    proot = (rootnode_t *) r_prev[f_pgsize];
-		    pmap = NULL;
+		    pmap = nullptr;
 		    if (f_map)
 			f_pg = f_map->get_pgent (proot);
 		}
@@ -573,7 +573,7 @@ word_t mdb_flush (mapnode_t * f_map, pgent_t * f_pg,
 		r_root[f_pgsize] = root;
 		r_rcnt[f_pgsize] = rcnt;
 
-		f_map = NULL;
+		f_map = nullptr;
 		root = nroot - 1;
 		rcnt = mdb_arraysize (f_pgsize);
 
@@ -585,7 +585,7 @@ word_t mdb_flush (mapnode_t * f_map, pgent_t * f_pg,
 		if (f_map)
 		{
 		    f_pg = f_map->get_pgent (root);
-		    pmap = NULL;
+		    pmap = nullptr;
 		    proot = root;
 		}
 	    }
@@ -626,7 +626,7 @@ static NOINLINE rootnode_t * mdb_create_roots (mapnode_t::pgsize_e size)
     newnodes = (rootnode_t *) mdb_alloc_buffer (sizeof (rootnode_t) * num);
 
     for (n = newnodes; num--; n++)
-	n->set_ptr ((mapnode_t *) NULL);
+	n->set_ptr ((mapnode_t *) nullptr);
 
     return newnodes;
 }

--- a/kernel/src/generic/mapping.h
+++ b/kernel/src/generic/mapping.h
@@ -138,7 +138,7 @@ public:
     mapnode_t * get_prevmap (pgent_t * pg)
 	{
 	    if (x.is_prev_root)
-		return (mapnode_t *) NULL;
+		return (mapnode_t *) nullptr;
 	    else
 		return (mapnode_t *) ((x.prev_ptr << 1) ^ (word_t) pg);
 	}
@@ -146,7 +146,7 @@ public:
     rootnode_t * get_prevroot (pgent_t * pg)
 	{
 	    if (! x.is_prev_root)
-		return (rootnode_t *) NULL;
+		return (rootnode_t *) nullptr;
 	    else
 		return (rootnode_t *) ((x.prev_ptr << 1) ^ (word_t) pg);
 	}
@@ -174,7 +174,7 @@ public:
     mapnode_t * get_nextmap (void)
 	{
 	    if (! x.is_next_map)
-		return (mapnode_t *) NULL;
+		return (mapnode_t *) nullptr;
 	    else if (x.is_next_root)
 		return (mapnode_t *) ((dualnode_t *) (x.next_ptr << 2))->map;
 	    else
@@ -184,7 +184,7 @@ public:
     rootnode_t * get_nextroot (void)
 	{
 	    if (! x.is_next_root)
-		return (rootnode_t *) NULL;
+		return (rootnode_t *) nullptr;
 	    else if (x.is_next_map)
 		return (rootnode_t *) ((dualnode_t *) (x.next_ptr << 2))->root;
 	    else
@@ -196,7 +196,7 @@ public:
 	    if (x.is_next_root && x.is_next_map)
 		return (dualnode_t *) (x.next_ptr << 2);
 	    else
-		return (dualnode_t *) NULL;
+		return (dualnode_t *) nullptr;
 	}
 
     void set_next (mapnode_t * map)
@@ -298,7 +298,7 @@ public:
     mapnode_t * get_map (void)
 	{
 	    if (! x.is_next_map)
-		return (mapnode_t *) NULL;
+		return (mapnode_t *) nullptr;
 	    else if (x.is_next_root)
 		return (mapnode_t *) ((dualnode_t *) (x.next_ptr << 2))->map;
 	    else
@@ -308,7 +308,7 @@ public:
     rootnode_t * get_root (void)
 	{
 	    if (! x.is_next_root)
-		return (rootnode_t *) NULL;
+		return (rootnode_t *) nullptr;
 	    else if (x.is_next_map)
 		return (rootnode_t *) ((dualnode_t *) (x.next_ptr << 2))->root;
 	    else
@@ -320,7 +320,7 @@ public:
 	    if (x.is_next_root && x.is_next_map)
 		return (dualnode_t *) (x.next_ptr << 2);
 	    else
-		return (dualnode_t *) NULL;
+		return (dualnode_t *) nullptr;
 	}
 
     void set_ptr (mapnode_t * map)

--- a/kernel/src/generic/mapping_alloc.cc
+++ b/kernel/src/generic/mapping_alloc.cc
@@ -65,15 +65,15 @@ DECLARE_KMEM_GROUP (kmem_mdb);
 #ifdef MDB_DEBUG
 #define ASSERT_BL(_bl_)							\
 {									\
-    mdb_mng_t *p = NULL, *m = (mdb_mng_t *) (_bl_)->list_of_lists;	\
+    mdb_mng_t *p = nullptr, *m = (mdb_mng_t *) (_bl_)->list_of_lists;	\
     mdb_link_t *l;							\
     int cnt;								\
 									\
     if (m) {								\
-	ASSERT (m->prev_freelist == NULL);				\
+	ASSERT (m->prev_freelist == nullptr);				\
 	do {								\
 	    ASSERT (m->prev_freelist == p);				\
-	    ASSERT (m->freelist != NULL);				\
+	    ASSERT (m->freelist != nullptr);				\
 	    ASSERT (m->num_free > 0);					\
 	    ASSERT (m->bl == (_bl_));					\
 	    for (cnt = 0, l = m->freelist; l; cnt++)			\
@@ -91,7 +91,7 @@ DECLARE_KMEM_GROUP (kmem_mdb);
 
 /*
  * We have AT MOST one entry for every MDB page size, one for
- * mapnode_t, one for dualnode_t. and one for the NULL entry.
+ * mapnode_t, one for dualnode_t. and one for the nullptr entry.
  */
 mdb_buflist_t mdb_buflists[MDB_NUM_PGSIZES + 3];
 
@@ -152,7 +152,7 @@ MDB_INIT_FUNCTION (2, mdb_buflist_init)
      */
     for (bl = mdb_buflists; bl->size; bl++)
     {
-	bl->list_of_lists = NULL;
+	bl->list_of_lists = nullptr;
 	if (bl->size >= KMEM_CHUNKSIZE)
 	    continue;
 	for (bl->max_free = 0, i = MDB_ALLOC_CHUNKSZ - bl->size;
@@ -187,7 +187,7 @@ void SECTION (".init") mdb_buflist_init (void)
      */
     for (bl = mdb_buflists; bl->size; bl++)
     {
-	bl->list_of_lists = NULL;
+	bl->list_of_lists = nullptr;
 	if (bl->size >= KMEM_CHUNKSIZE)
 	    continue;
 	for (bl->max_free = 0, i = MDB_ALLOC_CHUNKSZ - bl->size;
@@ -243,7 +243,7 @@ addr_t mdb_alloc_buffer (word_t size)
      * Get pool of available buffers.
      */
     mng = bl->list_of_lists;
-    if (mng == NULL)
+    if (mng == nullptr)
     {
 	mdb_link_t *b, *n, *p, *ed;
 
@@ -256,7 +256,7 @@ addr_t mdb_alloc_buffer (word_t size)
 	mng->freelist		= (mdb_link_t *)
 	    ((word_t) mng + MDB_ALLOC_CHUNKSZ - bl->max_free*size);
 	mng->num_free		= bl->max_free;
-	mng->prev_freelist	= (mdb_mng_t *) NULL;
+	mng->prev_freelist	= (mdb_mng_t *) nullptr;
 	mng->bl			= bl;
 
 	/*
@@ -269,7 +269,7 @@ addr_t mdb_alloc_buffer (word_t size)
 	    b->next = n;
 	}
 	p = (mdb_link_t *) ((word_t) b - size);
-	p->next = (mdb_link_t *) NULL;
+	p->next = (mdb_link_t *) nullptr;
 
 	disable_interrupts ();
 
@@ -300,8 +300,8 @@ addr_t mdb_alloc_buffer (word_t size)
 	 * list_of_lists.
 	 */
 	bl->list_of_lists = mng->next_freelist;
-	if (bl->list_of_lists != NULL)
-	    bl->list_of_lists->prev_freelist = (mdb_mng_t *) NULL;
+	if (bl->list_of_lists != nullptr)
+	    bl->list_of_lists->prev_freelist = (mdb_mng_t *) nullptr;
     }
 
     ASSERT_BL (bl);
@@ -361,7 +361,7 @@ void mdb_free_buffer (addr_t addr, word_t size)
 	if (bl->list_of_lists) 
 	    bl->list_of_lists->prev_freelist = mng;
 	mng->next_freelist = bl->list_of_lists;
-	mng->prev_freelist = (mdb_mng_t *) NULL;
+	mng->prev_freelist = (mdb_mng_t *) nullptr;
 	bl->list_of_lists = mng;
 
     }

--- a/kernel/src/generic/mdb.cc
+++ b/kernel/src/generic/mdb.cc
@@ -91,12 +91,12 @@ void * mdb_node_t::operator new (size_t size)
  */
 void mdb_t::delete_node (mdb_node_t * node)
 {
-    if (node == NULL)
+    if (node == nullptr)
 	return;
 
     mdb_node_t * p = node->get_prev ();
 
-    ASSERT (node->get_next () == NULL ||
+    ASSERT (node->get_next () == nullptr ||
 	    node->get_next ()->get_depth () <= node->get_depth ());
 
     if (p->get_next () == node)
@@ -146,7 +146,7 @@ void * mdb_table_t::operator new (size_t size, word_t radix_log2)
 {
     mdb_table_t * t = (mdb_table_t *) mdb_alloc_buffer (sizeof (mdb_table_t));
 
-    t->node = NULL;
+    t->node = nullptr;
     t->radix = radix_log2;
     t->count = 0;
     t->entries = (word_t) mdb_alloc_buffer (sizeof (mdb_tableent_t) * 
@@ -167,7 +167,7 @@ void * mdb_table_t::operator new (size_t size, word_t radix_log2)
  */
 void mdb_table_t::operator delete (void * t)
 {
-    if (t == NULL)
+    if (t == nullptr)
 	return;
 
     mdb_table_t * table = (mdb_table_t *) t;
@@ -238,11 +238,11 @@ mdb_node_t * mdb_t::map (mdb_node_t * f_node,
     // existing table.
 
     mdb_table_t * table = f_node->get_table ();
-    mdb_table_t * prev_table = NULL;
+    mdb_table_t * prev_table = nullptr;
 
     for (;;)
     {
-	if (table != NULL && table->match_prefix (addr))
+	if (table != nullptr && table->match_prefix (addr))
 	{
 	    if (table->get_objsize () == objsize)
 	    {
@@ -274,7 +274,7 @@ mdb_node_t * mdb_t::map (mdb_node_t * f_node,
 	    {
 		// The new table should contain the current mapping
 		// table within one of the table entries.  This will
-		// be taken care of below (table != NULL).
+		// be taken care of below (table != nullptr).
 	    }
 
 	    // Create a new mapping table just below mapping node or
@@ -288,14 +288,14 @@ mdb_node_t * mdb_t::map (mdb_node_t * f_node,
 	    newtable->set_prefix (addr);
 	    newtable->set_objsize (objsize);
 	    newtable->set_node (addr, newnode);
-	    newnode->set_next (NULL);
+	    newnode->set_next (nullptr);
 
 	    if (prev_table)
 		prev_table->set_table (addr, newtable);
 	    else
 		f_node->set_table (newtable);
 
-	    if (table != NULL)
+	    if (table != nullptr)
 	    {
 		// There already existed a table which did path
 		// compression and containing objects of smaller sizes
@@ -325,12 +325,12 @@ mdb_node_t * mdb_t::map (mdb_node_t * f_node,
 	newtable->set_prefix (addr);
 	newtable->set_objsize (objsize);
 	newtable->set_node (addr, newnode);
-	newnode->set_next (NULL);
+	newnode->set_next (nullptr);
 
-	if (table != NULL)
+	if (table != nullptr)
 	{
 	    auxnode = table->get_node ();
-	    table->set_node (NULL);
+	    table->set_node (nullptr);
 
 	    // Remove old table now to avoid propagating auxiliary
 	    // mapping node upwards during the set_table operations
@@ -535,7 +535,7 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
     } r_values[MAX_MDB_RECURSION];
     word_t recurse_level = 0;
 
-    mdb_table_t * table = NULL;
+    mdb_table_t * table = nullptr;
     word_t tableidx = 0;
     bool do_modify = false;
 
@@ -650,7 +650,7 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 	{
 	    // We need to recurse into a subtable.  Record the current
 	    // table and table entry we are working on.  Initially,
-	    // these will be NULL-entries.  Continue recursion if
+	    // these will be nullptr-entries.  Continue recursion if
 	    // selected entry in new table is another subtable.
 
 	    mdb_table_t * nexttab = node->get_table ();
@@ -694,7 +694,7 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 
 	// --- PART 3 ---
 
-	if (node == NULL)
+	if (node == nullptr)
 	{
 	    // We have reached the end of a subtree, or alternatively,
 	    // chosen an emptry subtree from a mapping table.
@@ -737,24 +737,24 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 
 		ASSERT (recurse_level > 0);
 
-		if (prev->get_table () != NULL)
+		if (prev->get_table () != nullptr)
 		    break;
 
 		do {
 		    node = prev;
 		    prev = prev->get_prev ();
 		    delete_node (node);
-		} while (prev->get_table () == NULL);
+		} while (prev->get_table () == nullptr);
 
 		table->remove_node (table->get_addr (tableidx));
-		node = NULL;
+		node = nullptr;
 
 		// Table may fall empty due to delete operation.  If
 		// so, delete it and recurse up to the parent table.
 		// Continue deleting tables if they also happen to
 		// fall empty.
 
-		while (table != NULL && table->get_count () == 0)
+		while (table != nullptr && table->get_count () == 0)
 		{
 		    mdb_table_t * t = table;
 
@@ -783,7 +783,7 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 		    delete t;
 		}
 
-		if (table == NULL) ASSERT (recurse_level == 0);
+		if (table == nullptr) ASSERT (recurse_level == 0);
 		else ASSERT (recurse_level > 0);
 
 		if (prev->get_table ())
@@ -795,10 +795,10 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 		    // we don't continue with the regular mapping node
 		    // before processing the table.
 
-		    ASSERT (table != NULL);
+		    ASSERT (table != nullptr);
 		    ASSERT (table->get_count () > 0);
 		    ASSERT (prev->get_table ()->get_count () > 0);
-		    node = NULL;
+		    node = nullptr;
 		    break;
 		}
 		else
@@ -807,7 +807,7 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 		    // indicates that all the subtrees beneath the
 		    // mapping table have been deleted.
 
-		    if (prev->get_next () != NULL)
+		    if (prev->get_next () != nullptr)
 		    {
 			// Continue performing mapcontrol on next node.
 			node = prev->get_next ();
@@ -816,7 +816,7 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 		    else if (recurse_level == 0)
 		    {
 			// Exit from main loop.
-			ASSERT (table == NULL);
+			ASSERT (table == nullptr);
 			break;
 		    }
 		    else
@@ -827,7 +827,7 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 
 	    // --- PART 3b ---
 
-	    if (ctrl.reset_status && prev->get_table () == NULL)
+	    if (ctrl.reset_status && prev->get_table () == nullptr)
 	    {
 		// Reset the reference status bits and propagate the
 		// old bit contents upwards to the parent of the table
@@ -857,7 +857,7 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 		} while (p->get_next () == node);
 
 		p->update_effective_status (this, status);
-		node = NULL;
+		node = nullptr;
 	    }
 
 	    // --- PART 3c ---
@@ -871,7 +871,7 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 	    // mapping table entries for valid nodes or recurse into
 	    // subtables if they exist.
 
-	    while (node == NULL && table != NULL)
+	    while (node == nullptr && table != nullptr)
 	    {
 		if (tableidx < (1UL << table->get_radix ()) - 1)
 		{
@@ -932,11 +932,11 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 	    // means that we are finished parsing the whole subtree.
 	    // Exit the main loop.
 
-	    if (node == NULL)
+	    if (node == nullptr)
 	    {
 		ASSERT (recurse_level == 0);
 		if (ctrl.unmap)
-		    ASSERT (prev->get_next () == NULL);
+		    ASSERT (prev->get_next () == nullptr);
 		break;
 	    }
 	}

--- a/kernel/src/generic/mdb.h
+++ b/kernel/src/generic/mdb.h
@@ -452,19 +452,19 @@ INLINE mdb_node_t * mdb_node_t::get_prev (void)
 
 /**
  * Retrieve pointer to mapping table.
- * @return pointer to mapping table, or NULL if no table exists
+ * @return pointer to mapping table, or nullptr if no table exists
  */
 INLINE mdb_table_t * mdb_node_t::get_table (void)
 {
     if (! next_is_table)
-	return NULL;
+	return nullptr;
 
     return (mdb_table_t *) (next << 1);
 }
 
 /**
  * Retrieve pointer to next mapping node.
- * @return pointer to next mappings node, or NULL if no next node exists
+ * @return pointer to next mappings node, or nullptr if no next node exists
  */
 INLINE mdb_node_t * mdb_node_t::get_next (void)
 {
@@ -558,7 +558,7 @@ INLINE void mdb_node_t::set_table (mdb_table_t * t)
 {
     t->set_node (get_next ());
     if (next_is_table)
-	get_table ()->set_node (NULL);
+	get_table ()->set_node (nullptr);
     next = ((word_t) t) >> 1;
     next_is_table = 1;
 }
@@ -657,19 +657,19 @@ INLINE bool mdb_tableent_t::is_table (void)
 
 /**
  * Retrieve pointer to mapping table.
- * @return pointer to mapping table, or NULL if no table exists
+ * @return pointer to mapping table, or nullptr if no table exists
  */
 INLINE mdb_table_t * mdb_tableent_t::get_table (void)
 {
     if (! ptr_is_table)
-	return NULL;
+	return nullptr;
 
     return (mdb_table_t *) (ptr << 1);
 }
 
 /**
  * Retrieve pointer to mapping node.
- * @return pointer to next mappings node, or NULL if no next node exists
+ * @return pointer to next mappings node, or nullptr if no next node exists
  */
 INLINE mdb_node_t * mdb_tableent_t::get_node (void)
 {
@@ -688,7 +688,7 @@ INLINE void mdb_tableent_t::set_table (mdb_table_t * t)
 {
     t->set_node (get_node ());
     if (ptr_is_table)
-	get_table ()->set_node (NULL);
+	get_table ()->set_node (nullptr);
     ptr = ((word_t) t) >> 1;
     ptr_is_table = 1;
 }
@@ -735,7 +735,7 @@ INLINE bool mdb_table_t::match_prefix (word_t addr)
 
 /**
  * Retrieve auxiliary mapping node pointer.
- * @return pointer to mapping node, or NULL if no node exists
+ * @return pointer to mapping node, or nullptr if no node exists
  */
 INLINE mdb_node_t * mdb_table_t::get_node (void)
 {
@@ -756,7 +756,7 @@ INLINE mdb_tableent_t * mdb_table_t::get_entry (word_t addr)
 /**
  * Retrieve mapping node from within mapping table.
  * @param addr		address to use for indexing
- * @return pointer to mapping node, or NULL if no node exists
+ * @return pointer to mapping node, or nullptr if no node exists
  */
 INLINE mdb_node_t * mdb_table_t::get_node (word_t addr)
 {
@@ -766,7 +766,7 @@ INLINE mdb_node_t * mdb_table_t::get_node (word_t addr)
 /**
  * Retrieve sub-table from within mapping table.
  * @param addr		address to use for indexing
- * @return pointer to mapping table, or NULL if no table exists
+ * @return pointer to mapping table, or nullptr if no table exists
  */
 INLINE mdb_table_t * mdb_table_t::get_table (word_t addr)
 {
@@ -818,7 +818,7 @@ INLINE void mdb_table_t::remove_node (word_t addr)
     mdb_tableent_t * e = get_entry (addr);
     if (e->is_valid () && ! e->is_table ())
 	count--;
-    e->set_node (NULL);
+    e->set_node (nullptr);
 }
 
 /**
@@ -832,7 +832,7 @@ INLINE void mdb_table_t::remove_table (word_t addr)
 	return;
 
     mdb_node_t * n = e->get_node ();
-    if (n == NULL)
+    if (n == nullptr)
 	count--;
     e->ptr_is_table = 0;
     e->ptr = ((word_t) n) >> 1;
@@ -854,7 +854,7 @@ INLINE void mdb_table_t::set_node (mdb_node_t * n)
  */
 INLINE void mdb_table_t::set_node (word_t addr, mdb_node_t * n)
 {
-    if (n == NULL)
+    if (n == nullptr)
 	remove_node (addr);
     else
     {
@@ -872,7 +872,7 @@ INLINE void mdb_table_t::set_node (word_t addr, mdb_node_t * n)
  */
 INLINE void mdb_table_t::set_table (word_t addr, mdb_table_t * t)
 {
-    if (t == NULL)
+    if (t == nullptr)
 	remove_table (addr);
     else
     {

--- a/kernel/src/generic/mdb_mem.cc
+++ b/kernel/src/generic/mdb_mem.cc
@@ -81,7 +81,7 @@ MDB_INIT_FUNCTION (3, init_mdb_mem)
     ASSERT (sigma0_memnode);
 
     sigma0_memnode->set_prev (sigma0_memnode);
-    sigma0_memnode->set_next (NULL);
+    sigma0_memnode->set_next (nullptr);
     sigma0_memnode->set_depth (0);
     sigma0_memnode->set_inrights (~0UL);
     sigma0_memnode->set_outrights (~0UL);

--- a/kernel/src/generic/vrt.cc
+++ b/kernel/src/generic/vrt.cc
@@ -84,7 +84,7 @@ void * vrt_table_t::operator new (size_t size, word_t radix_log2)
  */
 void vrt_table_t::operator delete (void * t)
 {
-    if (t == NULL)
+    if (t == nullptr)
 	return;
 
     vrt_table_t * table = (vrt_table_t *) t;

--- a/kernel/src/generic/vrt.h
+++ b/kernel/src/generic/vrt.h
@@ -231,7 +231,7 @@ INLINE word_t vrt_node_t::get_object (void)
 
 /**
  * Retrieve table pointer stored in node.
- * @return table pointer, or NULL if there is no table
+ * @return table pointer, or nullptr if there is no table
  */
 INLINE vrt_table_t * vrt_node_t::get_table (void)
 {
@@ -334,7 +334,7 @@ INLINE mdb_node_t * vrt_table_t::get_mapnode (word_t addr)
 /**
  * Retrieve sub-table from within mapping table.
  * @param addr		address to use for indexing
- * @return pointer to mapping table, or NULL if no table exists
+ * @return pointer to mapping table, or nullptr if no table exists
  */
 INLINE vrt_table_t * vrt_table_t::get_table (word_t addr)
 {
@@ -410,7 +410,7 @@ INLINE void vrt_table_t::set_object (vrt_t * vrt, word_t addr, word_t paddr,
 				     vrt_node_t * obj, word_t obj_size,
 				     word_t access)
 {
-    if (obj == NULL)
+    if (obj == nullptr)
 	clear (addr);
     else
     {
@@ -438,7 +438,7 @@ INLINE void vrt_table_t::set_mapnode (word_t addr, mdb_node_t * map)
  */
 INLINE void vrt_table_t::set_table (word_t addr, vrt_table_t * t)
 {
-    if (t == NULL)
+    if (t == nullptr)
 	clear (addr);
     else
     {

--- a/kernel/src/glue/v4-powerpc/except_handlers.cc
+++ b/kernel/src/glue/v4-powerpc/except_handlers.cc
@@ -124,7 +124,7 @@ tcb_t *get_kdebug_tcb() { return (tcb_t*)~0; }
 
 INLINE void try_to_debug( except_regs_t *regs, word_t exc_no, word_t dar=0, word_t dsisr=0 )
 {
-    if( EXPECT_TRUE(get_kip()->kdebug_entry == NULL) )
+    if( EXPECT_TRUE(get_kip()->kdebug_entry == nullptr) )
 	return;
 
     debug_param_t param;
@@ -251,7 +251,7 @@ EXCDEF( program_handler )
 	       "EXC Program Handler: IP=%p\n", srr0);
 
     space_t *space = get_current_space();
-    if( EXPECT_FALSE(space == NULL) )
+    if( EXPECT_FALSE(space == nullptr) )
 	space = get_kernel_space();
 
     word_t instr = space->get_from_user( (addr_t)srr0 );

--- a/kernel/src/glue/v4-powerpc/init.cc
+++ b/kernel/src/glue/v4-powerpc/init.cc
@@ -104,7 +104,7 @@ SECTION(SEC_INIT) void timer_init( word_t cpu_hz, word_t bus_hz, word_t cpu )
  *                            Platform init
  *
  *****************************************************************************/
-static dtree_t *dtree = NULL;
+static dtree_t *dtree = nullptr;
 static word_t dtree_size = 0;
 
 dtree_t *get_dtree()
@@ -424,7 +424,7 @@ static SECTION(SEC_INIT) void cpu_init( cpuid_t cpu )
     if( powerpc_version_t::read().is_750() )
 	ppc750_configure();
     perfmon_init();
-    set_fp_lazy_tcb( NULL );
+    set_fp_lazy_tcb( nullptr );
 }
 
 #if defined(CONFIG_SMP)

--- a/kernel/src/glue/v4-powerpc/ipc.cc
+++ b/kernel/src/glue/v4-powerpc/ipc.cc
@@ -116,15 +116,15 @@ static const word_t hwreg_shadow_tlb[] = {
 #endif
 
 const word_t* const ctrlxfer_item_t::hwregs[] = {
-    frame_gprs0, frame_gprs1, frame_gprx, NULL, 
+    frame_gprs0, frame_gprs1, frame_gprx, nullptr, 
 #ifdef CONFIG_X_PPC_SOFTHVM
     hwreg_mmu, hwreg_except, hwreg_ivor, 
     hwreg_timer, hwreg_config, hwreg_debug,
     hwreg_icache, hwreg_dcache, hwreg_shadow_tlb,
-    NULL, NULL, NULL, NULL, // TLBs (probably not required)
-    NULL, NULL, NULL, NULL, 
-    NULL, NULL, NULL, NULL, 
-    NULL, NULL, NULL, NULL, 
+    nullptr, nullptr, nullptr, nullptr, // TLBs (probably not required)
+    nullptr, nullptr, nullptr, nullptr, 
+    nullptr, nullptr, nullptr, nullptr, 
+    nullptr, nullptr, nullptr, nullptr, 
 #endif
 };
 

--- a/kernel/src/glue/v4-powerpc/resources.cc
+++ b/kernel/src/glue/v4-powerpc/resources.cc
@@ -35,13 +35,13 @@
 #include INC_GLUE(memcfg.h)
 #include INC_ARCH(ppc44x.h)
 
-// TODO: ensure that this is initialized to NULL for each cpu, perhaps via 
+// TODO: ensure that this is initialized to nullptr for each cpu, perhaps via 
 // ctors.
 tcb_t *_fp_lazy_tcb UNIT("cpulocal");
 
 INLINE void thread_resources_t::deactivate_fpu( tcb_t *tcb )
 {
-    set_fp_lazy_tcb( NULL );
+    set_fp_lazy_tcb( nullptr );
     // Disable fpu access for the tcb.
     except_regs_t *regs = get_user_except_regs(tcb);
     regs->srr1_flags = MSR_CLR( regs->srr1_flags, MSR_FP );

--- a/kernel/src/glue/v4-powerpc/softhvm.cc
+++ b/kernel/src/glue/v4-powerpc/softhvm.cc
@@ -60,7 +60,7 @@ DECLARE_TRACEPOINT(PPC_HVM_EMUL_INTERPRET);
 
 INLINE void try_to_debug( except_regs_t *regs, word_t exc_no, word_t dar=0, word_t dsisr=0 )
 {
-    if( EXPECT_TRUE(get_kip()->kdebug_entry == NULL) )
+    if( EXPECT_TRUE(get_kip()->kdebug_entry == nullptr) )
 	return;
 
     debug_param_t param;
@@ -337,7 +337,7 @@ EXCDEF( hvm_dtlb_miss_handler )
         return_except();
     }
     
-    ppc_softhvm_t::tlb_t *tlbentry = NULL;
+    ppc_softhvm_t::tlb_t *tlbentry = nullptr;
     int tlbidx = -1;
 
     if (vm->in_shadow_tlb(dear))
@@ -390,7 +390,7 @@ EXCDEF( hvm_itlb_miss_handler )
 
     ASSERT(!ppc_is_kernel_mode(srr1));
 
-    ppc_softhvm_t::tlb_t *tlbentry = NULL;
+    ppc_softhvm_t::tlb_t *tlbentry = nullptr;
     int tlbidx = -1;
 
     if (vm->in_shadow_tlb(srr0))

--- a/kernel/src/glue/v4-powerpc/space-pghash.cc
+++ b/kernel/src/glue/v4-powerpc/space-pghash.cc
@@ -168,7 +168,7 @@ EXCDEF( isi_handler )
     try_to_debug( frame, EXCEPT_ID(ISI) );
 
     space_t *space = get_current_tcb()->get_space();
-    if( EXPECT_FALSE(space == NULL) )
+    if( EXPECT_FALSE(space == nullptr) )
 	space = get_kernel_space();
 
     if( EXCEPT_IS_ISI_MISS(srr1) ) 
@@ -193,7 +193,7 @@ EXCDEF( dsi_handler )
 
     tcb_t *tcb = get_current_tcb();
     space_t *space = tcb->get_space();
-    if( EXPECT_FALSE(space == NULL) )
+    if( EXPECT_FALSE(space == nullptr) )
 	space = get_kernel_space();
 
     // Do we have a page hash miss?

--- a/kernel/src/glue/v4-powerpc/space-swtlb.cc
+++ b/kernel/src/glue/v4-powerpc/space-swtlb.cc
@@ -266,7 +266,7 @@ addr_t space_t::map_device_pinned(paddr_t paddr, word_t size, bool kernel, word_
 	    break;
 
     if (log2sz >= 32)
-	return NULL;
+	return nullptr;
 
     size = 1 << log2sz;
 

--- a/kernel/src/glue/v4-powerpc/space.cc
+++ b/kernel/src/glue/v4-powerpc/space.cc
@@ -55,7 +55,7 @@ EXTERN_KMEM_GROUP(kmem_space);
 #define TRACE_SPACE(x...)
 //#define TRACE_SPACE(x...)	TRACEF(x)
 
-space_t *kernel_space = NULL;
+space_t *kernel_space = nullptr;
 
 //translation table
 struct transtable_t transtable[TRANSLATION_TABLE_ENTRIES];
@@ -154,7 +154,7 @@ pgent_t * space_t::page_lookup( addr_t vaddr )
 {
     pgent_t *pgent = this->pgent( page_table_index(pgent_t::size_4m, vaddr) );
     if( !pgent->is_valid(this, pgent_t::size_4m) )
-	return NULL;
+	return nullptr;
 
     pgent = pgent->subtree( this, pgent_t::size_4m );
     pgent = pgent->next( this, pgent_t::size_4k, 
@@ -225,7 +225,7 @@ addr_t space_t::map_device( paddr_t paddr, word_t size, bool kernel, word_t attr
 	    // Increment the address to the next page.
 	    start_addr = addr_offset( start_addr, POWERPC_PAGE_SIZE );
 	    if( ((word_t)start_addr + size) > DEVICE_AREA_END )
-		return NULL;
+		return nullptr;
 
 	    // Move to the next page table entry.
 	    pgent = pgent->next( this, pgent_t::size_4k, 1 );
@@ -280,10 +280,10 @@ utcb_t *space_t::allocate_utcb( tcb_t *tcb )
     {
 	// Allocate a new UTCB page.
 	page = kmem.alloc( kmem_utcb, POWERPC_PAGE_SIZE );
-	if( page == NULL )
+	if( page == nullptr )
 	{
 	    WARNING( "out of memory!\n" );
-	    return NULL;
+	    return nullptr;
 	}
 	add_mapping( utcb, (paddr_t)virt_to_phys(page), pgent_t::size_4k, true, false );
     }

--- a/kernel/src/glue/v4-powerpc/space.h
+++ b/kernel/src/glue/v4-powerpc/space.h
@@ -169,7 +169,7 @@ public:
     void allocate_asid();
     void allocate_hw_asid(word_t hw_asid) {}
     void release_hw_asid(word_t hw_asid)
-	{ flush_tlb(NULL); }
+	{ flush_tlb(nullptr); }
     static asid_manager_t<space_t,CONFIG_MAX_NUM_ASIDS> *get_asid_manager();
 #endif
 
@@ -321,7 +321,7 @@ INLINE asid_manager_t<space_t, CONFIG_MAX_NUM_ASIDS> *get_asid_manager()
 INLINE asid_t *space_t::get_asid(cpuid_t cpu)
 {
 #if defined(CONFIG_X_PPC_SOFTHVM)
-    return hvm_mode ? NULL : &this->cpu[cpu].asid;
+    return hvm_mode ? nullptr : &this->cpu[cpu].asid;
 #else
     return &this->cpu[cpu].asid;
 #endif

--- a/kernel/src/glue/v4-powerpc/tcb.h
+++ b/kernel/src/glue/v4-powerpc/tcb.h
@@ -99,13 +99,13 @@ INLINE except_regs_t *get_user_except_regs( tcb_t *tcb )
 
 INLINE void tcb_t::set_utcb_location( word_t utcb_location )
 {
-    utcb_t *dummy = (utcb_t *)NULL;
+    utcb_t *dummy = (utcb_t *)nullptr;
     myself_local.set_raw( utcb_location + (word_t)dummy->mr );
 }
 
 INLINE word_t tcb_t::get_utcb_location()
 {
-    utcb_t *dummy = (utcb_t *)NULL;
+    utcb_t *dummy = (utcb_t *)nullptr;
     return myself_local.get_raw() - (word_t)dummy->mr;
 }
 

--- a/kernel/src/glue/v4-powerpc64/exception.cc
+++ b/kernel/src/glue/v4-powerpc64/exception.cc
@@ -185,7 +185,7 @@ extern "C" void ppc64_except_unhandled( word_t vect, powerpc64_irq_context_t *co
     {
 	printf( "\n-- KD# %s exception --\n", vector );
 
-	if( EXPECT_FALSE(get_kip()->kdebug_entry != NULL) )
+	if( EXPECT_FALSE(get_kip()->kdebug_entry != nullptr) )
 	    get_kip()->kdebug_entry(context);
 
 	halt_user_thread();
@@ -244,7 +244,7 @@ extern "C" void dsi_handler( word_t dar, word_t dsisr, powerpc64_irq_context_t *
     // Use kernel space if we have kernel fault in TCB area or
     // when no space is set (e.g., running on the idle thread)
     if ( EXPECT_FALSE( is_kernel && space->is_tcb_area ((addr_t)dar) )
-			    || space == NULL)
+			    || space == nullptr)
     {
         space = get_kernel_space();
 	//TRACEF( "kernel space\n" );
@@ -289,7 +289,7 @@ extern "C" void dsi_handler( word_t dar, word_t dsisr, powerpc64_irq_context_t *
 	if ( !send_exception_ipc( 0x300, dsisr, true, dar) )
 	{
 	    printf( "\n-- KD# data address exception --\n" );
-	    if( EXPECT_FALSE(get_kip()->kdebug_entry != NULL) )
+	    if( EXPECT_FALSE(get_kip()->kdebug_entry != nullptr) )
 		get_kip()->kdebug_entry(context);
 	}
     }
@@ -340,7 +340,7 @@ extern "C" void program_check_handler( word_t vect, powerpc64_irq_context_t *con
 	context->r3 = (u64_t) space->get_kip_page_area ().get_base ();
 	context->r4 = get_kip ()->api_version;
 	context->r5 = get_kip ()->api_flags;
-	context->r6 = (NULL != get_kip()->kernel_desc_ptr) ?
+	context->r6 = (nullptr != get_kip()->kernel_desc_ptr) ?
 		    *(word_t *)((word_t)get_kip() + get_kip()->kernel_desc_ptr) : 0;
 
 	except_return();
@@ -350,7 +350,7 @@ exception:
     if ( !send_exception_ipc( vect, 0, 0, 0) )
     {
 	printf( "\n-- KD# Program check --\n" );
-	if( EXPECT_FALSE(get_kip()->kdebug_entry != NULL) )
+	if( EXPECT_FALSE(get_kip()->kdebug_entry != nullptr) )
 	    get_kip()->kdebug_entry(context);
 
 	halt_user_thread();
@@ -401,7 +401,7 @@ extern "C" void isi_handler( powerpc64_irq_context_t *context )
     // Use kernel space if we have kernel fault in TCB area or
     // when no space is set (e.g., running on the idle thread)
     if ( EXPECT_FALSE( is_kernel && space->is_tcb_area ((addr_t)srr0) )
-			    || space == NULL)
+			    || space == nullptr)
     {
         space = get_kernel_space();
 	//TRACEF( "kernel space\n" );
@@ -433,7 +433,7 @@ extern "C" void isi_handler( powerpc64_irq_context_t *context )
 	}
     } else {
 	printf( "-- KD# Unknown instruction fault --\n");
-	if( EXPECT_FALSE(get_kip()->kdebug_entry != NULL) )
+	if( EXPECT_FALSE(get_kip()->kdebug_entry != nullptr) )
 	    get_kip()->kdebug_entry(context);
     }
 
@@ -452,7 +452,7 @@ extern "C" void isi_handler( powerpc64_irq_context_t *context )
 extern "C" void ppc64_except_trace( word_t vect, powerpc64_irq_context_t *context )
 {
     printf( "--KD# Trace Point: IP=%p, SRR1=%p --\n", context->srr0, context->srr1 );
-    if( EXPECT_FALSE(get_kip()->kdebug_entry != NULL) )
+    if( EXPECT_FALSE(get_kip()->kdebug_entry != nullptr) )
 	get_kip()->kdebug_entry(context);
     except_return();
 }
@@ -550,7 +550,7 @@ extern "C" void ppc64_except_syscall( word_t vect, powerpc64_irq_context_t *cont
     if ( !send_syscall_ipc( context ) )
     {
 	printf("-- KD# Unhandled user system call --\n");
-	if( EXPECT_FALSE(get_kip()->kdebug_entry != NULL) )
+	if( EXPECT_FALSE(get_kip()->kdebug_entry != nullptr) )
 	    get_kip()->kdebug_entry(context);
 
 	halt_user_thread();

--- a/kernel/src/glue/v4-powerpc64/resources.h
+++ b/kernel/src/glue/v4-powerpc64/resources.h
@@ -60,13 +60,13 @@ private:
 
 class processor_resources_t {
  public:
-    void init_cpu(void) { fp_lazy_tcb = NULL; }
+    void init_cpu(void) { fp_lazy_tcb = nullptr; }
 
  public:
     tcb_t *get_fp_lazy_tcb() { return fp_lazy_tcb; }
 
     void set_fp_lazy_tcb( tcb_t *tcb ) { fp_lazy_tcb = tcb; }
-    void clear_fp_lazy_tcb() { fp_lazy_tcb = NULL; }
+    void clear_fp_lazy_tcb() { fp_lazy_tcb = nullptr; }
     
  private:
     tcb_t *fp_lazy_tcb;

--- a/kernel/src/glue/v4-powerpc64/space.cc
+++ b/kernel/src/glue/v4-powerpc64/space.cc
@@ -69,7 +69,7 @@ char kernel_space_segment_table[POWERPC64_STAB_SIZE] __attribute__((aligned(POWE
 #endif
 
 space_t *kernel_space = (space_t*)&kernel_space_object;
-tcb_t *dummy_tcb = NULL;
+tcb_t *dummy_tcb = nullptr;
 
 //translation table
 struct transTable_t transTable[TRANSLATION_TABLE_ENTRIES];

--- a/kernel/src/glue/v4-powerpc64/tcb.h
+++ b/kernel/src/glue/v4-powerpc64/tcb.h
@@ -241,9 +241,9 @@ INLINE void tcb_t::switch_to(tcb_t * dest)
     space_t *space = dest->get_space();
     space_t *currspace = this->get_space();
 
-    if (space == NULL)
+    if (space == nullptr)
 	space = get_kernel_space();
-    if (currspace == NULL)
+    if (currspace == nullptr)
 	currspace = get_kernel_space();
 
 

--- a/kernel/src/glue/v4-x86/debug.cc
+++ b/kernel/src/glue/v4-x86/debug.cc
@@ -90,7 +90,7 @@ public:
     
     cpu_kdb_t()
 	{
-	    user_tcb = NULL;
+	    user_tcb = nullptr;
 	    kdb_tcb = (tcb_t *) &__kdb_tcb;
 	    get_idle_tcb()->create_kernel_thread(NILTHREAD, &__kdb_utcb, sktcb_hi);
 	    kdb_tcb->set_cpu(get_current_cpu());

--- a/kernel/src/glue/v4-x86/hvm-space.cc
+++ b/kernel/src/glue/v4-x86/hvm-space.cc
@@ -72,7 +72,7 @@ bool x86_hvm_space_t::activate (space_t *space)
     active = true;
 
     /* Loop through existing TCBs pointing to space, and activate HVM */
-    tcb_t *last_tcb = NULL;
+    tcb_t *last_tcb = nullptr;
     for (tcb_t *tcb = tcb_list; tcb != last_tcb; tcb = tcb->get_arch ()->space_list.prev)
     {
 	ASSERT (tcb->exists ());
@@ -92,7 +92,7 @@ void x86_hvm_space_t::handle_gphys_unmap (addr_t g_paddr, word_t log2size)
      * Loop through all TCBs (VCPUs) using the space,
      * and remove the entries from their VTLBs.
      */
-    tcb_t *last_tcb = NULL;
+    tcb_t *last_tcb = nullptr;
     for (tcb_t *tcb = tcb_list; tcb != last_tcb; tcb = tcb->get_arch ()->space_list.prev)
     {
 	ASSERT (tcb->exists ());

--- a/kernel/src/glue/v4-x86/ipc.cc
+++ b/kernel/src/glue/v4-x86/ipc.cc
@@ -100,9 +100,9 @@ static const word_t  x86_hvm_gdtrregs[]	 = { VMCS_IDX_G_GDTR_BASE, VMCS_IDX_G_GD
 const word_t *const ctrlxfer_item_t::hwregs[] = 
 {
     x86_gpregs,
-    NULL, /* fpu regs software-emulated */ 
+    nullptr, /* fpu regs software-emulated */ 
 #if defined(CONFIG_X_X86_HVM)
-    NULL, /* cr regs software-emulated */ 
+    nullptr, /* cr regs software-emulated */ 
     x86_hvm_dregs,
     x86_hvm_csregs,
     x86_hvm_ssregs,
@@ -114,9 +114,9 @@ const word_t *const ctrlxfer_item_t::hwregs[] =
     x86_hvm_ldtrregs,
     x86_hvm_idtrregs,
     x86_hvm_gdtrregs,
-    NULL, /* nonreg/exc state software-emulated */ 
-    NULL, /* execctrl   state software-emulated */ 
-    NULL /* otherregs        software-emulated */ 
+    nullptr, /* nonreg/exc state software-emulated */ 
+    nullptr, /* execctrl   state software-emulated */ 
+    nullptr /* otherregs        software-emulated */ 
 #endif 
 };
 

--- a/kernel/src/glue/v4-x86/mdb_io.cc
+++ b/kernel/src/glue/v4-x86/mdb_io.cc
@@ -82,7 +82,7 @@ MDB_INIT_FUNCTION (3, init_mdb_io)
     sigma0_ionode = new mdb_node_t;
 
     sigma0_ionode->set_prev (sigma0_ionode);
-    sigma0_ionode->set_next (NULL);
+    sigma0_ionode->set_next (nullptr);
     sigma0_ionode->set_depth (0);
     sigma0_ionode->set_inrights (~0UL);
     sigma0_ionode->set_outrights (~0UL);

--- a/kernel/src/glue/v4-x86/resources.cc
+++ b/kernel/src/glue/v4-x86/resources.cc
@@ -94,7 +94,7 @@ void thread_resources_t::load(tcb_t * tcb)
     if (tcb->resource_bits.have_resource(FPU))
     {
 	ASSERT (fpu_owner == tcb);
-	ASSERT (fpu_state != NULL);
+	ASSERT (fpu_state != nullptr);
 	TRACEPOINT(X86_X64_FPU_REENABLE, "strictly reenabling FPU for %t\n", tcb);
 	x86_fpu_t::enable();
     }
@@ -108,7 +108,7 @@ void thread_resources_t::purge(tcb_t * tcb)
     {
 	x86_fpu_t::enable();
 	x86_fpu_t::save_state(this->fpu_state);
-	fpu_owner = NULL;
+	fpu_owner = nullptr;
 	x86_fpu_t::disable();
 #ifdef FPU_REENABLE
 	tcb->resource_bits -= FPU;
@@ -128,7 +128,7 @@ void thread_resources_t::purge(tcb_t * tcb)
 void thread_resources_t::init(tcb_t * tcb)
 {
     tcb->resource_bits.init ();
-    fpu_state = NULL;
+    fpu_state = nullptr;
 
     last_copy_area = 0;
     for (word_t i = 0; i < COPY_AREA_PDIRS; i++)
@@ -143,11 +143,11 @@ void thread_resources_t::free(tcb_t * tcb)
     if (fpu_state)
     {
 	kmem.free(kmem_resources, fpu_state, x86_fpu_t::get_state_size());
-	fpu_state = NULL;
+	fpu_state = nullptr;
 
 	if (fpu_owner == tcb)
 	{
-	    fpu_owner = NULL;
+	    fpu_owner = nullptr;
 	    x86_fpu_t::disable();
 	}
     }
@@ -165,7 +165,7 @@ void thread_resources_t::x86_no_math_exception(tcb_t * tcb)
     // if the current thread owns the fpu already do a quick exit
     if (fpu_owner != tcb)
     {
-	if (fpu_owner != NULL)
+	if (fpu_owner != nullptr)
 	{
 	    x86_fpu_t::save_state(fpu_owner->resources.fpu_state);
 #ifdef  FPU_REENABLE
@@ -174,7 +174,7 @@ void thread_resources_t::x86_no_math_exception(tcb_t * tcb)
 	}
 	fpu_owner = tcb;
 
-	if (fpu_state == NULL)
+	if (fpu_state == nullptr)
 	{
 	    fpu_state = kmem.alloc(kmem_resources, x86_fpu_t::get_state_size());
 	    x86_fpu_t::init();

--- a/kernel/src/glue/v4-x86/space.cc
+++ b/kernel/src/glue/v4-x86/space.cc
@@ -38,8 +38,8 @@ EXTERN_KMEM_GROUP (kmem_tcb);
 DECLARE_KMEM_GROUP (kmem_iofp);
 DECLARE_KMEM_GROUP (kmem_utcb);
 
-space_t * kernel_space = NULL;
-addr_t utcb_page = NULL;
+space_t * kernel_space = nullptr;
+addr_t utcb_page = nullptr;
 
 /**********************************************************************
  *
@@ -448,9 +448,9 @@ addr_t space_t::get_io_bitmap(cpuid_t cpu)
     if (this->lookup_mapping(tss.get_io_bitmap(), &pgent, &pgsize, cpu))
 	return phys_to_virt(pgent->address(this, pgsize));
     
-    TRACEF("BUG: get_io_bitmap_phys returns NULL\n");
+    TRACEF("BUG: get_io_bitmap_phys returns nullptr\n");
     enter_kdebug("IO-Fpage BUG?");
-    return NULL;
+    return nullptr;
 }
 
 
@@ -462,14 +462,14 @@ addr_t space_t::get_io_bitmap(cpuid_t cpu)
  */
 addr_t space_t::install_io_bitmap(bool create)
 {
-    addr_t new_bitmap = NULL;
+    addr_t new_bitmap = nullptr;
     cpuid_t cpu = get_current_cpu();
     
     if (create)
     {
 	new_bitmap = (word_t*) kmem.alloc(kmem_iofp, IOPERMBITMAP_SIZE);
 	if (!new_bitmap) 
-	    return NULL;
+	    return nullptr;
     }
     else
     {
@@ -495,10 +495,10 @@ addr_t space_t::install_io_bitmap(bool create)
     {
 	pgent_t *new_subtree = (pgent_t *) kmem.alloc (kmem_iofp, X86_PAGE_SIZE);
 	
-	if (new_subtree == NULL)
+	if (new_subtree == nullptr)
 	{
 	    kmem.free(kmem_iofp, new_bitmap, IOPERMBITMAP_SIZE);
-	    return NULL;
+	    return nullptr;
 	}
 
 		
@@ -559,7 +559,7 @@ void space_t::free_io_bitmap()
     /*
      * Do not release the default IOPBM
      */
-    if (get_io_bitmap() == tss.get_io_bitmap() || get_io_bitmap() == NULL)
+    if (get_io_bitmap() == tss.get_io_bitmap() || get_io_bitmap() == nullptr)
 	return;
     
 
@@ -960,7 +960,7 @@ X86_EXCWITH_ERRORCODE(exc_pagefault, 0)
      * we will get a pagefault with an invalid space
      * so we use CR3 to figure out the space
      */
-    if (EXPECT_FALSE( space == NULL ))
+    if (EXPECT_FALSE( space == nullptr ))
 	space = space_t::top_pdir_to_space(x86_mmu_t::get_active_pagetable());
     
     ASSERT(space);
@@ -1002,7 +1002,7 @@ static void flush_tlb_remote()
 {
     for (cpuid_t cpu = 0; cpu < cpu_t::count; cpu++)
 	if (cpu_remote_flush & (1 << cpu))
-	    sync_xcpu_request(cpu, do_xcpu_flush_tlb, NULL,
+	    sync_xcpu_request(cpu, do_xcpu_flush_tlb, nullptr,
 			      cpu_remote_flush_global & (1 << cpu));
     cpu_remote_flush = 0;
     cpu_remote_flush_global = 0;
@@ -1128,7 +1128,7 @@ void space_t::free_cpu_top_pdir(cpuid_t cpu)
     ASSERT(data.cpu_ptab[cpu].top_pdir);
     ASSERT(data.cpu_ptab[cpu].thread_count == 0);
     top_pdir_t* pdir = data.cpu_ptab[cpu].top_pdir;
-    data.cpu_ptab[cpu].top_pdir = NULL; // mem ordering, for X86 no barrier needed
+    data.cpu_ptab[cpu].top_pdir = nullptr; // mem ordering, for X86 no barrier needed
     kmem.free(kmem_space, (addr_t)pdir, sizeof(top_pdir_t));
 }
 

--- a/kernel/src/glue/v4-x86/space.h
+++ b/kernel/src/glue/v4-x86/space.h
@@ -214,7 +214,7 @@ INLINE x86_pgent_t * space_t::get_top_pdir_phys(cpuid_t cpu)
 
 INLINE bool space_t::has_cpu_top_pdir(cpuid_t cpu)
 {
-    return data.cpu_ptab[cpu].top_pdir != NULL;
+    return data.cpu_ptab[cpu].top_pdir != nullptr;
 }
 
 /**
@@ -313,7 +313,7 @@ INLINE pgent_t * space_t::pgent (word_t num, word_t cpu)
 {
     ASSERT(cpu < CONFIG_SMP_MAX_CPUS);
     if (!data.cpu_ptab[cpu].top_pdir)
-	return NULL;
+	return nullptr;
     return &data.cpu_ptab[cpu].top_pdir->pgent[num];
 }
 

--- a/kernel/src/glue/v4-x86/tcb.h
+++ b/kernel/src/glue/v4-x86/tcb.h
@@ -46,7 +46,7 @@ INLINE void tcb_t::init_stack()
 INLINE void tcb_t::set_space(space_t * space)
 {
     this->space = space;
-    this->pdir_cache = space ? (word_t)space->get_top_pdir_phys(get_cpu()) : NULL;
+    this->pdir_cache = space ? (word_t)space->get_top_pdir_phys(get_cpu()) : nullptr;
 
 }
 
@@ -74,13 +74,13 @@ INLINE void tcb_t::set_cpu(cpuid_t cpu)
 
 INLINE void tcb_t::set_utcb_location(word_t utcb_location)
 {
-    utcb_t * dummy = (utcb_t*)NULL;
+    utcb_t * dummy = (utcb_t*)nullptr;
     myself_local.set_raw (utcb_location + ((word_t)&dummy->mr[0]));
 }
 
 INLINE word_t tcb_t::get_utcb_location()
 {
-    utcb_t * dummy = (utcb_t*)NULL;
+    utcb_t * dummy = (utcb_t*)nullptr;
     return myself_local.get_raw() - ((word_t)&dummy->mr[0]);
 }
 

--- a/kernel/src/glue/v4-x86/x32/hvm-vmx.cc
+++ b/kernel/src/glue/v4-x86/x32/hvm-vmx.cc
@@ -447,7 +447,7 @@ void arch_hvm_ktcb_t::disable_hvm ()
     if (vmcs)
     {
 	vmcs_t::free_vmcs (vmcs);
-	vmcs = NULL;
+	vmcs = nullptr;
     }
     vtlb.free ();
 }

--- a/kernel/src/glue/v4-x86/x32/hvm-vtlb.cc
+++ b/kernel/src/glue/v4-x86/x32/hvm-vtlb.cc
@@ -81,7 +81,7 @@ void x86_hvm_vtlb_t::free()
     if (hpdir_nonpaged)
 	kmem.free (kmem_vtlb, hpdir_nonpaged, X86_PAGE_SIZE);
 
-    this->space = NULL;
+    this->space = nullptr;
 }
 
 
@@ -276,7 +276,7 @@ void x86_hvm_vtlb_t::set_gphys_entry (addr_t gvaddr, addr_t gpaddr, pgent_t::pgs
 				      word_t rwx, word_t attrib, bool kernel, bool global,
 				      word_t access)
 {
-    pgent_t *gppgent = NULL;
+    pgent_t *gppgent = nullptr;
     pgent_t::pgsize_e gppgsz;
     
     tcb_t *current = get_current_tcb();

--- a/kernel/src/glue/v4-x86/x32/smallspaces.cc
+++ b/kernel/src/glue/v4-x86/x32/smallspaces.cc
@@ -61,7 +61,7 @@ DEFINE_SPINLOCK (small_space_owner_lock);
 /**
  * Linked list of spaces that are polluted with small space mappings.
  */
-static x86_space_t * polluted_spaces = NULL;
+static x86_space_t * polluted_spaces = nullptr;
 
 
 /**
@@ -184,7 +184,7 @@ bool x86_space_t::make_small (smallspace_id_t id)
     // Try allocation small space slots.
     for (i = 0; i < size; i++)
     {
-	if (small_space_owner[offset + i] == NULL)
+	if (small_space_owner[offset + i] == nullptr)
 	    small_space_owner[offset + i] = this;
 	else
 	    break;
@@ -195,7 +195,7 @@ bool x86_space_t::make_small (smallspace_id_t id)
     if (i < size)
     {
 	while (i > 0)
-	    small_space_owner[offset + --i] = NULL;
+	    small_space_owner[offset + --i] = nullptr;
 
 	small_space_owner_lock.unlock ();
 	return false;
@@ -261,7 +261,7 @@ void x86_space_t::make_large (void)
     for (word_t i = 0; i < size; i++)
     {
 	ASSERT (small_space_owner[offset + i] == this);
-	small_space_owner[offset + i] = NULL;
+	small_space_owner[offset + i] = nullptr;
     }
 
     smallid ()->set_large ();
@@ -337,14 +337,14 @@ void x86_space_t::dequeue_polluted (void)
 {
     polluted_spaces_lock.lock ();
 
-    if (get_next () == NULL)
+    if (get_next () == nullptr)
     {
 	// Space is not in list.
     }
     else if (get_next () == this)
     {
 	// Space is only member of list.
-	polluted_spaces = NULL;
+	polluted_spaces = nullptr;
     }
     else
     {
@@ -357,8 +357,8 @@ void x86_space_t::dequeue_polluted (void)
 	    polluted_spaces = n;
     }
 
-    set_prev (NULL);
-    set_next (NULL);
+    set_prev (nullptr);
+    set_next (nullptr);
 
     polluted_spaces_lock.unlock ();
 }
@@ -371,11 +371,11 @@ void x86_space_t::enqueue_polluted (void)
 {
     polluted_spaces_lock.lock ();
 
-    if (get_next () != NULL)
+    if (get_next () != nullptr)
     {
 	// Space already in list.
     }
-    else if (polluted_spaces != NULL)
+    else if (polluted_spaces != nullptr)
     {
 	// Insert into list.
 	x86_space_t * p = polluted_spaces->get_prev ();

--- a/kernel/src/glue/v4-x86/x32/tcb.h
+++ b/kernel/src/glue/v4-x86/x32/tcb.h
@@ -241,7 +241,7 @@ INLINE SECTION(".text") void tcb_t::switch_to(tcb_t * dest)
 	"cmpl	%7, %8		\n\t"	/* same page dir?	*/
 	"je	2f		\n\t"
 #if defined(CONFIG_CPU_X86_P4)
-	"cmpl	$0, %c5(%2)	\n\t"	/* kernel thread (space==NULL)?	*/
+	"cmpl	$0, %c5(%2)	\n\t"	/* kernel thread (space==nullptr)?	*/
 	"jne	1f		\n\t"
 	"movl	%8, %c6(%2)	\n\t"	/* rewrite dest->pdir_cache */
 	"jmp	2f		\n\t"

--- a/kernel/src/glue/v4-x86/x64/tcb.h
+++ b/kernel/src/glue/v4-x86/x64/tcb.h
@@ -143,7 +143,7 @@ INLINE void tcb_t::switch_to(tcb_t * dest)
 	"cmpq	%[spdir], %[dpdir]		\n\t"	/* same pdir_cache?		*/
 	"je	2f				\n\t"
 
-	"cmpq	$0, %c[space](%[dtcb])		\n\t"	/* kernel thread (space==NULL)?	*/
+	"cmpq	$0, %c[space](%[dtcb])		\n\t"	/* kernel thread (space==nullptr)?	*/
 	"jnz	1f				\n\t"	
 	"movq	%[spdir], %c[pdir](%[dtcb])	\n\t"	/* yes: update dest->pdir_cache */
 	"jmp	2f				\n\t"

--- a/kernel/src/glue/v4-x86/x64/x32comp/tcb.h
+++ b/kernel/src/glue/v4-x86/x64/x32comp/tcb.h
@@ -41,7 +41,7 @@
 INLINE void tcb_t::set_space(space_t * space)
 {
     this->space = space;
-    this->pdir_cache = space ? (word_t)space->get_top_pdir_phys(get_cpu()) : NULL;
+    this->pdir_cache = space ? (word_t)space->get_top_pdir_phys(get_cpu()) : nullptr;
     if (space && space->is_compatibility_mode())
 	resource_bits += COMPATIBILITY_MODE;
     

--- a/kernel/src/kdb/cmd.h
+++ b/kernel/src/kdb/cmd.h
@@ -125,7 +125,7 @@ private:
  */
 #define DECLARE_CMD_GROUP(group)					\
     DECLARE_SET(__kdb_group_##group);					\
-    cmd_group_t group = { &__kdb_group_##group, NULL, NULL };		\
+    cmd_group_t group = { &__kdb_group_##group, nullptr, nullptr };		\
     DECLARE_CMD (cmd__help, group, '?', "help", "this help message");   \
     DECLARE_CMD (cmd__abort, group, KEY_BS, "up", "back up to previous menu"); \
     DECLARE_CMD (cmd__prior, group, KEY_ESC, "prior", "back to previous menu")

--- a/kernel/src/kdb/input.h
+++ b/kernel/src/kdb/input.h
@@ -44,21 +44,21 @@ class vrt_t;
 #define ABORT_MAGIC	(0x19022002)
 
 
-word_t get_hex (const char * prompt = NULL,
+word_t get_hex (const char * prompt = nullptr,
 		const word_t defnum = 0,
-		const char * defstr = NULL);
+		const char * defstr = nullptr);
 
-word_t get_dec (const char * prompt = NULL,
+word_t get_dec (const char * prompt = nullptr,
 		const word_t defnum = 0,
-		const char * defstr = NULL);
+		const char * defstr = nullptr);
 
 char get_choice (const char * prompt,
 		 const char * choices,
 		 char def);
 
-space_t * get_space (const char * prompt = NULL);
-tcb_t * get_thread (const char * prompt = NULL);
-comspace_t * get_comspace (const char * prompt = NULL);
-vrt_t * get_thrspace (const char * prompt = NULL);
+space_t * get_space (const char * prompt = nullptr);
+tcb_t * get_thread (const char * prompt = nullptr);
+comspace_t * get_comspace (const char * prompt = nullptr);
+vrt_t * get_thrspace (const char * prompt = nullptr);
 
 #endif /* !__KDB__INPUT_H__ */

--- a/kernel/src/kdb/linker_set.h
+++ b/kernel/src/kdb/linker_set.h
@@ -76,7 +76,7 @@ public:
  */
 #define DECLARE_SET(name)						\
   linker_set_t name							\
-  __attribute__ ((__section__ (".setlist"), __unused__)) = { NULL, 0 }
+  __attribute__ ((__section__ (".setlist"), __unused__)) = { nullptr, 0 }
 
 
 /**

--- a/kernel/src/platform/efi/acpi.cc
+++ b/kernel/src/platform/efi/acpi.cc
@@ -42,13 +42,13 @@ acpi_rsdp_t* acpi_rsdp_t::locate(addr_t addr)
 
     /* look for ACPI 2.0 RSDT pointer */
     p = (acpi_rsdp_t*) efi_config_table.find_table(ACPI_20_TABLE_GUID);
-    if (p != NULL)
+    if (p != nullptr)
 	return p;
 
     /* look for ACPI 1.0 RSDT pointer */
     p = (acpi_rsdp_t*) efi_config_table.find_table(ACPI_TABLE_GUID);
-    if (p != NULL)
+    if (p != nullptr)
 	return p;
 
-    return NULL;
+    return nullptr;
 };

--- a/kernel/src/platform/efi/hcdp.h
+++ b/kernel/src/platform/efi/hcdp.h
@@ -71,7 +71,7 @@ public:
 	    if (hcdp_dev[i].type == type)
 		return &hcdp_dev[i];
 	}
-	return NULL;
+	return nullptr;
     }
 } __attribute__((packed));
 

--- a/kernel/src/platform/efi/memory_map.h
+++ b/kernel/src/platform/efi/memory_map.h
@@ -238,7 +238,7 @@ efi_memory_map_t::reset (void)
 
 /**
  * Iterate to next memory map descritor.
- * @return pointer to next memory map descriptor, or NULL if the whole
+ * @return pointer to next memory map descriptor, or nullptr if the whole
  * set of descriptors has been iterater over
  */
 INLINE efi_memory_desc_t *
@@ -247,7 +247,7 @@ efi_memory_map_t::next (void)
     efi_memory_desc_t * ret = (efi_memory_desc_t *) _curptr;
 
     if ((word_t) _curptr - (word_t) _base >= _size)
-	return NULL;
+	return nullptr;
 
     _curptr += _desc_size;
     return ret;

--- a/kernel/src/platform/efi/system_table.h
+++ b/kernel/src/platform/efi/system_table.h
@@ -63,7 +63,7 @@ public:
 /**
  * Search for indicated system table.
  * @param guid		unique id of table
- * @return point to table, or NULL if table is not found.
+ * @return point to table, or nullptr if table is not found.
  */
 INLINE void * efi_config_table_ptr_t::find_table (efi_guid_t guid)
 {
@@ -71,7 +71,7 @@ INLINE void * efi_config_table_ptr_t::find_table (efi_guid_t guid)
 	if (config_table[i].vendor_guid == guid)
 	    return config_table[i].vendor_table;
 
-    return NULL;
+    return nullptr;
 } 
 
 

--- a/kernel/src/platform/generic/intctrl-apic.cc
+++ b/kernel/src/platform/generic/intctrl-apic.cc
@@ -162,7 +162,7 @@ void intctrl_t::init_arch()
 
     TRACE_INIT("\tRSDP is at %p\n", rsdp);
     
-    if (rsdp == NULL)
+    if (rsdp == nullptr)
     {
 	TRACE_INIT("\tAssuming local APIC defaults");
         get_kernel_space()->add_mapping(addr_t(APIC_MAPPINGS_START),
@@ -180,25 +180,25 @@ void intctrl_t::init_arch()
 	return;
     }
     
-    acpi_rsdt_t *rsdt = NULL, *rsdt_phys = rsdp->rsdt();
-    acpi_xsdt_t *xsdt = NULL, *xsdt_phys = rsdp->xsdt();
+    acpi_rsdt_t *rsdt = nullptr, *rsdt_phys = rsdp->rsdt();
+    acpi_xsdt_t *xsdt = nullptr, *xsdt_phys = rsdp->xsdt();
 
-    if ((rsdt_phys == NULL) && (xsdt_phys == NULL))
+    if ((rsdt_phys == nullptr) && (xsdt_phys == nullptr))
 	return;
 
     TRACE_INIT("\tRSDT is at %p\n", rsdt_phys);
     TRACE_INIT("\tXSDT is at %p\n", xsdt_phys);
 
-    acpi_fadt_t *fadt = NULL, *_fadt;
-    acpi_madt_t *madt = NULL, *_madt; 
+    acpi_fadt_t *fadt = nullptr, *_fadt;
+    acpi_madt_t *madt = nullptr, *_madt; 
    
-    if (xsdt_phys != NULL)
+    if (xsdt_phys != nullptr)
     {
 	xsdt = (acpi_xsdt_t*)acpi_remap(xsdt_phys);	
 	fadt = (acpi_fadt_t*) xsdt->find("FACP", (addr_t) xsdt_phys);
 	madt = (acpi_madt_t*) xsdt->find("APIC", (addr_t) xsdt_phys);
     }
-    if ((madt == NULL) && (rsdt_phys != NULL))
+    if ((madt == nullptr) && (rsdt_phys != nullptr))
     {
 	rsdt = (acpi_rsdt_t*)acpi_remap(rsdt_phys);
 	rsdt->list(rsdt_phys);	
@@ -218,7 +218,7 @@ void intctrl_t::init_arch()
     else 
 	pmtimer_available = false;
 
-    if (madt == NULL)
+    if (madt == nullptr)
 	return;
 
     _madt = (acpi_madt_t*)acpi_remap(madt);
@@ -244,7 +244,7 @@ void intctrl_t::init_arch()
     {
 	word_t total_cpus = 0;
 	acpi_madt_lapic_t* p;
-	for (word_t i = 0; ((p = _madt->lapic(i)) != NULL); i++)
+	for (word_t i = 0; ((p = _madt->lapic(i)) != nullptr); i++)
 	{
 	    TRACE_INIT("\tlocal APIC: apic_id=%d use=%s proc_id=%d\n",
 		       p->id, p->flags.enabled ? "ok" : "disabled",
@@ -272,7 +272,7 @@ void intctrl_t::init_arch()
     {
 	acpi_madt_ioapic_t* p;
 
-	for (word_t i = 0; ((p = _madt->ioapic(i)) != NULL); i++)
+	for (word_t i = 0; ((p = _madt->ioapic(i)) != nullptr); i++)
 	{
 	    TRACE_INIT("\tIOAPIC: id=%d irq_base=%d addr=%p\n",
 		       p->id, p->irq_base, p->address);
@@ -291,7 +291,7 @@ void intctrl_t::init_arch()
     /* IRQ source overrides */
     {
 	acpi_madt_irq_t* p;
-	for (word_t i = 0; ((p = _madt->irq(i)) != NULL); i++)
+	for (word_t i = 0; ((p = _madt->irq(i)) != nullptr); i++)
 	{
 	    TRACE_INIT("  IRQ source override: "
 		       "srcbus=%d, srcirq=%d, dest=%d, "
@@ -325,7 +325,7 @@ void intctrl_t::init_arch()
     {
 	acpi_madt_hdr_t* p;
 	for (u8_t t = 3; t <= 8; t++)
-	    for (word_t i = 0; ((p = _madt->find(t, i)) != NULL); i++)
+	    for (word_t i = 0; ((p = _madt->find(t, i)) != nullptr); i++)
 		TRACE_INIT("MADT: found unknown type=%d, len=%d\n", p->type, p->len);
     }
     

--- a/kernel/src/platform/generic/intctrl-apic.h
+++ b/kernel/src/platform/generic/intctrl-apic.h
@@ -66,14 +66,14 @@ private:
     class ioapic_redir_table_t 
     {
     public:
-	void init() { ioapic = NULL; } // mark entry invalid
+	void init() { ioapic = nullptr; } // mark entry invalid
 	void set(ioapic_t * ioapic, word_t line) 
 	    {
 		this->ioapic = ioapic;
 		this->line = line;
 		this->pending = false;
 	    }
-	bool is_valid() { return this->ioapic != NULL; }
+	bool is_valid() { return this->ioapic != nullptr; }
 
     public:
 	ioapic_redir_t entry;

--- a/kernel/src/platform/ofpower3/opic.cc
+++ b/kernel/src/platform/ofpower3/opic.cc
@@ -40,7 +40,7 @@
 
 intctrl_t intctrl;
 
-open_pic_t *opic = NULL;
+open_pic_t *opic = nullptr;
 
 SECTION(".init") void intctrl_t::init_arch()
 {

--- a/kernel/src/platform/ofpower3/prom.cc
+++ b/kernel/src/platform/ofpower3/prom.cc
@@ -79,7 +79,7 @@ SECTION(".init") void of1275_tree_init( kernel_interface_page_t *kip )
     // Not found.  Things won't work, but ...
     prom_puts( "*** Error: the boot loader didn't supply a copy of the\n\r"
 	       "*** Open Firmware device tree!\n\r" );
-    get_of1275_tree()->init( NULL );
+    get_of1275_tree()->init( nullptr );
 }
 
 

--- a/kernel/src/platform/ofpower4/prom.cc
+++ b/kernel/src/platform/ofpower4/prom.cc
@@ -79,7 +79,7 @@ SECTION(".init") void of1275_tree_init( kernel_interface_page_t *kip )
     // Not found.  Things won't work, but ...
     prom_puts( "*** Error: the boot loader didn't supply a copy of the\n\r"
 	       "*** Open Firmware device tree!\n\r" );
-    PTRRELOC(get_of1275_tree())->init( NULL );
+    PTRRELOC(get_of1275_tree())->init( nullptr );
 }
 
 

--- a/kernel/src/platform/ofppc/1275tree.cc
+++ b/kernel/src/platform/ofppc/1275tree.cc
@@ -99,7 +99,7 @@ of1275_device_t * of1275_tree_t::find( const char *name )
 {
     of1275_device_t *dev = this->first();
     if( !dev )
-	return NULL;
+	return nullptr;
 
     while( dev->is_valid() )
     {
@@ -108,14 +108,14 @@ of1275_device_t * of1275_tree_t::find( const char *name )
 	dev = dev->next();
     }
 
-    return NULL;
+    return nullptr;
 }
 
 of1275_device_t * of1275_tree_t::find_handle( word_t handle )
 {
     of1275_device_t *dev = this->first();
     if( !dev )
-	return NULL;
+	return nullptr;
 
     while( dev->is_valid() )
     {
@@ -124,28 +124,28 @@ of1275_device_t * of1275_tree_t::find_handle( word_t handle )
 	dev = dev->next();
     }
 
-    return NULL;
+    return nullptr;
 }
 
 of1275_device_t * of1275_tree_t::get_parent( of1275_device_t *dev )
 {
-    char *slash = NULL;
+    char *slash = nullptr;
     int cnt, depth;
 
     if( !dev || !this->first() )
-	return NULL;
+	return nullptr;
 
     // Do we have any parents?
     depth = dev->get_depth();
     if( depth <= 1 )
-	return NULL;
+	return nullptr;
 
     // Locate the last slash in the name.
     for( char *c = dev->get_name(); *c; c++ )
 	if( *c == '/' )
 	    slash = c;
-    if( slash == NULL )
-	return NULL;
+    if( slash == nullptr )
+	return nullptr;
 
     // Count the offset of the last slash.
     cnt = 0;
@@ -162,7 +162,7 @@ of1275_device_t * of1275_tree_t::get_parent( of1275_device_t *dev )
 	parent = parent->next();
     }
 
-    return NULL;
+    return nullptr;
 }
 
 of1275_device_t * of1275_tree_t::find_device_type( const char *device_type )
@@ -173,7 +173,7 @@ of1275_device_t * of1275_tree_t::find_device_type( const char *device_type )
 
     dev = this->first();
     if( !dev )
-	return NULL;
+	return nullptr;
 
     while( dev->is_valid() )
     {
@@ -183,6 +183,6 @@ of1275_device_t * of1275_tree_t::find_device_type( const char *device_type )
 	dev = dev->next();
     }
 
-    return NULL;
+    return nullptr;
 }
 

--- a/kernel/src/platform/ofppc/ofppc.cc
+++ b/kernel/src/platform/ofppc/ofppc.cc
@@ -49,12 +49,12 @@ SECTION(".init") bool ofppc_get_cpu_speed( word_t *cpu_hz, word_t *bus_hz )
 	if( dev->get_prop("cpu", &handle) )
 	    dev = get_of1275_tree()->find_handle( handle );
 	else
-	    dev = NULL;
+	    dev = nullptr;
     }
 
-    if( dev == NULL )
+    if( dev == nullptr )
     	dev = get_of1275_tree()->find( "/cpus/cpu@0" ); // Try a fallback.
-    if( dev == NULL )
+    if( dev == nullptr )
 	return false;
 
     if( !dev->get_prop("clock-frequency", cpu_hz) )
@@ -72,7 +72,7 @@ SECTION(".init") int ofppc_get_cpu_count()
     char token[] = "/cpus/";
 
     dev = get_of1275_tree()->first();
-    if( dev == NULL )
+    if( dev == nullptr )
 	return 1;
 
     // Search through every device, looking for those which are in the /cpus

--- a/kernel/src/platform/ofppc/opic.cc
+++ b/kernel/src/platform/ofppc/opic.cc
@@ -192,17 +192,17 @@ SECTION(".init") of1275_device_t *intctrl_t::find_opic()
 
     /* Look for the open-pic device. */
     dev_opic = get_of1275_tree()->find_device_type( "open-pic" );
-    if( dev_opic == NULL ) {
+    if( dev_opic == nullptr ) {
 	printf( "Error: unable to find an open-pic device.\n" );
-	return NULL;
+	return nullptr;
     }
     TRACE_INIT( "The open-pic device: %s\n", dev_opic->get_name() );
 
     /* Obtain the open-pic's parent handle. */
     dev_bus = get_of1275_tree()->get_parent( dev_opic );
-    if( dev_bus == NULL ) {
+    if( dev_bus == nullptr ) {
 	printf( "Error: unable to find the open-pic's bus.\n" );
-	return NULL;
+	return nullptr;
     }
     TRACE_INIT( "The opic-pic bus: %s\n", dev_bus->get_name() );
 
@@ -212,7 +212,7 @@ SECTION(".init") of1275_device_t *intctrl_t::find_opic()
     if( !dev_bus->get_prop("device_type", &data, &len) ) {
 	printf( "Error: unable to determine the device type of the open-pic's"
 		" bus.\n" );
-	return NULL;
+	return nullptr;
     } 
     else if( !strcmp(data, "pci") )
 	dev_pci_client = dev_opic;
@@ -222,7 +222,7 @@ SECTION(".init") of1275_device_t *intctrl_t::find_opic()
 	printf( "Error: expected the open-pic to be attached to mac-io or a\n"
 		"pci bus.  But it is attached to a bus of type '%s'.\n",
 		data );
-	return NULL;
+	return nullptr;
     }
 
     /* Look for the assigned-addresses property.
@@ -247,7 +247,7 @@ SECTION(".init") of1275_device_t *intctrl_t::find_opic()
     else {
 	printf( "Error: unable to determine the address range of the open-pic's"
 		"bus.\n" );
-	return NULL;
+	return nullptr;
     }
 
     if( dev_pci_client == dev_bus )
@@ -260,7 +260,7 @@ SECTION(".init") of1275_device_t *intctrl_t::find_opic()
 	{
 	    printf( "Error: unable to find the 'reg' property of the"
 		    " open-pic.\n" );
-	    return NULL;
+	    return nullptr;
 	}
 	this->opic_paddr += opic_reg->offset;
 	this->opic_size = opic_reg->size;
@@ -337,7 +337,7 @@ SECTION(".init") void intctrl_t::init_arch()
     this->opic_size = 0;
 
     of1275_device_t *dev_opic = this->find_opic();
-    if( dev_opic == NULL )
+    if( dev_opic == nullptr )
     {
 	printf( ">> Running without an interrupt controller! <<\n" );
 	return;

--- a/kernel/src/platform/pc99/acpi.h
+++ b/kernel/src/platform/pc99/acpi.h
@@ -60,7 +60,7 @@ INLINE acpi_rsdp_t* acpi_rsdp_t::locate(addr_t addr)
 	    return r;
     };
     /* not found */
-    return NULL;
+    return nullptr;
 };
 
 #endif /* !__PLATFORM__PC99__ACPI_H__ */

--- a/kernel/src/platform/pc99/mps.h
+++ b/kernel/src/platform/pc99/mps.h
@@ -169,7 +169,7 @@ static inline mps_mp_floating_t * mps_mp_floating_t::scan(addr_t start, addr_t e
 	    return (mps_mp_floating_t*)start;
 	start = addr_offset(start, 0x10);
     }
-    return NULL;
+    return nullptr;
 }
 
 

--- a/kernel/src/platform/ppc44x/bluegene.h
+++ b/kernel/src/platform/ppc44x/bluegene.h
@@ -54,7 +54,7 @@ INLINE fdt_header_t *find_cpu( fdt_t *fdt, word_t cpu )
 	printf("FDT prop: %s\n", curr->name);
 	curr = fdt->find_next_subtree_node(curr);
     }
-    return NULL;
+    return nullptr;
 }
 
 INLINE bool get_cpu_speed( word_t cpu, word_t *cpu_hz, word_t *bus_hz )

--- a/kernel/src/platform/ppc44x/ebony.h
+++ b/kernel/src/platform/ppc44x/ebony.h
@@ -52,7 +52,7 @@ INLINE fdt_header_t *find_cpu( fdt_t *fdt, word_t cpu )
 	printf("FDT prop: %s\n", curr->name);
 	curr = fdt->find_next_subtree_node(curr);
     }
-    return NULL;
+    return nullptr;
 }
 
 INLINE bool get_cpu_speed( word_t cpu, word_t *cpu_hz, word_t *bus_hz )

--- a/src-userland/lib/sched/sched_client.cc
+++ b/src-userland/lib/sched/sched_client.cc
@@ -20,7 +20,7 @@ L4_MsgTag_t sched_send_request(const SchedRequest *req)
     L4_Word_t w[5] = { req->thread.raw, req->time_control,
                        req->processor_control, req->prio_control,
                        req->preemption_control };
-    L4_MsgPut(&msg, SCHED_LABEL, 5, w, 0, NULL);
+    L4_MsgPut(&msg, SCHED_LABEL, 5, w, 0, nullptr);
     L4_MsgLoad(&msg);
     return L4_Call(server_tid);
 }

--- a/user/apps/l4test/amd64/help.cc
+++ b/user/apps/l4test/amd64/help.cc
@@ -46,7 +46,7 @@ void setup_exreg(L4_Word_t *ip, L4_Word_t *sp, void (*func)(void))
   if (*sp == 0)
     {
       stack = (L4_Word_t*)get_pages( STACK_PAGES, 1 );
-      assert( stack != NULL );
+      assert( stack != nullptr );
       *sp = (L4_Word_t)&stack[max-1];
     }
 

--- a/user/apps/l4test/amd64/tests.cc
+++ b/user/apps/l4test/amd64/tests.cc
@@ -46,7 +46,7 @@ void all_arch_tests( void )
 
 static struct menuitem menu_items[] =
 {
-    { NULL,		"return" },
+    { nullptr,		"return" },
     { all_arch_tests,	"All AMD64 tests" },
 };
 

--- a/user/apps/l4test/exreg.cc
+++ b/user/apps/l4test/exreg.cc
@@ -76,7 +76,7 @@ dumb_exreg_thread( L4_ThreadId_t tid )
 	/* Make an invalid exreg on it */
 	control = EX_RECV | EX_SEND | EX_SP | EX_IP | EX_PAGR;
 
-	ret = L4_ExchangeRegisters( tid, control, NULL, NULL, 0, 0, pager, 
+	ret = L4_ExchangeRegisters( tid, control, nullptr, nullptr, 0, 0, pager, 
 				    &control, &sp, &pc, &flags, &user, 
 				    &pager );
 
@@ -132,8 +132,8 @@ exreg_to_null(void)
 
 	//printf( "Starting with exreg..." );
 
-	/* exreg it to the NULL */
-	do_exreg_thread_pager( L4_nilthread, tid, NULL, NULL );
+	/* exreg it to the nullptr */
+	do_exreg_thread_pager( L4_nilthread, tid, nullptr, nullptr );
 
 	/* wait a bit */
 	/* it should print out now... */
@@ -194,7 +194,7 @@ ex_thrash(void)
 	int x = 0;
 
 	/* init a new stack & all */
-	sp = NULL;
+	sp = nullptr;
 	setup_exreg( &ip, &sp, printy_thread );
 
 	/* get a TID */
@@ -243,7 +243,7 @@ ex_thrash2(void)
 	int x = 0;
 
 	/* init a new stack & all */
-	sp = NULL;
+	sp = nullptr;
 	setup_exreg( &ip, &sp, printy_thread );
 
 	/* get a TID */
@@ -369,7 +369,7 @@ void all_exreg_tests(void)
 /* the menu */
 static struct menuitem menu_items[] = 
 {
-	{ NULL, "return" },
+	{ nullptr, "return" },
 	{ exreg_ret,  "Test return value" },
 	{ exreg_g2l,  "Test global <-> local" },
 	{ ex_thrash,  "ExReg many times (with wait)" },
@@ -377,7 +377,7 @@ static struct menuitem menu_items[] =
 	{ ex_tc    ,  "ExReg then ThreadControl" },
 	{ exreg_inactive_thread,
 	  "ExchangeRegisters on inactive thread" },
-	{ exreg_to_null, "Try to start a thread with no pager (@NULL)" },
+	{ exreg_to_null, "Try to start a thread with no pager (@nullptr)" },
         { all_exreg_tests, "All exreg tests" },
 
 };

--- a/user/apps/l4test/ia32/help.cc
+++ b/user/apps/l4test/ia32/help.cc
@@ -46,7 +46,7 @@ void setup_exreg(L4_Word_t *ip, L4_Word_t *sp, void (*func)(void))
   if (*sp == 0)
     {
       stack = (L4_Word_t*)get_pages( STACK_PAGES, 1 );
-      assert( stack != NULL );
+      assert( stack != nullptr );
       *sp = (L4_Word_t)&stack[max-1];
     }
 

--- a/user/apps/l4test/ia32/tests.cc
+++ b/user/apps/l4test/ia32/tests.cc
@@ -221,7 +221,7 @@ void all_arch_tests( void )
 
 static struct menuitem menu_items[] =
 {
-    { NULL,		"return" },
+    { nullptr,		"return" },
     { exception_test,	"Exception test" },
     { ctrlxfer_test,	"CtrlXfer test" },
     { all_arch_tests,	"All IA32 tests" }

--- a/user/apps/l4test/ipc.cc
+++ b/user/apps/l4test/ipc.cc
@@ -560,7 +560,7 @@ void all_ipc_tests (void)
 
 static struct menuitem menu_items[] = 
 {
-    { NULL, 		"return" },
+    { nullptr, 		"return" },
     { simple_ipc, 	"Simple IPC" },
     { string_ipc, 
       "String copy IPC, inter address space (no pagefaults)"},

--- a/user/apps/l4test/kip.cc
+++ b/user/apps/l4test/kip.cc
@@ -299,7 +299,7 @@ void all_kip_tests(void)
 /* the menu */
 static struct menuitem menu_items[] = 
 {
-	{ NULL, "return" },
+	{ nullptr, "return" },
 	{ print_kip,  "Print KIP" },
 	{ thrash_kip, "Thrash GetKip" },
         { all_kip_tests, "All KIP tests" },

--- a/user/apps/l4test/mem.cc
+++ b/user/apps/l4test/mem.cc
@@ -73,7 +73,7 @@ void all_mem_tests()
 /* the menu */
 static struct menuitem menu_items[] = 
 {
-	{ NULL, "return" },
+	{ nullptr, "return" },
 	{ page_touch,  "Page Touch" },
 	{ all_mem_tests,  "All mem tests" },
 };

--- a/user/apps/l4test/menu.cc
+++ b/user/apps/l4test/menu.cc
@@ -52,7 +52,7 @@ print_menu( struct menu *menu )
 {
 	int i;
 
-	assert( menu != NULL );
+	assert( menu != nullptr );
 
 #if USE_ANSI
 	if( menu->clear )
@@ -81,7 +81,7 @@ get_item( struct menu *menu )
 	int ch, i;
 	void (*func)(void);
 
-	assert( menu != NULL );
+	assert( menu != nullptr );
 
 	while(1)
 	{
@@ -112,8 +112,8 @@ get_item( struct menu *menu )
 
 		func = menu->items[i].func;
 
-		/* NULL == return */
-		if( func == NULL )
+		/* nullptr == return */
+		if( func == nullptr )
 			return;
 
 #if USE_ANSI
@@ -131,7 +131,7 @@ get_item( struct menu *menu )
 void 
 menu_input( struct menu *menu )
 {
-	assert( menu != NULL );
+	assert( menu != nullptr );
 	
 	get_item( menu );
 }

--- a/user/apps/l4test/powerpc/help.cc
+++ b/user/apps/l4test/powerpc/help.cc
@@ -46,7 +46,7 @@ void setup_exreg(L4_Word_t *ip, L4_Word_t *sp, void (*func)(void))
   if (*sp == 0)
     {
       stack = (L4_Word_t*)get_pages( STACK_PAGES, 1 );
-      assert( stack != NULL );
+      assert( stack != nullptr );
       *sp = (L4_Word_t)&stack[max-1];
     }
 }

--- a/user/apps/l4test/powerpc/tests.cc
+++ b/user/apps/l4test/powerpc/tests.cc
@@ -582,7 +582,7 @@ void all_arch_tests( void )
 
 static struct menuitem menu_items[] =
 {
-    { NULL,			"return" },
+    { nullptr,			"return" },
     { generic_exc_test,		"Generic exception test" },
     { syscall_exc_test,		"Legacy system call exception test" },
     { generic_unwind_test,	"Generic exception unwind" },

--- a/user/apps/l4test/powerpc64/help.cc
+++ b/user/apps/l4test/powerpc64/help.cc
@@ -39,8 +39,8 @@ extern L4_Word_t _exreg_target;
 
 /* setup an exreg 
  *
- * *sp == NULL: allocate a new stack
- * *sp != NULL: top of sp from an old exreg used, just refresh it!
+ * *sp == nullptr: allocate a new stack
+ * *sp != nullptr: top of sp from an old exreg used, just refresh it!
  */
 void 
 setup_exreg( L4_Word_t *ip, L4_Word_t *sp, void (*func)(void) )
@@ -56,7 +56,7 @@ setup_exreg( L4_Word_t *ip, L4_Word_t *sp, void (*func)(void) )
     if( *sp == 0 )
     {
 	stack = (L4_Word_t*) get_pages( STACK_PAGES, 1 );
-	assert( stack != NULL );
+	assert( stack != nullptr );
 
 	stack = &stack[max-6];
     }

--- a/user/apps/l4test/powerpc64/tests.cc
+++ b/user/apps/l4test/powerpc64/tests.cc
@@ -40,7 +40,7 @@
 #include "1275tree.h"
 
 L4_Word_t Args[16];
-char *devtree = NULL;
+char *devtree = nullptr;
 
 /* sigma0 fpage request stuff */
 #define FP_REQUEST_LABEL ((-6UL) << 4)     /* that's what the API says! */
@@ -98,7 +98,7 @@ static char * find_1275tree(void)
 {
     L4_MemoryDesc_t * md;
     L4_KernelInterfacePage_t * kip = (L4_KernelInterfacePage_t *)
-	    L4_KernelInterface( NULL, NULL, NULL );
+	    L4_KernelInterface( nullptr, nullptr, nullptr );
 
     // Parse through all memory descriptors in kip.
     for (L4_Word_t n = 0; (md = L4_MemoryDesc (kip, n)); n++)
@@ -116,14 +116,14 @@ static char * find_1275tree(void)
 		if( request_page( (void *)i ) )
 		{
 		    printf( "Cannot get 1275 device tree memory\n" );
-		    return NULL;
+		    return nullptr;
 		}
 	    }
 	    return (char *)low;
 	}
 
     }
-    return NULL;
+    return nullptr;
 }
 
 void rtas_test(void)
@@ -186,7 +186,7 @@ void all_arch_tests( void )
 /* the menu */
 static struct menuitem menu_items[] = 
 {
-    { NULL, "return" },
+    { nullptr, "return" },
     { rtas_test,  "Test RTAS" },
     { fpu_test, "Test FPU" },
     { all_arch_tests,	"All PowerPC tests" },

--- a/user/apps/l4test/schedule.cc
+++ b/user/apps/l4test/schedule.cc
@@ -93,7 +93,7 @@ void all_schedule_tests(void)
 /* the menu */
 static struct menuitem menu_items[] = 
 {
-	{ NULL, "return" },
+	{ nullptr, "return" },
 	{ test_irq_priority_unassociated,  
 	  "Change irq thread priority of an unassociated thread" },
 	{ test_irq_priority_associated,  

--- a/user/apps/l4test/sig0.cc
+++ b/user/apps/l4test/sig0.cc
@@ -191,7 +191,7 @@ void all_s0_tests(void)
 /* the menu */
 static struct menuitem menu_items[] = 
 {
-	{ NULL, "return" },
+	{ nullptr, "return" },
 	{ request_mem,  "Request Memory" },
 	{ bad_send,     "Phony Send" },
 	{ bad_recv,     "Phony Receive" },

--- a/user/apps/l4test/tcontrol.cc
+++ b/user/apps/l4test/tcontrol.cc
@@ -70,7 +70,7 @@ run_a_thread(void)
 	L4_ThreadId_t tid;
 
 	/* init a new stack & all */
-	sp = NULL;
+	sp = nullptr;
 	setup_exreg( &ip, &sp, printy_thread );
 
 	/* get a TID */
@@ -108,7 +108,7 @@ tc_then_exreg(void)
 	L4_ThreadId_t tid;
 
 	/* init a new stack & all */
-	sp = NULL;
+	sp = nullptr;
 	setup_exreg( &ip, &sp, print_ok_thread );
 
 	/* get a TID */
@@ -152,7 +152,7 @@ void all_tc_tests(void)
 /* the menu */
 static struct menuitem menu_items[] = 
 {
-	{ NULL, "return" },
+	{ nullptr, "return" },
 	{ run_a_thread,  "Run a thread" },
 	{ delete_self,  "Delete self" },
 	{ tc_then_exreg, "ThreadControl + ExReg" },

--- a/user/contrib/elf-loader/platform/amd64-pc99/bootloader.cc
+++ b/user/contrib/elf-loader/platform/amd64-pc99/bootloader.cc
@@ -34,7 +34,7 @@
 #include "globals.h"
 
 
-/* L4µK */
+/* L4ÂµK */
 static char kip_magic[] = {'L', '4', 230, 'K'};
 
 
@@ -69,7 +69,7 @@ extern "C" void startup(struct multiboot_info *mb_info, unsigned int mb_magic ){
 
     
     /* Check Kernel */
-    if ((kernel_ehdr = valid_elf64((L4_Word_t)_binary_kernel_mod_start, &kernel_entry_addr)) == NULL){
+    if ((kernel_ehdr = valid_elf64((L4_Word_t)_binary_kernel_mod_start, &kernel_entry_addr)) == nullptr){
 	printf("PANIC: Wrong kernel image format at 0x%x!\n", (L4_Word_t) &_binary_kernel_mod_start);
 	spin(1);
     }
@@ -145,7 +145,7 @@ extern "C" void startup(struct multiboot_info *mb_info, unsigned int mb_magic ){
     L4_Word64_t sigma0_start;
     L4_Word64_t sigma0_end;
       
-    if ((module_ehdr = valid_elf64(modules[0].mod_start, &sigma0_entry)) == NULL){
+    if ((module_ehdr = valid_elf64(modules[0].mod_start, &sigma0_entry)) == nullptr){
 	printf("PANIC: Wrong sigma0 image format at 0x%x!\n", (L4_Word_t) sigma0_entry);
 	spin(1);
 	 	
@@ -166,7 +166,7 @@ extern "C" void startup(struct multiboot_info *mb_info, unsigned int mb_magic ){
     L4_Word64_t root_start;
     L4_Word64_t root_end;
       
-    if ((module_ehdr = valid_elf64(modules[1].mod_start, &root_entry)) == NULL){
+    if ((module_ehdr = valid_elf64(modules[1].mod_start, &root_entry)) == nullptr){
 	printf("PANIC: Wrong root image format at 0x%x!\n", (L4_Word_t) root_entry);
 	spin(1);
 	 	

--- a/user/contrib/elf-loader/platform/amd64-pc99/elf.cc
+++ b/user/contrib/elf-loader/platform/amd64-pc99/elf.cc
@@ -34,10 +34,10 @@
 
 Elf64_Shdr *elf64_next_shdr(Elf64_Ehdr *ehdr, int *index)						
 {														
-    Elf64_Shdr *result = NULL;
+    Elf64_Shdr *result = nullptr;
 
     if (*index < 0 )
-	return NULL;
+	return nullptr;
     
     while(*index < ehdr->e_shnum){
 	result = (Elf64_Shdr *)(((L4_Word_t) ehdr) + (L4_Word_t)ehdr->e_shoff + *(index) * ehdr->e_shentsize);	
@@ -48,15 +48,15 @@ Elf64_Shdr *elf64_next_shdr(Elf64_Ehdr *ehdr, int *index)
 	}
 	
     }
-    return NULL;													
+    return nullptr;													
 }													
 
 Elf64_Phdr *elf64_next_phdr(Elf64_Ehdr *ehdr, int *index)						
 {														
-    Elf64_Phdr *result = NULL;
+    Elf64_Phdr *result = nullptr;
 
     if (*index < 0)
-	return NULL;
+	return nullptr;
     
     while(*index < ehdr->e_phnum){
 	result = (Elf64_Phdr *)(((L4_Word_t) ehdr) + (L4_Word_t) ehdr->e_phoff + *index * ehdr->e_phentsize);	
@@ -67,7 +67,7 @@ Elf64_Phdr *elf64_next_phdr(Elf64_Ehdr *ehdr, int *index)
 	}
 	
     }
-    return NULL;
+    return nullptr;
 }													
 														
 Elf64_Ehdr *valid_elf64(L4_Word_t addr,  L4_Word64_t *entry)					
@@ -78,14 +78,14 @@ Elf64_Ehdr *valid_elf64(L4_Word_t addr,  L4_Word64_t *entry)
        e_ident[EI_MAG1] != ELFMAG1 ||										
        e_ident[EI_MAG2] != ELFMAG2 ||										
        e_ident[EI_MAG3] != ELFMAG3)										
-        return NULL;												
+        return nullptr;												
 														
     if(e_ident[EI_CLASS] != ELFCLASS64)									
-        return NULL;												
+        return nullptr;												
 														
     /* Possibly allow for old elf formats */									
     if(e_ident[EI_VERSION] != EV_CURRENT)									
-        return NULL;												
+        return nullptr;												
 														
     Elf64_Ehdr *ehdr = (Elf64_Ehdr *) addr;								
     

--- a/user/contrib/elf-loader/platform/amd64-pc99/mini-print.cc
+++ b/user/contrib/elf-loader/platform/amd64-pc99/mini-print.cc
@@ -96,7 +96,7 @@ int printf(const char* format, ...)
 #define arg(x) va_arg (ap, L4_Word_t)
 
     /* sanity check */
-    if (format == NULL)
+    if (format == nullptr)
 	return 0;
 
     while (*format)

--- a/user/contrib/elf-loader/platform/amd64-pc99/string.cc
+++ b/user/contrib/elf-loader/platform/amd64-pc99/string.cc
@@ -36,7 +36,7 @@
  
 #include <l4/types.h>
 #include "globals.h"
-char * ___strtok = NULL;
+char * ___strtok = nullptr;
 
 char * strcpy(char * dest,const char *src)
 {
@@ -114,13 +114,13 @@ char * strchr(const char * s,char c)
 {
 	for(; *s != c; ++s)
 		if (*s == '\0')
-			return NULL;
+			return nullptr;
 	return (char *) s;
 }
 
 char * strrchr(const char * s,char c)
 {
-	const char * r = NULL;
+	const char * r = nullptr;
 	while (*s++)
 		if (*s == c) r = s;
 	return (char *) r;
@@ -173,7 +173,7 @@ char * strpbrk(const char * cs,const char * ct)
 				return (char *) sc1;
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 char * strtok(char * s,const char * ct)
@@ -182,12 +182,12 @@ char * strtok(char * s,const char * ct)
 
 	sbegin  = s ? s : ___strtok;
 	if (!sbegin) {
-		return NULL;
+		return nullptr;
 	}
 	sbegin += strspn(sbegin,ct);
 	if (*sbegin == '\0') {
-		___strtok = NULL;
-		return( NULL );
+		___strtok = nullptr;
+		return( nullptr );
 	}
 	send = strpbrk( sbegin, ct);
 	if (send && *send != '\0')

--- a/user/lib/io/print.cc
+++ b/user/lib/io/print.cc
@@ -161,7 +161,7 @@ int __l4_vsnprintf(char *str, L4_Size_t size, const char *fmt, va_list ap)
     /*
      * Sanity check on fmt string.
      */
-    if ( fmt == NULL ) {
+    if ( fmt == nullptr ) {
 	PUTSTR( "(null fmt string)" );
 	goto Done;
     }
@@ -505,7 +505,7 @@ int __l4_vsnprintf(char *str, L4_Size_t size, const char *fmt, va_list ap)
 	    /*
 	     * Sanity check.
 	     */
-	    if ( string == NULL ) {
+	    if ( string == nullptr ) {
 		PUTSTR( "(null)" );
 		break;
 	    }
@@ -581,7 +581,7 @@ int __l4_snprintf(char *str, L4_Size_t size, const char *fmt, ...)
     /*
      * Safety check
      */
-    if ( fmt == NULL )
+    if ( fmt == nullptr )
 	return 0;
 
     /*
@@ -609,7 +609,7 @@ int __l4_printf(const char *fmt, ...)
     /*
      * Safety check
      */
-    if ( fmt == NULL )
+    if ( fmt == nullptr )
 	return 0;
 
     /*

--- a/user/lib/l4/amd64.cc
+++ b/user/lib/l4/amd64.cc
@@ -36,18 +36,18 @@
 #define NULL 0
 #endif
 
-__L4_Ipc_t __L4_Ipc = NULL;
-__L4_Lipc_t __L4_Lipc = NULL;
-__L4_Unmap_t __L4_Unmap = NULL;
-__L4_Schedule_t __L4_Schedule = NULL;
-__L4_ThreadSwitch_t __L4_ThreadSwitch = NULL;
-__L4_SystemClock_t __L4_SystemClock = NULL;
-__L4_ExchangeRegisters_t __L4_ExchangeRegisters = NULL;
+__L4_Ipc_t __L4_Ipc = nullptr;
+__L4_Lipc_t __L4_Lipc = nullptr;
+__L4_Unmap_t __L4_Unmap = nullptr;
+__L4_Schedule_t __L4_Schedule = nullptr;
+__L4_ThreadSwitch_t __L4_ThreadSwitch = nullptr;
+__L4_SystemClock_t __L4_SystemClock = nullptr;
+__L4_ExchangeRegisters_t __L4_ExchangeRegisters = nullptr;
 
-__L4_ThreadControl_t __L4_ThreadControl = NULL;
-__L4_SpaceControl_t __L4_SpaceControl = NULL;
-__L4_ProcessorControl_t __L4_ProcessorControl = NULL;
-__L4_MemoryControl_t __L4_MemoryControl = NULL;
+__L4_ThreadControl_t __L4_ThreadControl = nullptr;
+__L4_SpaceControl_t __L4_SpaceControl = nullptr;
+__L4_ProcessorControl_t __L4_ProcessorControl = nullptr;
+__L4_MemoryControl_t __L4_MemoryControl = nullptr;
 
 extern "C" void __L4_Init( void )
 {

--- a/user/lib/l4/powerpc.cc
+++ b/user/lib/l4/powerpc.cc
@@ -35,22 +35,22 @@
 #define NULL 0
 #endif
 
-__L4_Ipc_t __L4_Ipc = NULL;
-__L4_Lipc_t __L4_Lipc = NULL;
-__L4_Unmap_t __L4_Unmap = NULL;
-__L4_Schedule_t __L4_Schedule = NULL;
-__L4_ThreadSwitch_t __L4_ThreadSwitch = NULL;
-__L4_SystemClock_t __L4_SystemClock = NULL;
-__L4_ExchangeRegisters_t __L4_ExchangeRegisters = NULL;
+__L4_Ipc_t __L4_Ipc = nullptr;
+__L4_Lipc_t __L4_Lipc = nullptr;
+__L4_Unmap_t __L4_Unmap = nullptr;
+__L4_Schedule_t __L4_Schedule = nullptr;
+__L4_ThreadSwitch_t __L4_ThreadSwitch = nullptr;
+__L4_SystemClock_t __L4_SystemClock = nullptr;
+__L4_ExchangeRegisters_t __L4_ExchangeRegisters = nullptr;
 
-__L4_ThreadControl_t __L4_ThreadControl = NULL;
-__L4_SpaceControl_t __L4_SpaceControl = NULL;
-__L4_ProcessorControl_t __L4_ProcessorControl = NULL;
-__L4_MemoryControl_t __L4_MemoryControl = NULL;
+__L4_ThreadControl_t __L4_ThreadControl = nullptr;
+__L4_SpaceControl_t __L4_SpaceControl = nullptr;
+__L4_ProcessorControl_t __L4_ProcessorControl = nullptr;
+__L4_MemoryControl_t __L4_MemoryControl = nullptr;
 
 extern "C" void __L4_Init( void )
 {
-    L4_KernelInterfacePage_t *kip = (L4_KernelInterfacePage_t *) L4_KernelInterface( NULL, NULL, NULL );
+    L4_KernelInterfacePage_t *kip = (L4_KernelInterfacePage_t *) L4_KernelInterface( nullptr, nullptr, nullptr );
 
 #define KIP_RELOC(a) (a)
 

--- a/user/lib/l4/powerpc64.cc
+++ b/user/lib/l4/powerpc64.cc
@@ -35,26 +35,26 @@
 #define NULL 0
 #endif
 
-__L4_Ipc_t __L4_Ipc = NULL;
-__L4_Lipc_t __L4_Lipc = NULL;
-__L4_Unmap_t __L4_Unmap = NULL;
-__L4_Schedule_t __L4_Schedule = NULL;
-__L4_ThreadSwitch_t __L4_ThreadSwitch = NULL;
-__L4_SystemClock_t __L4_SystemClock = NULL;
-__L4_ExchangeRegisters_t __L4_ExchangeRegisters = NULL;
+__L4_Ipc_t __L4_Ipc = nullptr;
+__L4_Lipc_t __L4_Lipc = nullptr;
+__L4_Unmap_t __L4_Unmap = nullptr;
+__L4_Schedule_t __L4_Schedule = nullptr;
+__L4_ThreadSwitch_t __L4_ThreadSwitch = nullptr;
+__L4_SystemClock_t __L4_SystemClock = nullptr;
+__L4_ExchangeRegisters_t __L4_ExchangeRegisters = nullptr;
 
-__L4_ThreadControl_t __L4_ThreadControl = NULL;
-__L4_SpaceControl_t __L4_SpaceControl = NULL;
-__L4_ProcessorControl_t __L4_ProcessorControl = NULL;
-__L4_MemoryControl_t __L4_MemoryControl = NULL;
+__L4_ThreadControl_t __L4_ThreadControl = nullptr;
+__L4_SpaceControl_t __L4_SpaceControl = nullptr;
+__L4_ProcessorControl_t __L4_ProcessorControl = nullptr;
+__L4_MemoryControl_t __L4_MemoryControl = nullptr;
 
-__L4_RtasCall_t __L4_RtasCall = NULL;
+__L4_RtasCall_t __L4_RtasCall = nullptr;
 
 void __L4_Init( void )
 {
     L4_KernelInterfacePage_t *kip;
     
-    kip = L4_KernelInterface( NULL, NULL, NULL );
+    kip = L4_KernelInterface( nullptr, nullptr, nullptr );
 
 #define KIP_RELOC(a) ((L4_Word_t)kip + a)
 

--- a/user/serv/sigma0/region.cc
+++ b/user/serv/sigma0/region.cc
@@ -344,7 +344,7 @@ void region_list_t::add (L4_Paddr_t addr, L4_Word_t size)
 {
     if (addr == 0)
     {
-	// Avoid inserting a NULL pointer into the list.
+	// Avoid inserting a nullptr pointer into the list.
 	addr += sizeof (region_listent_t);
 	size -= sizeof (region_listent_t);
     }
@@ -365,7 +365,7 @@ void region_list_t::add (L4_Paddr_t addr, L4_Word_t size)
 L4_Word_t region_list_t::contents (void)
 {
     L4_Word_t n = 0;
-    for (region_listent_t * m = list; m != NULL; m = m->next ())
+    for (region_listent_t * m = list; m != nullptr; m = m->next ())
 	n++;
     return n;
 }
@@ -392,9 +392,9 @@ region_t * region_list_t::alloc (void)
 		L4_KDB_Enter ("s0: out of memory");
 	}
 
-	bool was_alloced = (list == NULL);
+	bool was_alloced = (list == nullptr);
 	if (! was_alloced)
-	    list = (region_listent_t *) NULL;
+	    list = (region_listent_t *) nullptr;
 
 	// Add newly allocated memory to pool.
 	add (L4_Address (L4_SndFpage (dummy)), (1UL << min_pgsize));
@@ -565,7 +565,7 @@ void region_pool_t::dump (void)
 {
     region_t * r;
     reset ();
-    while ((r = next ()) != NULL)
+    while ((r = next ()) != nullptr)
     {
 	printf ("s0:  %p-%p   %p %s\n",
 		(void *) r->low, (void *) r->high,
@@ -587,7 +587,7 @@ void region_pool_t::reset (void)
 region_t * region_pool_t::next (void)
 {
     if (ptr == &last)
-	return (region_t *) NULL;
+	return (region_t *) nullptr;
     region_t * ret = ptr;
     ptr = ptr->next;
     return ret;

--- a/user/serv/sigma0/sigma0_io.cc
+++ b/user/serv/sigma0/sigma0_io.cc
@@ -87,7 +87,7 @@ bool allocate_iopage (L4_ThreadId_t tid, L4_Fpage_t iofp, L4_MapItem_t & map)
 
     io_pool.reset ();
     
-    while ((r = io_pool.next ()) != NULL)
+    while ((r = io_pool.next ()) != nullptr)
     {
 	if (r->low > addr_high || r->high < addr)
 	    continue;
@@ -105,7 +105,7 @@ bool allocate_iopage (L4_ThreadId_t tid, L4_Fpage_t iofp, L4_MapItem_t & map)
 
     // Check if memory has already been allocated.
     io_alloc_pool.reset ();
-    while ((r = io_alloc_pool.next ()) != NULL)
+    while ((r = io_alloc_pool.next ()) != nullptr)
     {
 	if (r->can_allocate (addr, log2size, tid))
 	{
@@ -120,7 +120,7 @@ bool allocate_iopage (L4_ThreadId_t tid, L4_Fpage_t iofp, L4_MapItem_t & map)
 
     region_pool_t * all_io_pools[] = { &io_pool,
 					  &io_alloc_pool,
-					  (region_pool_t *) NULL };
+					  (region_pool_t *) nullptr };
     
     // Loop once for checking followed by once for allocating
     for (L4_Word_t phase = 0; phase < 2; phase++)
@@ -132,10 +132,10 @@ bool allocate_iopage (L4_ThreadId_t tid, L4_Fpage_t iofp, L4_MapItem_t & map)
 	    bool failed = true;
 
 	    // Try the different pools
-	    for (L4_Word_t i = 0; failed && all_io_pools[i] != NULL; i++)
+	    for (L4_Word_t i = 0; failed && all_io_pools[i] != nullptr; i++)
 	    {
 		all_io_pools[i]->reset ();
-		while ((r = all_io_pools[i]->next ()) != NULL)
+		while ((r = all_io_pools[i]->next ()) != nullptr)
 		{
 		    if (r->low > a_end || r->high < a)
 			continue;

--- a/user/serv/sigma0/sigma0_mem.cc
+++ b/user/serv/sigma0/sigma0_mem.cc
@@ -327,17 +327,17 @@ bool allocate_page (L4_ThreadId_t tid, L4_Paddr_t addr, L4_Word_t log2size,
     }
 
     region_pool_t * pools[] = { &conv_memory_pool, &memory_pool,
-				(region_pool_t *) NULL };
+				(region_pool_t *) nullptr };
 
     // Check if we only want to try the conventional memory pool
     if (only_conventional)
-	pools[1] = (region_pool_t *) NULL;
+	pools[1] = (region_pool_t *) nullptr;
 
     // Try allocating from one of the memory pools.
-    for (L4_Word_t i = 0; pools[i] != NULL; i++)
+    for (L4_Word_t i = 0; pools[i] != nullptr; i++)
     {
 	pools[i]->reset ();
-	while ((r = pools[i]->next ()) != NULL)
+	while ((r = pools[i]->next ()) != nullptr)
 	{
 	    if (r->low > addr_high || r->high < addr)
 		continue;
@@ -354,7 +354,7 @@ bool allocate_page (L4_ThreadId_t tid, L4_Paddr_t addr, L4_Word_t log2size,
 
     // Check if memory has already been allocated.
     alloc_pool.reset ();
-    while ((r = alloc_pool.next ()) != NULL)
+    while ((r = alloc_pool.next ()) != nullptr)
     {
 	if (r->can_allocate (addr, log2size, tid))
 	{
@@ -369,11 +369,11 @@ bool allocate_page (L4_ThreadId_t tid, L4_Paddr_t addr, L4_Word_t log2size,
     region_pool_t * allpools[] = { &conv_memory_pool,
 				   &alloc_pool,
 				   &memory_pool,
-				   (region_pool_t *) NULL };
+				   (region_pool_t *) nullptr };
 
     // Check if we only want to try the conventional memory pool
     if (only_conventional)
-	allpools[2] = (region_pool_t *) NULL;
+	allpools[2] = (region_pool_t *) nullptr;
 
     // Loop once for checking followed by once for allocating
     for (L4_Word_t phase = 0; phase < 2; phase++)
@@ -386,10 +386,10 @@ bool allocate_page (L4_ThreadId_t tid, L4_Paddr_t addr, L4_Word_t log2size,
 	    bool failed = true;
 
 	    // Try the different pools
-	    for (L4_Word_t i = 0; failed && allpools[i] != NULL; i++)
+	    for (L4_Word_t i = 0; failed && allpools[i] != nullptr; i++)
 	    {
 		allpools[i]->reset ();
-		while ((r = allpools[i]->next ()) != NULL)
+		while ((r = allpools[i]->next ()) != nullptr)
 		{
 		    if (r->low > a_end || r->high < a)
 			continue;
@@ -446,7 +446,7 @@ bool allocate_page (L4_ThreadId_t tid, L4_Word_t log2size, L4_MapItem_t & map)
 
     // Try allocating memory from pool of real memory.
     conv_memory_pool.reset ();
-    while ((r = conv_memory_pool.next ()) != NULL)
+    while ((r = conv_memory_pool.next ()) != nullptr)
     {
 	fp = r->allocate (log2size, tid, L4_FpageLog2);
 	if (! L4_IsNilFpage (fp))

--- a/user/util/kickstart/elf.cc
+++ b/user/util/kickstart/elf.cc
@@ -297,8 +297,8 @@ bool __elf_func(elf_find_sections) (L4_Word_t addr,
  * @param memory_start  Pointer to address of first byte of loaded image
  * @param memory_end    Pointer to address of first byte behind loaded image
  * @param entry         Pointer to address of entry point
- * @param type          Pointer to ELF format ID (1: 32-bit, 2: 64-bit), may be NULL
- * @param check         Pointer to function to check for memory conflicts, may be NULL
+ * @param type          Pointer to ELF format ID (1: 32-bit, 2: 64-bit), may be nullptr
+ * @param check         Pointer to function to check for memory conflicts, may be nullptr
  *
  * This function ELF-loads an ELF image that is located in memory.  It
  * interprets the program header table and copies all segments marked

--- a/user/util/kickstart/kickstart.h
+++ b/user/util/kickstart/kickstart.h
@@ -68,7 +68,7 @@ public:
 
 
 /**
- * NULL terminated array of loader formats.
+ * nullptr terminated array of loader formats.
  */
 extern loader_format_t loader_formats[];
 

--- a/user/util/kickstart/mbi-loader.cc
+++ b/user/util/kickstart/mbi-loader.cc
@@ -158,7 +158,7 @@ bool load_modules (void)
                 }                                                           \
             } while(0)
 
-            LOADIT(0, " kernel  ", NULL);
+            LOADIT(0, " kernel  ", nullptr);
             LOADIT(1, " sigma0  ", &sigma0_type);
             LOADIT(2, " roottask", &root_task_type);
         }
@@ -173,7 +173,7 @@ bool load_modules (void)
 	    for (L4_Word_t i = 3; i < mbi->modcount; i++)
 		elf_load (mbi->mods[i].start, mbi->mods[i].end,
 			  &mbi->mods[i].start, &mbi->mods[i].end,
-			  &mbi->mods[i].entry, NULL, check_memory);
+			  &mbi->mods[i].entry, nullptr, check_memory);
 	}
 
 	return true;
@@ -260,7 +260,7 @@ mbi_t * install_mbi (kip_manager_t* kip)
  * the architecture/kernel.  The bootinfo structure is additionally
  * recorded in a memory descriptor in the KIP.
  *
- * @returns pointer to newly allocated bootinfo structure, or NULL if
+ * @returns pointer to newly allocated bootinfo structure, or nullptr if
  * unable to allocate memory to hold the structure.
  */
 void * create_bootinfo (kip_manager_t * kip)
@@ -269,7 +269,7 @@ void * create_bootinfo (kip_manager_t * kip)
     L4_Word_t bi = find_free_mem_region (max_bootinfo_size, kip);
 
     if (!bi)
-	return NULL;
+	return nullptr;
 
     // Protect bootinfo structure
     kip->dedicate_memory (bi,
@@ -288,7 +288,7 @@ bool mbi_probe (void)
 {
     mbi_t * _mbi = mbi_t::prepare();
 
-    if (_mbi == NULL)
+    if (_mbi == nullptr)
 	return false;
 
     // Make a safe copy of the MBI structure itself.
@@ -318,7 +318,7 @@ L4_Word_t mbi_init (void)
 {
     kip_manager_t kip;
 
-    void * bi = NULL;
+    void * bi = nullptr;
     bool use_bootinfo = true;
     bool use_mbi = true;
 
@@ -355,7 +355,7 @@ L4_Word_t mbi_init (void)
 	COPY_STRING (mbi->cmdline);
 
 #define PARSENUM(name, var, msg, massage...)			\
-        if ((p = strstr(mbi->cmdline, name"=")) != NULL)	\
+        if ((p = strstr(mbi->cmdline, name"=")) != nullptr)	\
         {							\
             var = strtoul(p+strlen(name)+1, &p, 10);		\
             if (*p == 'K') var*=1024;				\
@@ -372,7 +372,7 @@ L4_Word_t mbi_init (void)
         }
 
 #define PARSEBOOL(name, var, msg)				\
-	if ((p = strstr (mbi->cmdline, name"=")) != NULL)	\
+	if ((p = strstr (mbi->cmdline, name"=")) != nullptr)	\
 	{							\
 	    p = strchr (p, '=') + 1;				\
 	    if (strncmp (p, "yes", 3) == 0 ||			\
@@ -462,7 +462,7 @@ L4_Word_t mbi_init (void)
 #if defined(L4_32BIT) || defined(ALSO_BOOTINFO32)
     if (root_task_type == 1)
     {
-	BI32::L4_BootRec_t * rec = NULL;
+	BI32::L4_BootRec_t * rec = nullptr;
 
 	if (use_bootinfo)
 	{
@@ -499,7 +499,7 @@ L4_Word_t mbi_init (void)
 #if defined(L4_64BIT) || defined(ALSO_BOOTINFO64)
     if (root_task_type == 2)
     {
-	BI64::L4_BootRec_t * rec = NULL;
+	BI64::L4_BootRec_t * rec = nullptr;
 
 	if (use_bootinfo)
 	{


### PR DESCRIPTION
## Summary
- replace uses of `NULL` with `nullptr` in C++ sources and headers
- keep integral `NULL` macros for C compatibility
- verify build with `make`

## Testing
- `make`