### PR TITLE
Improve pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+minimum_pre_commit_version: '3.7.0'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -5,6 +6,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+      - id: check-added-large-files
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:

--- a/README
+++ b/README
@@ -115,12 +115,15 @@ Development workflow
 --------------------
 The repository uses [pre-commit](https://pre-commit.com) to run
 formatters and linters such as **black**, **ruff**, **shellcheck** and
-**golangci-lint**.  Install the hooks once after cloning::
+**golangci-lint**.  The `setup.sh` script installs `pre-commit` via
+`pip` and fetches the hook environments automatically.  After cloning
+the repository you can re-install the hooks manually if desired::
 
-    $ pre-commit install
+    $ pre-commit install --install-hooks
 
 With the hooks installed, each commit will automatically format and
-lint changed files.
+lint changed files.  Run `pre-commit` manually to check all files or
+`pre-commit autoupdate` to refresh hook versions.
 
 Running clang-tidy
 ------------------

--- a/setup.sh
+++ b/setup.sh
@@ -171,7 +171,8 @@ fi
   # Ensure pre-commit and its hook environments are installed while network is available
   pip3 install --no-cache-dir -U pre-commit || echo "pip install pre-commit failed" | tee -a "$FAIL_LOG"
   if [ -f .pre-commit-config.yaml ]; then
-    pre-commit install --install-hooks || echo "pre-commit hook install failed" | tee -a "$FAIL_LOG"
+    python3 -m pre_commit install --install-hooks \
+      || echo "pre-commit hook install failed" | tee -a "$FAIL_LOG"
   fi
 
 fi
@@ -180,16 +181,20 @@ fi
 for pip_pkg in pytest pre-commit; do
   pip3 install --no-cache-dir -U "$pip_pkg" || echo "pip install $pip_pkg failed" | tee -a "$FAIL_LOG"
 done
+python3 -m pre_commit --version >/dev/null 2>&1 || echo "pre-commit not available" | tee -a "$FAIL_LOG"
 
 # Create a minimal pre-commit configuration if one does not already exist
 if [ ! -f .pre-commit-config.yaml ]; then
 cat > .pre-commit-config.yaml <<'EOF'
+minimum_pre_commit_version: '3.7.0'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
 EOF
 fi
 


### PR DESCRIPTION
## Summary
- tweak README notes on using pre-commit
- require pre-commit >=3.7 and add a check for large files
- ensure setup.sh installs hooks using `python3 -m pre_commit`
- create richer default `.pre-commit-config.yaml`

## Testing
- `pytest -q`