### PR TITLE
Refactor scheduler list locking to RAII

### DIFF
--- a/kernel/src/api/v4/smp.cc
+++ b/kernel/src/api/v4/smp.cc
@@ -129,11 +129,10 @@ void cpu_mb_t::walk_mailbox()
 {
     while(first_free != first_alloc)
     {
-	lock.lock();
-	cpu_mb_entry_t entry = entries[first_alloc];
-	entries[first_alloc].handler = nullptr;
-	first_alloc = (first_alloc + 1) % MAX_MAILBOX_ENTRIES;
-	lock.unlock();
+        scoped_spinlock guard(lock);
+        cpu_mb_entry_t entry = entries[first_alloc];
+        entries[first_alloc].handler = nullptr;
+        first_alloc = (first_alloc + 1) % MAX_MAILBOX_ENTRIES;
 	ASSERT(entry.handler);
 	
 	//printf("CPU%d: XCPU-entry (handler: %t)\n", get_current_cpu(), entry.handler);


### PR DESCRIPTION
## Summary
- use RAII guard for `schedule_request_queue_t`
- manage SMP requeue locks with RAII in RR/HS schedulers
- apply RAII to CPU mailbox processing

## Testing
- `python3 tests/test_subdomain.py`