### PR TITLE
Refactor PPC44x spinlocks

### DIFF
--- a/kernel/src/platform/ppc44x/bic.h
+++ b/kernel/src/platform/ppc44x/bic.h
@@ -167,22 +167,20 @@ public:
 
     void mask(word_t irq)
 	{ 
-	    lock.lock();
-	    ctrl->mask_irq(irq);
-	    lock.unlock();
-	}
+            scoped_spinlock guard(lock);
+            ctrl->mask_irq(irq);
+        }
 
     bool unmask(word_t irq)
 	{
-	    ASSERT(irq < BGP_MAX_IRQS);
-	    lock.lock();
-        ctrl->ack_irq(irq);
-        bool pending = is_pending(irq);
-        if (!pending)
-            ctrl->unmask_irq(irq, get_irq_routing(irq));
-        lock.unlock();
-	    return pending; 
-	}
+            ASSERT(irq < BGP_MAX_IRQS);
+            scoped_spinlock guard(lock);
+            ctrl->ack_irq(irq);
+            bool pending = is_pending(irq);
+            if (!pending)
+                ctrl->unmask_irq(irq, get_irq_routing(irq));
+            return pending;
+        }
 
     bool is_masked(word_t irq)
 	{ return ctrl->is_masked(irq); }


### PR DESCRIPTION
## Summary
- use scoped_spinlock to manage PPC44x locks
- clean up manual lock/unlock pairs

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*