### PR TITLE
Add PPC64 warning default

### DIFF
--- a/doc/notes/ppc-build.txt
+++ b/doc/notes/ppc-build.txt
@@ -72,3 +72,12 @@ line to boot the kernel is::
 
 For 64-bit targets use `qemu-system-ppc64` instead.
 
+Configuration Notes
+-------------------
+
+When configuring a PowerPC64 kernel the build system checks for
+platform macros such as `CONFIG_PLAT_OFPOWER4`.  If no known platform
+is selected the kernel now defaults to big-endian 64-bit API flags and
+issues a compile-time warning rather than aborting the build.  Override
+`KIP_API_FLAGS` if your environment requires different settings.
+

--- a/kernel/src/glue/v4-powerpc64/config.h
+++ b/kernel/src/glue/v4-powerpc64/config.h
@@ -57,7 +57,8 @@
 #if defined(CONFIG_PLAT_OFPOWER4) || defined(CONFIG_PLAT_OFPOWER3) || defined(CONFIG_PLAT_OFG5)
 #define KIP_API_FLAGS   {SHUFFLE2(endian:1, word_size:1)}       // 64-bit, big endian
 #else
-#error "Unsupported PowerPC64 platform: please define KIP_API_FLAGS"
+#warning "Unknown PowerPC64 platform. Assuming big-endian 64-bit defaults for KIP_API_FLAGS"
+#define KIP_API_FLAGS   {SHUFFLE2(endian:1, word_size:1)}
 #endif
 
 /**


### PR DESCRIPTION
## Summary
- warn for unknown PowerPC64 platforms instead of aborting the build
- document default KIP_API_FLAGS handling

## Testing
- `pytest -q`
- `clang -target powerpc64-unknown-linux-gnu -std=c++23 -Iuser/include -Iuser/contrib/elf-loader/include -c user/contrib/elf-loader/platform/amd64-pc99/string.cc -o build/string.o`