### PR TITLE
Add CMake build wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+project(pistachio C CXX)
+
+set(CMAKE_C_STANDARD 23)
+set(CMAKE_CXX_STANDARD 23)
+
+# Build the string.o example from the legacy Makefile
+add_library(string_obj OBJECT
+    user/contrib/elf-loader/platform/amd64-pc99/string.cc
+)
+
+target_include_directories(string_obj PRIVATE
+    ${CMAKE_SOURCE_DIR}/user/include
+    ${CMAKE_SOURCE_DIR}/user/contrib/elf-loader/include
+)
+
+add_subdirectory(kernel)
+add_subdirectory(src-userland/lib)
+
+add_custom_target(default_all ALL DEPENDS string_obj kernel_target userlib_target)
+

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,36 @@
+# Building with CMake
+
+The repository now provides a small CMake build that mirrors the legacy
+Makefiles for the kernel and userland libraries.  It wraps the existing
+`make` based build system so the traditional workflow still works.
+
+## Quick start
+
+```bash
+$ mkdir build && cd build
+$ cmake ..
+$ cmake --build .
+```
+
+The default target compiles the example `string.o` object, builds the
+kernel using the Makefile under `kernel/` and builds the userland
+libraries from `src-userland/lib`.
+
+To build individual pieces you can specify the targets explicitly:
+
+```bash
+$ cmake --build . --target kernel_target
+$ cmake --build . --target userlib_target
+```
+
+Cleaning can be performed with the matching clean targets:
+
+```bash
+$ cmake --build . --target kernel_clean
+$ cmake --build . --target userlib_clean
+```
+
+These commands simply invoke the existing Makefiles so any custom
+settings in `kernel/Makeconf.local` or environment variables are still
+honoured.
+

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Wrap the existing kernel Makefile
+
+add_custom_target(kernel_target ALL
+    COMMAND ${CMAKE_MAKE_PROGRAM}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Building kernel via Makefile"
+)
+
+add_custom_target(kernel_clean
+    COMMAND ${CMAKE_MAKE_PROGRAM} clean
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Cleaning kernel build"
+)

--- a/src-userland/lib/CMakeLists.txt
+++ b/src-userland/lib/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Build userland static libraries
+
+add_library(useripc STATIC
+    ipc/user_ipc.cc
+)
+
+add_library(sched STATIC
+    sched/sched_client.cc
+)
+
+# Include directories match the Makefile
+# using absolute paths from the repository root
+
+target_include_directories(useripc PRIVATE
+    ${CMAKE_SOURCE_DIR}/user/include
+    ${CMAKE_SOURCE_DIR}/user/contrib/elf-loader/include
+)
+
+target_include_directories(sched PRIVATE
+    ${CMAKE_SOURCE_DIR}/user/include
+    ${CMAKE_SOURCE_DIR}/user/contrib/elf-loader/include
+)
+
+add_custom_target(userlib_target ALL
+    DEPENDS useripc sched
+)
+
+add_custom_target(userlib_clean
+    COMMAND ${CMAKE_MAKE_PROGRAM} clean
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)


### PR DESCRIPTION
## Summary
- add a root `CMakeLists.txt`
- wrap the kernel Makefile with a CMake custom target
- add a CMake file for userland libraries
- document the CMake flow

## Testing
- `pre-commit run --files CMakeLists.txt kernel/CMakeLists.txt src-userland/lib/CMakeLists.txt docs/building.md` *(fails: command not found)*