### PR TITLE
Add kernel build CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,17 +14,41 @@ jobs:
   build-userland:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install build tools
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y build-essential
-    - name: Configure userland
-      run: |
-        mkdir build
-        cd build
-        ../user/configure
-    - name: Build userland
-      run: |
-        cd build
-        make -j$(nproc)
+      - uses: actions/checkout@v4
+      - name: Install build tools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential
+      - name: Configure userland
+        run: |
+          mkdir build
+          cd build
+          ../user/configure
+      - name: Build userland
+        run: |
+          cd build
+          make -j$(nproc)
+      - name: Run tests
+        run: |
+          pip install pytest
+          pytest tests/test_subdomain.py
+
+  build-kernel:
+    runs-on: ubuntu-latest
+    needs: build-userland
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build tools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential
+      - name: Build kernel
+        run: |
+          make -C kernel BUILDDIR=$PWD/kernel-build
+          cd kernel-build
+          make -j$(nproc)
+      - name: Archive kernel image
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-image
+          path: kernel-build/*-kernel


### PR DESCRIPTION
## Summary
- extend build workflow with kernel build job
- run unit tests for subdomain logic

## Testing
- `python -m pytest tests/test_subdomain.py`