### PR TITLE
Add IPC server interface doc and update examples

### DIFF
--- a/README
+++ b/README
@@ -100,6 +100,14 @@ Then launch them together with the kernel using `kickstart`::
           -roottask=user/serv/memory/memory \
           user/serv/scheduler/scheduler
 
+Additional servers can be started in the same manner.  For example,
+to also launch a device service pass its binary as another argument::
+
+    $ user/util/kickstart/kickstart \
+          -roottask=user/serv/memory/memory \
+          user/serv/scheduler/scheduler \
+          user/serv/device/device
+
 
 Migration from the microkernel API
 ----------------------------------

--- a/docs/server_interfaces.md
+++ b/docs/server_interfaces.md
@@ -1,0 +1,37 @@
+# Server IPC Interfaces
+
+This document outlines the expected IPC messages used by the example
+resource managers.  Each service defines a small message format which
+is exchanged over L4 IPC.
+
+## Memory Server
+
+The memory server receives requests consisting of a four word message.
+`MR0` contains the label `0`.  `MR1`--`MR3` encode the following
+structure:
+
+```c
+struct mem_request {
+    mem_opcode op;    /* MEM_ALLOC or MEM_FREE */
+    L4_Word_t  size;  /* bytes to allocate or free */
+    L4_Word_t  addr;  /* address when freeing */
+};
+```
+
+For a `MEM_ALLOC` request the server returns the allocated address in
+`MR1`.  `MEM_FREE` requests return `0`.
+
+## Scheduler Server
+
+Scheduler messages use label `0x1234`.  Five untyped words encode the
+`sched_client.h` `SchedRequest` structure.  Threads send a request and
+then block until the server replies.  The server switches to the next
+thread using `L4_ThreadSwitch` and replies when the time slice is
+consumed.
+
+## Device Servers
+
+Future device servers will follow the same pattern: a unique message
+label and a packed request structure starting at `MR1`.  Clients will
+send device specific operations (read/write, interrupt handling, and
+configuration) and wait for the server's reply.

--- a/user/serv/memory/memory.cc
+++ b/user/serv/memory/memory.cc
@@ -5,6 +5,8 @@
 #include <cstring>
 #include <l4/memory.h>
 
+static const L4_Word_t MEM_LABEL = 0;
+
 static L4_Word_t handle_request(const mem_request &req)
 {
     if (req.op == MEM_ALLOC) {
@@ -26,9 +28,15 @@ int main()
         L4_ThreadId_t partner;
         partner = L4_Wait(&tag);
         L4_StoreMR(0, &label);
+        if (label != MEM_LABEL) {
+            L4_Reply(partner);
+            continue;
+        }
+
         mem_request req;
         L4_StoreMRs(1, sizeof(req)/sizeof(L4_Word_t), (L4_Word_t*)&req);
         L4_Word_t res = handle_request(req);
+
         L4_MsgClear(&msg);
         L4_MsgAppendWord(&msg, res);
         L4_Set_MsgLabel(&msg, label);

--- a/user/serv/scheduler/scheduler.cc
+++ b/user/serv/scheduler/scheduler.cc
@@ -4,6 +4,8 @@
 #include <deque>
 #include "../../src-userland/lib/sched/sched_client.h"
 
+static const L4_Word_t SCHED_LABEL = 0x1234;
+
 int main()
 {
     printf("Scheduler server started\n");
@@ -15,7 +17,9 @@ int main()
     {
         SchedRequest req;
         L4_ThreadId_t from;
-        sched_wait_request(&req, &from);
+        L4_MsgTag_t tag = sched_wait_request(&req, &from);
+        if (L4_Label(tag) != SCHED_LABEL)
+            continue;
 
         /* enqueue requesting thread */
         queue.push_back(from);


### PR DESCRIPTION
## Summary
- document IPC contracts for the resource managers
- add example to launch several servers with `kickstart`
- validate message labels in example memory and scheduler servers

## Testing
- `pytest -q`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*