### PR TITLE
Use nullptr in userland C++ sources

### DIFF
--- a/user/configure
+++ b/user/configure
@@ -142,7 +142,8 @@ sed \
 # Create a minimal config.status for compatibility
 cat > config.status <<CONFEOF
 #!/bin/sh
-"$srcdir/configure" "$@"
+[ "\$1" = "--recheck" ] && shift
+exec "$srcdir/configure" "\$@"
 CONFEOF
 chmod +x config.status
 

--- a/user/lib/io/1275tree.cc
+++ b/user/lib/io/1275tree.cc
@@ -100,7 +100,7 @@ of1275_device_t * of1275_tree_t::find( const char *name )
 {
     of1275_device_t *dev = this->first();
     if( !dev )
-	return 0;
+        return nullptr;
 
     while( dev->is_valid() )
     {
@@ -109,14 +109,14 @@ of1275_device_t * of1275_tree_t::find( const char *name )
 	dev = dev->next();
     }
 
-    return 0;
+    return nullptr;
 }
 
 of1275_device_t * of1275_tree_t::find_handle( L4_Word_t handle )
 {
     of1275_device_t *dev = this->first();
     if( !dev )
-	return 0;
+        return nullptr;
 
     while( dev->is_valid() )
     {
@@ -125,28 +125,28 @@ of1275_device_t * of1275_tree_t::find_handle( L4_Word_t handle )
 	dev = dev->next();
     }
 
-    return 0;
+    return nullptr;
 }
 
 of1275_device_t * of1275_tree_t::get_parent( of1275_device_t *dev )
 {
-    char *slash = 0;
+    char *slash = nullptr;
     int cnt, depth;
 
     if( !dev || !this->first() )
-	return 0;
+        return nullptr;
 
     // Do we have any parents?
     depth = dev->get_depth();
     if( depth <= 1 )
-	return 0;
+        return nullptr;
 
     // Locate the last slash in the name.
     for( char *c = dev->get_name(); *c; c++ )
 	if( *c == '/' )
 	    slash = c;
-    if( slash == 0 )
-	return 0;
+    if( slash == nullptr )
+        return nullptr;
 
     // Count the offset of the last slash.
     cnt = 0;
@@ -163,7 +163,7 @@ of1275_device_t * of1275_tree_t::get_parent( of1275_device_t *dev )
 	parent = parent->next();
     }
 
-    return 0;
+    return nullptr;
 }
 
 of1275_device_t * of1275_tree_t::find_device_type( const char *device_type )
@@ -174,7 +174,7 @@ of1275_device_t * of1275_tree_t::find_device_type( const char *device_type )
 
     dev = this->first();
     if( !dev )
-	return 0;
+        return nullptr;
 
     while( dev->is_valid() )
     {
@@ -184,7 +184,7 @@ of1275_device_t * of1275_tree_t::find_device_type( const char *device_type )
 	dev = dev->next();
     }
 
-    return 0;
+    return nullptr;
 }
 
 #endif	/* !CONFIG_COMPORT */

--- a/user/lib/io/fdt.cc
+++ b/user/lib/io/fdt.cc
@@ -62,7 +62,7 @@ fdt_header_t *fdt_t::find_subtree_node(fdt_node_t *node, char *name)
 	    break;
 	}
     } while(level > 0);
-    return 0;
+    return nullptr;
 }
 
 fdt_property_t *fdt_t::find_property_node(fdt_node_t *node, char *name)
@@ -92,7 +92,7 @@ fdt_property_t *fdt_t::find_property_node(fdt_node_t *node, char *name)
 	    break;
 	}
     } while(level > 0);
-    return 0;
+    return nullptr;
 }
 
 fdt_property_t *fdt_t::find_property_node(char *path)
@@ -107,17 +107,17 @@ fdt_property_t *fdt_t::find_property_node(char *path)
     for (;;)
     {
 	next_path = strchr(path, '/');
-	if (next_path != 0)
-	{
-	    *next_path = 0;
-	    node = find_subtree_node(node, path);
-	    *next_path = '/';
-	    path = next_path + 1;
-	    if (!node)
-		return 0;
-	}
-	else
-	    return find_property_node(node, path);
+        if (next_path != nullptr)
+        {
+            *next_path = 0;
+            node = find_subtree_node(node, path);
+            *next_path = '/';
+            path = next_path + 1;
+            if (!node)
+                return nullptr;
+        }
+        else
+            return find_property_node(node, path);
     } 
 }
 
@@ -133,16 +133,16 @@ fdt_header_t *fdt_t::find_subtree(char *path)
     for (;;)
     {
 	next_path = strchr(path, '/');
-	if (next_path != 0)
-	{
-	    *next_path = 0;
-	    node = find_subtree_node(node, path);
-	    *next_path = '/';
-	    path = next_path + 1;
-	    if (!node)
-		return 0;
-	}
-	else
-	    return find_subtree_node(node, path);
+        if (next_path != nullptr)
+        {
+            *next_path = 0;
+            node = find_subtree_node(node, path);
+            *next_path = '/';
+            path = next_path + 1;
+            if (!node)
+                return nullptr;
+        }
+        else
+            return find_subtree_node(node, path);
     }
 }

--- a/user/lib/io/powerpc.cc
+++ b/user/lib/io/powerpc.cc
@@ -58,7 +58,7 @@ static volatile L4_Word8_t *comport = CONFIG_COMPORT;
 #define DTREE_KIP_TYPE	        (L4_BootLoaderSpecificMemoryType + (DTREE_KIP_SUBTYPE << 4))
 
 #define SIGMA0_DEVICE_RELOC     0xf0000000
-void *__l4_dtree = 0;
+void *__l4_dtree = nullptr;
 static L4_Word8_t __attribute__((aligned(4096))) comport_page[4096];
    
 
@@ -87,17 +87,17 @@ static void io_init( void )
     of1275_device_t *dev;
     of1275_tree_t *of1275_tree =  (of1275_tree_t *) L4_Sigma0_GetSpecial(DTREE_KIP_TYPE, 0, 4096);
 
-    if( of1275_tree == 0 )
+    if( of1275_tree == nullptr )
         return;
 
     dev = of1275_tree->find( "/aliases" );
-    if( dev == 0 )
+    if( dev == nullptr )
         return;
     if( !dev->get_prop("com", &alias, &len) )
         return;
 
     dev = of1275_tree->find( alias );
-    if( dev == 0 )
+    if( dev == nullptr )
         return;
     if( !dev->get_prop("reg", (char **)&reg, &len) )
         return;

--- a/user/lib/io/print.cc
+++ b/user/lib/io/print.cc
@@ -34,9 +34,6 @@
 #include <l4io.h>
 #include "lib.h"
 
-#ifndef NULL
-#define NULL ((void *) 0)
-#endif
 
 /*
  * Make __l4_ prefixes for regular output functions, and create weak

--- a/user/lib/l4/amd64.cc
+++ b/user/lib/l4/amd64.cc
@@ -32,9 +32,6 @@
 
 #include <l4/kip.h>
 
-#if !defined(NULL)
-#define NULL 0
-#endif
 
 __L4_Ipc_t __L4_Ipc = nullptr;
 __L4_Lipc_t __L4_Lipc = nullptr;

--- a/user/lib/l4/debug.cc
+++ b/user/lib/l4/debug.cc
@@ -31,7 +31,7 @@
 #include <l4/kip.h>
 #include <l4/tracebuffer.h>
 
-L4_TraceBuffer_t *__L4_Tracebuffer = 0;
+L4_TraceBuffer_t *__L4_Tracebuffer = nullptr;
 
 L4_TraceBuffer_t *L4_GetTraceBuffer()
 {
@@ -56,7 +56,7 @@ L4_TraceBuffer_t *L4_GetTraceBuffer()
                     __L4_Tracebuffer = (L4_TraceBuffer_t*) L4_MemoryDescLow(mdesc);
                     
                     if (__L4_Tracebuffer->magic != L4_TRACEBUFFER_MAGIC)
-                        __L4_Tracebuffer = 0;
+                        __L4_Tracebuffer = nullptr;
                     break;
                 }
            

--- a/user/lib/l4/powerpc.cc
+++ b/user/lib/l4/powerpc.cc
@@ -31,9 +31,6 @@
  ***************************************************************************/
 #include <l4/kip.h>
 
-#if !defined(NULL)
-#define NULL 0
-#endif
 
 __L4_Ipc_t __L4_Ipc = nullptr;
 __L4_Lipc_t __L4_Lipc = nullptr;

--- a/user/lib/l4/powerpc64.cc
+++ b/user/lib/l4/powerpc64.cc
@@ -31,9 +31,6 @@
  ***************************************************************************/
 #include <l4/kip.h>
 
-#if !defined(NULL)
-#define NULL 0
-#endif
 
 __L4_Ipc_t __L4_Ipc = nullptr;
 __L4_Lipc_t __L4_Lipc = nullptr;

--- a/user/serv/sigma0/sigma0.h
+++ b/user/serv/sigma0/sigma0.h
@@ -62,9 +62,6 @@ extern int verbose;
 extern L4_KernelInterfacePage_t * kip;
 
 
-#ifndef NULL
-#define NULL ((void *) 0)
-#endif
 
 
 /**


### PR DESCRIPTION
## Summary
- prefer `nullptr` in C++ sources under `user/lib` and `user/serv`
- drop custom `NULL` definitions
- tweak `configure` to allow re-run via `config.status`

## Testing
- `clang++ -std=c++23 -Wall -c user/lib/io/1275tree.cc` *(fails: 'config.h' file not found)*