### PR TITLE
Fix scoped_spinlock RAII in non-SMP builds

### DIFF
--- a/kernel/src/generic/sync.h
+++ b/kernel/src/generic/sync.h
@@ -55,7 +55,19 @@ public:
 class scoped_spinlock
 {
 public:
-    explicit scoped_spinlock(spinlock_t &) {}
+    explicit scoped_spinlock(spinlock_t &lock)
+        : lock(&lock)
+    {
+        this->lock->lock();
+    }
+
+    ~scoped_spinlock()
+    {
+        this->lock->unlock();
+    }
+
+private:
+    spinlock_t *lock;
 };
 
 


### PR DESCRIPTION
## Summary
- ensure scoped_spinlock always calls lock()/unlock() even when CONFIG_SMP is off
- verify that the header compiles with and without CONFIG_SMP

## Testing
- `g++ -std=c++23 /tmp/test.cc -I. -Ikernel/src -o /tmp/test_non_smp`
- `g++ -std=c++23 /tmp/test.cc -I. -Ikernel/src -DCONFIG_SMP -D__ARCH__=x86 -D__CPU__=x32 -D__PLATFORM__=pc99 -D__API__=v4 -D__SCHED__=rr -o /tmp/test_smp`