### PR TITLE
Switch to nullptr usage

### DIFF
--- a/contrib/disas/ppc-opc.cc
+++ b/contrib/disas/ppc-opc.cc
@@ -561,7 +561,7 @@ const struct powerpc_operand powerpc_operands[] =
   if (invalid != (int *) nullptr
 
   if (invalid != (int *) nullptr
-#define MTMSRD_L WS + 1
+  if (invalid != (int *) nullptr
   { 1, 16, 0, 0, PPC_OPERAND_OPTIONAL },
 
 };

--- a/kernel/src/generic/types.h
+++ b/kernel/src/generic/types.h
@@ -121,9 +121,6 @@ INLINE addr_t addr_align_up (addr_t addr, word_t align)
 
 
 
-#ifndef NULL
-#define NULL 0
-#endif
 
 #define BITS_WORD	(sizeof(word_t)*8)
 #define BYTES_WORD	(sizeof(word_t))

--- a/kernel/src/kdb/console.h
+++ b/kernel/src/kdb/console.h
@@ -45,7 +45,7 @@ public:
     char (*getc) (bool block);
 };
 
-#define KDB_NULL_CONSOLE { NULL, NULL, NULL, NULL }
+#define KDB_NULL_CONSOLE { nullptr, nullptr, nullptr, nullptr }
 
 extern kdb_console_t kdb_consoles[];
 extern word_t kdb_current_console;

--- a/user/apps/l4test/l4test.h
+++ b/user/apps/l4test/l4test.h
@@ -53,9 +53,6 @@
 /* memory stuff */
 #define PAGE_MASK   (~(PAGE_SIZE-1))
 
-#if !defined(NULL)
-#define NULL	0
-#endif
 
 /* ex-reg flags */
 #define EX_HALT (1<<0)

--- a/user/contrib/elf-loader/platform/amd64-pc99/globals.h
+++ b/user/contrib/elf-loader/platform/amd64-pc99/globals.h
@@ -34,7 +34,6 @@
 #include <multiboot.h>
 #include <stdarg.h>
 
-#define NULL    (0)
 
 
 /* From elf.cc */


### PR DESCRIPTION
## Summary
- stop redefining `NULL`
- use `nullptr` for sentinel console definition
- convert ppc disassembler to `nullptr`

## Testing
- `make`