### PR TITLE
Add scoped spinlock helper

### DIFF
--- a/kernel/kdb/api/v4/schedule-hs.cc
+++ b/kernel/kdb/api/v4/schedule-hs.cc
@@ -124,7 +124,7 @@ static void show_prio_queue( int depth, scheduler_t *scheduler, prio_queue_t *pr
 
 CMD(cmd_show_sched, cg)
 {
-    present_list_lock.lock();
+    scoped_spinlock guard(present_list_lock);
     printf("\n");
     
     for (cpuid_t cpu = 0; cpu < cpu_t::count; cpu++)
@@ -139,7 +139,6 @@ CMD(cmd_show_sched, cg)
     }
     printf("idle : %p\n\n", get_idle_tcb());
 
-    present_list_lock.unlock();
     return CMD_NOQUIT;
 }
 

--- a/kernel/kdb/api/v4/schedule-rr.cc
+++ b/kernel/kdb/api/v4/schedule-rr.cc
@@ -47,7 +47,7 @@ DECLARE_CMD(cmd_show_sched_empty, root, 'Q', "showqueue",  "show scheduling queu
 static void show_sched_queue(bool empty)
 {
     int abort = 1000000;
-    present_list_lock.lock();
+    scoped_spinlock guard(present_list_lock);
 
     for (cpuid_t cpu = 0; cpu < cpu_t::count; cpu++)
     {
@@ -118,7 +118,6 @@ static void show_sched_queue(bool empty)
 	}
     }
     printf("idle : %t\n\n", get_idle_tcb());
-    present_list_lock.unlock();
     return;
 }
 

--- a/kernel/kdb/api/v4/space.cc
+++ b/kernel/kdb/api/v4/space.cc
@@ -40,7 +40,7 @@ DECLARE_CMD(cmd_list_spaces, root, 'S', "listspaces",  "list all address spaces"
 
 CMD(cmd_list_spaces, cg)
 {
-    spaces_list_lock.lock();
+    scoped_spinlock guard(spaces_list_lock);
     space_t * walk = global_spaces_list;
 
     do {
@@ -64,7 +64,6 @@ CMD(cmd_list_spaces, cg)
 	walk = walk->get_spaces_list().next;
     } while (walk != global_spaces_list);
 
-    spaces_list_lock.unlock();
     return CMD_NOQUIT;
 }
 

--- a/kernel/kdb/generic/print.cc
+++ b/kernel/kdb/generic/print.cc
@@ -278,7 +278,7 @@ int SECTION(SEC_KDEBUG) do_printf(const char* format_p, va_list args)
     
 #define arg(x) va_arg(args, x)
     
-    printf_spin_lock.lock();
+    scoped_spinlock guard(printf_spin_lock);
     
     /* sanity check */
     if (format == NULL)
@@ -414,7 +414,6 @@ int SECTION(SEC_KDEBUG) do_printf(const char* format_p, va_list args)
     }
     
 done:
-    printf_spin_lock.unlock();
     return n;
 }
 

--- a/kernel/kdb/platform/ofppc/of1275.cc
+++ b/kernel/kdb/platform/ofppc/of1275.cc
@@ -85,7 +85,7 @@ of1275_phandle_t of1275_client_interface_t::find_device( const char *name )
     if( (sizeof(this->args.find_device) + namelen) > sizeof(this->args.shared) )
 	return OF1275_INVALID_PHANDLE;
 
-    this->ci_lock.lock();
+    scoped_spinlock guard(this->ci_lock);
 
     // Install all parameters in the shared data area.
     this->args.find_device.service = "finddevice";
@@ -100,7 +100,6 @@ of1275_phandle_t of1275_client_interface_t::find_device( const char *name )
 
     of1275_phandle_t ret = this->args.find_device.phandle;
 
-    this->ci_lock.unlock();
     return ret;
 }
 
@@ -109,7 +108,7 @@ int of1275_client_interface_t::get_prop( of1275_phandle_t phandle,
 {
     int ret = -1;
 
-    this->ci_lock.lock();
+    scoped_spinlock guard(this->ci_lock);
 
     // Initialize the argument structure, fitting all data within our
     // shared memory region.
@@ -142,7 +141,6 @@ int of1275_client_interface_t::get_prop( of1275_phandle_t phandle,
 	}
     }
 
-    this->ci_lock.unlock();
     return ret;
 }
 
@@ -155,7 +153,7 @@ int of1275_client_interface_t::write( of1275_phandle_t phandle,
     if( (len + sizeof(this->args.write)) > sizeof(this->args.shared) )
 	len = sizeof(this->args.shared) - sizeof(this->args.write);
 
-    this->ci_lock.lock();
+    scoped_spinlock guard(this->ci_lock);
 
     // Initialize the argument structure, fitting all data within our
     // shared data region.
@@ -172,7 +170,6 @@ int of1275_client_interface_t::write( of1275_phandle_t phandle,
     this->ci( &this->args.write );
     ret = this->args.write.actual;
 
-    this->ci_lock.unlock();
     return ret;
 }
 
@@ -181,7 +178,7 @@ int of1275_client_interface_t::read( of1275_phandle_t phandle,
 {
     int ret = -1;
 
-    this->ci_lock.lock();
+    scoped_spinlock guard(this->ci_lock);
 
     // Adjust the size of the requested data to fit our shared buffer size.
     if( (len + sizeof(this->args.read)) > sizeof(this->args.shared) )
@@ -207,13 +204,12 @@ int of1275_client_interface_t::read( of1275_phandle_t phandle,
     else
 	ret = -1;
 
-    this->ci_lock.unlock();
     return ret;
 }
 
 void of1275_client_interface_t::exit()
 {
-    this->ci_lock.lock();
+    scoped_spinlock guard(this->ci_lock);
 
     // Pack the arguments into our shared data region.
     this->args.simple.service = "exit";
@@ -224,12 +220,12 @@ void of1275_client_interface_t::exit()
     this->ci( &this->args.simple );
 
     // Hopefully the Open Firmware will never return to us ...
-    this->ci_lock.unlock();
+
 }
 
 void of1275_client_interface_t::enter()
 {
-    this->ci_lock.lock();
+    scoped_spinlock guard(this->ci_lock);
 
     // Pack the arguments into our shared data region.
     this->args.simple.service = "enter";
@@ -239,7 +235,6 @@ void of1275_client_interface_t::enter()
     // Invoke OF.
     this->ci( &this->args.simple );
 
-    this->ci_lock.unlock();
 }
 
 int of1275_client_interface_t::interpret( const char *forth )
@@ -250,7 +245,7 @@ int of1275_client_interface_t::interpret( const char *forth )
     if( (forth_len + sizeof(this->args.interpret)) > sizeof(this->args.shared))
 	return ret;
 
-    this->ci_lock.lock();
+    scoped_spinlock guard(this->ci_lock);
 
     // Pack the arguments into our shared data region.
     this->args.interpret.service = "interpret";
@@ -264,13 +259,12 @@ int of1275_client_interface_t::interpret( const char *forth )
     this->ci( &this->args.interpret );
     ret = this->args.interpret.result;
 
-    this->ci_lock.unlock();
     return ret;
 }
 
 void of1275_client_interface_t::quiesce()
 {
-    this->ci_lock.lock();
+    scoped_spinlock guard(this->ci_lock);
 
     // Pack the arguments into our shared data region.
     this->args.simple.service = "quiesce";
@@ -283,7 +277,6 @@ void of1275_client_interface_t::quiesce()
     // Prevent any further invocations of Open Firmware.
     this->entry = NULL;
 
-    this->ci_lock.unlock();
 }
 
 #endif	/* CONFIG_KDB_CONS_OF1275 */

--- a/kernel/kdb/platform/ofppc/ofppc.cc
+++ b/kernel/kdb/platform/ofppc/ofppc.cc
@@ -213,7 +213,7 @@ word_t of1275_space_t::execute_of1275( word_t (*func)(void *), void *param )
     word_t result;
     word_t *sp;
 
-    this->lock.lock();
+    scoped_spinlock guard(this->lock);
 
     // Choose a stack.  Note: to avoid TLB faults, it is important that we 
     // use a stack mapped by a bat register.  It is also important to use a 
@@ -236,7 +236,6 @@ word_t of1275_space_t::execute_of1275( word_t (*func)(void *), void *param )
 	    this->current_ptab_loc, this->current_segments,
 	    this->of1275_stack_top-16, func, param );
 
-    this->lock.unlock();
 
     return result;
 }

--- a/kernel/src/api/v4/processor.cc
+++ b/kernel/src/api/v4/processor.cc
@@ -67,7 +67,7 @@ init_cpu(cpuid_t processor, word_t external_freq, word_t internal_freq)
 {
     TRACE_INIT("\tRegistering processor %d in KIP (%dMHz, %dMHz)\n", 
 	       processor, external_freq/1000, internal_freq/1000);
-    kiplock.lock();
+    scoped_spinlock guard(kiplock);
 
     procdesc_t * pdesc = get_kip()->processor_info.get_procdesc(processor);
     ASSERT (pdesc);
@@ -79,5 +79,4 @@ init_cpu(cpuid_t processor, word_t external_freq, word_t internal_freq)
     if ( get_kip()->processor_info.processors < processor )
 	get_kip()->processor_info.processors = processor;
     
-    kiplock.unlock();
 }

--- a/kernel/src/arch/powerpc/sync.h
+++ b/kernel/src/arch/powerpc/sync.h
@@ -46,6 +46,8 @@ public: // to allow initializers
     volatile word_t _lock;
 };
 
+class scoped_spinlock;
+
 #define DECLARE_SPINLOCK(name) extern spinlock_t name;
 #define DEFINE_SPINLOCK(name) spinlock_t name = {_lock: 0}
 

--- a/kernel/src/arch/powerpc64/rtas.cc
+++ b/kernel/src/arch/powerpc64/rtas.cc
@@ -184,11 +184,10 @@ word_t rtas_t::rtas_call( u32_t token, u32_t nargs, u32_t nret, word_t *outputs,
 	rtas_args.set_arg( i, (rtas_arg_t)(va_arg(list, word_t) & 0xffffffff));
     va_end(list);
 
-    this->lock.lock();
+    scoped_spinlock guard(this->lock);
 
     __call_rtas((void *)virt_to_phys(&rtas_args));
 
-    this->lock.unlock();
 
     if (nret > 1 && outputs != NULL)
         for (word_t i = 0; i < nret-1; ++i)
@@ -204,11 +203,10 @@ word_t rtas_t::rtas_call( word_t *data, u32_t token, u32_t nargs, u32_t nret )
     for (word_t i = 0; i < nargs; i++)
 	rtas_args.set_arg( i, data[i] & 0xffffffff );
 
-    this->lock.lock();
+    scoped_spinlock guard2(this->lock);
 
     __call_rtas((void *)virt_to_phys(&rtas_args));
 
-    this->lock.unlock();
 
     if (nret > 1 )
         for (word_t i = 0; i < nret-1; ++i)

--- a/kernel/src/arch/powerpc64/sync.h
+++ b/kernel/src/arch/powerpc64/sync.h
@@ -45,6 +45,8 @@ public: // to allow initializers
     volatile word_t _lock;
 };
 
+class scoped_spinlock;
+
 #define DECLARE_SPINLOCK(name) extern spinlock_t name;
 #define DEFINE_SPINLOCK(name) spinlock_t name = ((spinlock_t) {{_lock: 0}})
 

--- a/kernel/src/arch/x86/sync.h
+++ b/kernel/src/arch/x86/sync.h
@@ -52,6 +52,30 @@ public: // to allow initializers
     volatile word_t _lock;
 };
 
+/**
+ * Scoped spinlock helper
+ *
+ * Locks the given spinlock on construction and releases it when going
+ * out of scope.
+ */
+class scoped_spinlock
+{
+public:
+    explicit scoped_spinlock(spinlock_t &lock)
+        : lock(&lock)
+    {
+        this->lock->lock();
+    }
+
+    ~scoped_spinlock()
+    {
+        this->lock->unlock();
+    }
+
+private:
+    spinlock_t *lock;
+};
+
 #define DECLARE_SPINLOCK(name) extern spinlock_t name;
 #define DEFINE_SPINLOCK(name) spinlock_t name = {_lock: 0}
 

--- a/kernel/src/generic/mapping.cc
+++ b/kernel/src/generic/mapping.cc
@@ -60,7 +60,7 @@ void SECTION (".init") init_mdb (void)
     void mdb_buflist_init (void);
     mdb_buflist_init ();
 
-    mdb_lock.lock();
+    scoped_spinlock guard(mdb_lock);
 
     // Frame table for the complete address space.
     dual = mdb_create_dual (NULL, mdb_create_roots (mapnode_t::size_max));
@@ -87,7 +87,6 @@ void SECTION (".init") init_mdb (void)
 	    panic ("mdb_pgshifts[] is not a superset of valid hw_pgshifts[]");
     }
 
-    mdb_lock.unlock();
 }
 
 
@@ -202,7 +201,7 @@ mapnode_t * mdb_map (mapnode_t * f_map, pgent_t * f_pg,
     mapnode_t *nmap;
 
     //space_t::begin_update();
-    mdb_lock.lock();
+    scoped_spinlock guard(mdb_lock);
 
     // Grant operations simply reuse the old mapping node
     if (grant)
@@ -213,7 +212,7 @@ mapnode_t * mdb_map (mapnode_t * f_map, pgent_t * f_pg,
 	    f_map->set_backlink (f_map->get_prevmap (f_pg), t_pg);
 
 	f_map->set_space (t_space);
-	mdb_lock.unlock();
+
 	//space_t::end_update();
 	return f_map;
     }
@@ -245,7 +244,6 @@ mapnode_t * mdb_map (mapnode_t * f_map, pgent_t * f_pg,
 	if (nmap)
 	    nmap->set_backlink (newmap, nmap->get_pgent (f_map));
 
-	mdb_lock.unlock();
 	//space_t::end_update();
 	return newmap;
     }
@@ -318,7 +316,6 @@ mapnode_t * mdb_map (mapnode_t * f_map, pgent_t * f_pg,
     if (nmap)
 	nmap->set_backlink (newmap, nmap->get_pgent (root));
 
-    mdb_lock.unlock();
     //space_t::end_update();
     return newmap;
 }
@@ -400,7 +397,7 @@ word_t mdb_flush (mapnode_t * f_map, pgent_t * f_pg,
     mapnode_t::pgsize_e f_pgsize = mdb_pgsize (f_hwpgsize);
     mapnode_t::pgsize_e t_pgsize = mdb_pgsize (t_hwpgsize);
 
-    mdb_lock.lock();
+    scoped_spinlock guard(mdb_lock);
 
     do {
 	// Variables `f_map' and `f_pg' are valid at this point
@@ -602,8 +599,7 @@ word_t mdb_flush (mapnode_t * f_map, pgent_t * f_pg,
     // XXX: Handle the case where one does flush instead of unmap.
     if (parent_pg)
 	parent_pg->update_reference_bits (parent_space, parent_pgsize, rwx);
-   
-    mdb_lock.unlock();
+
 
     return rwx;
 }

--- a/kernel/src/generic/mdb.cc
+++ b/kernel/src/generic/mdb.cc
@@ -203,7 +203,7 @@ mdb_node_t * mdb_t::map (mdb_node_t * f_node,
 		get_name (),  f_node,  obj, objsize,   addr,  (out_rights & 7UL), 
 		(in_rights & 7UL));
 
-    mdb_lock.lock();
+    scoped_spinlock guard(mdb_lock);
 
     // Allocate and initialize new mapping node.
 
@@ -228,7 +228,7 @@ mdb_node_t * mdb_t::map (mdb_node_t * f_node,
 	if (f_node->get_next ())
 	    f_node->get_next ()->set_prev (newnode);
 	f_node->set_next (newnode);
-	mdb_lock.unlock();
+
 	return newnode;
     }
 
@@ -256,7 +256,7 @@ mdb_node_t * mdb_t::map (mdb_node_t * f_node,
 		if (n)
 		    n->set_prev (newnode);
 		table->set_node (addr, newnode);
-		mdb_lock.unlock();
+
 		return newnode;
 	    }
 	    else if (table->get_objsize () > objsize)
@@ -308,7 +308,6 @@ mdb_node_t * mdb_t::map (mdb_node_t * f_node,
 		newtable->set_table (table->get_prefix (), table);
 	    }
 
-	    mdb_lock.unlock();
 	    return newnode;
 	}
 
@@ -398,7 +397,7 @@ mdb_node_t * mdb_t::map (mdb_node_t * f_node,
 	    f_node->set_table (newtable);
 
 	newtable->set_node (auxnode);
-	mdb_lock.unlock();
+
 	return newnode;
     }
 }
@@ -436,7 +435,7 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 		ctrl.raw, (word_t) ctrl.string(),
 		rights & 0x7, node->get_phys_address (this));
 
-    mdb_lock.lock();
+    scoped_spinlock guard(mdb_lock);
 
     // If we are unmapping the whole node there is no need to perform
     // any updates on it first.  We do need to read out the status
@@ -1011,7 +1010,6 @@ word_t mdb_t::mapctrl (mdb_node_t * node, range_t range,
 	}
     }
 
-    mdb_lock.unlock();
     return status_bits;
 }
 

--- a/kernel/src/generic/sync.h
+++ b/kernel/src/generic/sync.h
@@ -52,6 +52,12 @@ public:
     bool is_locked() { return false; }
 };
 
+class scoped_spinlock
+{
+public:
+    explicit scoped_spinlock(spinlock_t &) {}
+};
+
 
 #else /* CONFIG_SMP */
 /* 


### PR DESCRIPTION
## Summary
- add `scoped_spinlock` RAII class for spinlock_t
- declare helper in non-x86 headers
- use `scoped_spinlock` in various critical sections

## Testing
- `pre-commit` *(fails: command not found)*