### PR TITLE
Fix powerpc64 KIP_API_FLAGS logic

### DIFF
--- a/kernel/src/glue/v4-powerpc64/config.h
+++ b/kernel/src/glue/v4-powerpc64/config.h
@@ -54,12 +54,10 @@
 /**
  * endianess and word size
  */
-#if (CONFIG_PLAT_OFPOWER4 || CONFIG_PLAT_OFPOWER3)
-#define KIP_API_FLAGS	{SHUFFLE2(endian:1, word_size:1)}	// 64-bit, big endian
-#elif (CONFIG_PLAT_OFG5)
-#define KIP_API_FLAGS	{SHUFFLE2(endian:1, word_size:1)}	// 64-bit, big endian
+#if defined(CONFIG_PLAT_OFPOWER4) || defined(CONFIG_PLAT_OFPOWER3) || defined(CONFIG_PLAT_OFG5)
+#define KIP_API_FLAGS   {SHUFFLE2(endian:1, word_size:1)}       // 64-bit, big endian
 #else
-#error "FIXME"
+#error "Unsupported PowerPC64 platform: please define KIP_API_FLAGS"
 #endif
 
 /**


### PR DESCRIPTION
## Summary
- handle all supported powerpc64 platforms in KIP_API_FLAGS
- emit clear diagnostic for unknown platforms

## Testing
- `make -C kernel BUILDDIR=$(pwd)/build-ppc64 ARCH=powerpc64` *(fails: "Oops, /workspace/pistachio/build-ppc64 already exists ... aborting.")*
- `make ARCH=powerpc64` in build dir *(fails: missing cross compiler and unsupported platform)*