### PR TITLE
Improve clang-tidy docs and hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: clang-tidy
         name: clang-tidy
-        entry: clang-tidy
+        entry: clang-tidy -p user
         language: system
         files: \.(c|cc|cpp|cxx|h|hpp)$
 

--- a/README
+++ b/README
@@ -129,7 +129,9 @@ Running clang-tidy
 ------------------
 The tree includes a `.clang-tidy` configuration enabling the modernize
 and readability checks. The pre-commit hook runs the tool on modified
-C/C++ sources. To invoke it manually on a file::
+C/C++ sources.  A `compile_commands.json` database is generated under
+`user/` to provide build flags.  Invoke the tool manually with the
+database path::
 
-    $ clang-tidy path/to/file.cc
+    $ clang-tidy -p user path/to/file.cc
 


### PR DESCRIPTION
## Summary
- use compile database path in the clang-tidy hook
- document how to run clang-tidy with the compile database

## Testing
- `pytest -q`