### PR TITLE
Implement scoped spinlock guards for PowerPC

### DIFF
--- a/kernel/kdb/arch/powerpc64/prepost.cc
+++ b/kernel/kdb/arch/powerpc64/prepost.cc
@@ -31,8 +31,17 @@
  ********************************************************************/
 
 #include <kdb/kdb.h>
+#include <sync.h>
 
 static spinlock_t powerpc64_kdb_lock;
 
-bool kdb_t::pre() { powerpc64_kdb_lock.lock(); return true; }
-void kdb_t::post() { powerpc64_kdb_lock.unlock(); }
+bool kdb_t::pre()
+{
+    scoped_spinlock guard(powerpc64_kdb_lock);
+    return true;
+}
+
+void kdb_t::post()
+{
+    scoped_spinlock guard(powerpc64_kdb_lock);
+}

--- a/kernel/kdb/glue/v4-powerpc/prepost.cc
+++ b/kernel/kdb/glue/v4-powerpc/prepost.cc
@@ -34,6 +34,7 @@
 #include <debug.h>
 #include <kdb/kdb.h>
 #include <kdb/console.h>
+#include <sync.h>
 
 #include INC_GLUE(debug.h)
 
@@ -50,7 +51,7 @@ static bool user_kdb_enter = true;
 bool kdb_t::pre() 
 { 
     bool enter_kdb = false;
-    kdb_lock.lock();
+    scoped_spinlock guard(kdb_lock);
 
     tcb_t *current = get_current_tcb();
     debug_param_t *param = (debug_param_t *)kdb_param;
@@ -194,14 +195,13 @@ bool kdb_t::pre()
 	}
 	printf( "\n" );
     }
-    else
-	kdb_lock.unlock();
+
 
     return enter_kdb; 
 }
 
-void kdb_t::post() 
-{ 
-    kdb_lock.unlock();
+void kdb_t::post()
+{
+    scoped_spinlock guard(kdb_lock);
 }
 

--- a/kernel/src/arch/powerpc/sync.h
+++ b/kernel/src/arch/powerpc/sync.h
@@ -46,7 +46,23 @@ public: // to allow initializers
     volatile word_t _lock;
 };
 
-class scoped_spinlock;
+class scoped_spinlock
+{
+public:
+    explicit scoped_spinlock(spinlock_t &lock)
+        : lock(&lock)
+    {
+        this->lock->lock();
+    }
+
+    ~scoped_spinlock()
+    {
+        this->lock->unlock();
+    }
+
+private:
+    spinlock_t *lock;
+};
 
 #define DECLARE_SPINLOCK(name) extern spinlock_t name;
 #define DEFINE_SPINLOCK(name) spinlock_t name = {_lock: 0}

--- a/kernel/src/arch/powerpc64/sync.h
+++ b/kernel/src/arch/powerpc64/sync.h
@@ -45,7 +45,23 @@ public: // to allow initializers
     volatile word_t _lock;
 };
 
-class scoped_spinlock;
+class scoped_spinlock
+{
+public:
+    explicit scoped_spinlock(spinlock_t &lock)
+        : lock(&lock)
+    {
+        this->lock->lock();
+    }
+
+    ~scoped_spinlock()
+    {
+        this->lock->unlock();
+    }
+
+private:
+    spinlock_t *lock;
+};
 
 #define DECLARE_SPINLOCK(name) extern spinlock_t name;
 #define DEFINE_SPINLOCK(name) spinlock_t name = ((spinlock_t) {{_lock: 0}})

--- a/kernel/src/glue/v4-x86/debug.cc
+++ b/kernel/src/glue/v4-x86/debug.cc
@@ -41,6 +41,7 @@
 #include INC_API(tcb.h)
 #include INC_API(smp.h)
 #include INC_API(cpu.h)
+#include <sync.h>
 #include INC_ARCH(traps.h)
 #include INC_ARCH(trapgate.h)
 #include INC_ARCH(apic.h)
@@ -63,12 +64,12 @@ extern "C" void sync_debug (word_t address)
     
     if (!sync_dbg_enter)
     {
-	printf_spin_lock.unlock();
-	sync_dbg_enter = true;
- 	TRACEPOINT(DEBUG_LOCK, "CPU %d, tcb %t, spinlock BUG (lock %x) @ %x\n", 
-		   get_current_cpu(), get_current_tcb(), 
-		   address, __builtin_return_address((0)));
-	enter_kdebug("spinlock BUG");
+        scoped_spinlock guard(printf_spin_lock);
+        sync_dbg_enter = true;
+        TRACEPOINT(DEBUG_LOCK, "CPU %d, tcb %t, spinlock BUG (lock %x) @ %x\n",
+                   get_current_cpu(), get_current_tcb(),
+                   address, __builtin_return_address((0)));
+        enter_kdebug("spinlock BUG");
     }
     sync_dbg_enter = false;
 }


### PR DESCRIPTION
## Summary
- add RAII `scoped_spinlock` to PowerPC and PowerPC64 sync headers
- use `scoped_spinlock` in PowerPC KDB pre/post handlers
- update PowerPC64 KDB handlers for RAII lock guard
- guard x86 debug spinlock with scoped spinlock

## Testing
- `pre-commit` *(fails: command not found)*