### PR TITLE
Update CML2 utilities for Python3

### DIFF
--- a/contrib/cml2/cmlcompile.py
+++ b/contrib/cml2/cmlcompile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Compiler for CML2
 
@@ -7,10 +7,10 @@ by Eric S. Raymond, <esr@thyrsus.com>
 import sys
 
 if sys.version[0] < '2':
-    print "Python 2.0 or later is required for this program."
+    print("Python 2.0 or later is required for this program.")
     sys.exit(0)
 
-import string, os, getopt, shlex, cPickle, cml, cStringIO
+import string, os, getopt, shlex, pickle, cml, io
 
 # Globals
 rulebase = None
@@ -46,26 +46,26 @@ class CompilationState:
         self.propnames = {}
         self.dfltsyms = []
         # Used by the menu-declaration parser
-        self.condition_stack = []	# Stack of active conditions for {} shorthand
-        self.property_stack = []	# Stack of property switches
-        self.symbol_list = []		# Result list
+        self.condition_stack = []       # Stack of active conditions for {} shorthand
+        self.property_stack = []        # Stack of property switches
+        self.symbol_list = []           # Result list
 
 # Lexical analysis
 _keywords = (
-    'alias',		'banner',	'choices',	'choicegroup',
-    'condition',	'debug',	'default',	'dependent',
-    'derive',		'enum',		'expert',	'explanation',
-    'give',		'icon',		'like',		'menu',
-    'nohelp',		'on',		'prefix',	'prohibit',
-    'property',		'range',	'require',	'save',
-    'start',		'suppress',	'symbols',	'text',
-    'trits',		'unless',	'warndepend',	'when',
+    'alias',            'banner',       'choices',      'choicegroup',
+    'condition',        'debug',        'default',      'dependent',
+    'derive',           'enum',         'expert',       'explanation',
+    'give',             'icon',         'like',         'menu',
+    'nohelp',           'on',           'prefix',       'prohibit',
+    'property',         'range',        'require',      'save',
+    'start',            'suppress',     'symbols',      'text',
+    'trits',            'unless',       'warndepend',   'when',
     )
 _ternaryops = ('?', ':')
 _arithops = ('*', '+', '-')
 _boolops = ('and', 'or', 'implies')
 _relops = ('==', '!=', '<', '>', '>=', '<=') 
-_termops = ('|', '&', '$')		# min, max, similarity
+_termops = ('|', '&', '$')              # min, max, similarity
 _operators = _termops + _relops + _boolops + _arithops + _ternaryops + ("(", ")")
 _tritvals = ("n", "m", "y")
 _atoms = ("trit", "string", "decimal", "hexadecimal")
@@ -74,14 +74,14 @@ _atoms = ("trit", "string", "decimal", "hexadecimal")
 class Token:
     "CML2's internal token type."
     def __init__(self, type, attr=None):
-	self.type = type
-	self.attr = attr
-	if compstate.debug > 1: print "CML token: ", `self`
+        self.type = type
+        self.attr = attr
+        if compstate.debug > 1: print("CML token: ", repr(self))
     def __repr__(self):
         if self.type == "EOF":
             return "EOF"
         elif self.attr is not None:
-            return self.type + "=" + `self.attr`
+            return self.type + "=" + repr(self.attr)
         else:
             return self.type
     def __cmp__(self, other):
@@ -105,38 +105,38 @@ class lexwrapper(shlex.shlex):
         if endtok:
             contents = stream
         else:
-            contents = cStringIO.StringIO(stream.read())
+            contents = io.StringIO(stream.read())
             stream.close()
-	shlex.shlex.__init__(self, contents, name)
+        shlex.shlex.__init__(self, contents, name)
 
     def lex_token(self):
-	# Get a (type, attr) token tuple, handling inclusion  
-	raw = self.get_token()
-	if type(raw) is not type(""):	# Pushed-back token
-	    return raw
-	elif not raw or raw == self.endtok:
-	    return Token("EOF")
-	elif raw[0] in self.quotes:
-	    return Token('string', raw[1:-1])
-	elif raw in _tritvals:
-	    return Token('trit', raw)
-	elif len(raw) > 2 and \
-		raw[0] == '0' and raw[1] == 'x' and raw[2] in string.hexdigits:
-            return Token('hexadecimal', long(raw[2:], 16))
-	elif raw[0] in string.digits:
-	    return Token('decimal', int(raw))
-	elif raw in ('!', '=', '<', '>'):	# Relational tests
-	    next = self.get_token()
-	    if next == '=':
-		return Token(raw+next)
-	    else:
-		self.push_token(next)
-		return Token(raw)
+        # Get a (type, attr) token tuple, handling inclusion  
+        raw = self.get_token()
+        if type(raw) is not type(""):   # Pushed-back token
+            return raw
+        elif not raw or raw == self.endtok:
+            return Token("EOF")
+        elif raw[0] in self.quotes:
+            return Token('string', raw[1:-1])
+        elif raw in _tritvals:
+            return Token('trit', raw)
+        elif len(raw) > 2 and \
+                raw[0] == '0' and raw[1] == 'x' and raw[2] in string.hexdigits:
+            return Token('hexadecimal', int(raw[2:], 16))
+        elif raw[0] in string.digits:
+            return Token('decimal', int(raw))
+        elif raw in ('!', '=', '<', '>'):       # Relational tests
+            next = self.get_token()
+            if next == '=':
+                return Token(raw+next)
+            else:
+                self.push_token(next)
+                return Token(raw)
         elif raw == 'text':
             data = ""
             while 1:
                 line = self.instream.readline()
-                if line == "" or line == ".\n":	# Terminated by dot.
+                if line == "" or line == ".\n": # Terminated by dot.
                     break
                 if line[0] == '.':
                     line = line[1:]
@@ -146,61 +146,61 @@ class lexwrapper(shlex.shlex):
             data = ""
             while 1:
                 line = self.instream.readline()
-                if line == "" or line == "\n":	# Terminated by blank line
+                if line == "" or line == "\n":  # Terminated by blank line
                     break
                 data = data + line
             self.push_token(data)
             return Token(raw)
-	elif raw in _keywords or raw in _operators:
-	    return Token(raw)
-        elif compstate.propnames.has_key(raw):
+        elif raw in _keywords or raw in _operators:
+            return Token(raw)
+        elif raw in compstate.propnames:
             return Token('property', raw)
-	else:
+        else:
             # Nasty hack alert.  If there is a declared prefix for the
             # rulebase, ignore it as a prefix of names.  This will
             # enable us to be backward-compatible with names like like
             # CONFIG_3C515 that have leading numerics when stripped.
             if rulebase.prefix and raw[:len(rulebase.prefix)] == rulebase.prefix:
                 raw = raw[len(rulebase.prefix):]
-	    return Token('word', raw)
+            return Token('word', raw)
 
     def complain(self, str):
-	# Report non-fatal parse error; format like C compiler message.
+        # Report non-fatal parse error; format like C compiler message.
         if not compstate.debug and not compstate.errors:
             sys.stderr.write('\n')
-	sys.stderr.write(self.error_leader() + " " + str + "\n")
-	compstate.errors = compstate.errors + 1
+        sys.stderr.write(self.error_leader() + " " + str + "\n")
+        compstate.errors = compstate.errors + 1
 
     def croak(self, str):
-	# Report a fatal parse error and die
-	self.complain(str)
-	sys.exit(1)
+        # Report a fatal parse error and die
+        self.complain(str)
+        sys.exit(1)
 
     def demand(self, type, attr=None):
-	# Require a given token or token type, croak if we don't get it 
-	tok = self.lex_token()
-	if tok.type == "EOF":
-	    self.croak("premature EOF")
-	elif attr is not None and tok.attr != attr:
-	    self.croak("syntax error, saw `%s' while expecting `%s'" % (tok, attr))
-	elif tok.type != type:
-	    self.croak("syntax error, expecting token of type `%s' (actually saw %s=%s)" % (type, tok.type, tok.attr))
-	else:
-	    return tok.attr
+        # Require a given token or token type, croak if we don't get it 
+        tok = self.lex_token()
+        if tok.type == "EOF":
+            self.croak("premature EOF")
+        elif attr is not None and tok.attr != attr:
+            self.croak("syntax error, saw `%s' while expecting `%s'" % (tok, attr))
+        elif tok.type != type:
+            self.croak("syntax error, expecting token of type `%s' (actually saw %s=%s)" % (type, tok.type, tok.attr))
+        else:
+            return tok.attr
 
     def sourcehook(self, newfile):
-	# Override the hook in the shlex class
-	try:
-	    if newfile[0] == '"':
-		newfile = newfile[1:-1]
+        # Override the hook in the shlex class
+        try:
+            if newfile[0] == '"':
+                newfile = newfile[1:-1]
                 # This implements cpp-like semantics for relative-path inclusion.
                 if type(self.infile) is type("") and not os.path.isabs(newfile):
                     newfile = os.path.join(os.path.dirname(self.infile), newfile)
-	    return (newfile, open(newfile, "r"))
-	except IOError:
-	    self.complain("I/O error while opening '%s'" % (newfile,))
-	    sys.exit(1)
-        return None	# Appease pychecker
+            return (newfile, open(newfile, "r"))
+        except IOError:
+            self.complain("I/O error while opening '%s'" % (newfile,))
+            sys.exit(1)
+        return None     # Appease pychecker
 
 # Parsing
 
@@ -210,53 +210,53 @@ class ExpressionError:
         self.args = ("expression error " + explain,)
 
 def parse_atom(input):
-    if compstate.debug >= 2: print "entering parse_atom..."
+    if compstate.debug >= 2: print("entering parse_atom...")
     op = input.lex_token()
     if op.type in _atoms:
-        if compstate.debug >= 2: print "parse_atom returns", op.attr
+        if compstate.debug >= 2: print("parse_atom returns", op.attr)
         return op
     elif op.type == '(':
         sub = parse_expr_inner(input)
         close = input.lex_token()
         if close != ')':
-            raise ExpressionError, "while expecting a close paren"
+            raise ExpressionError("while expecting a close paren")
         else:
-            if compstate.debug >= 2: print "parse_atom returns singleton", sub
+            if compstate.debug >= 2: print("parse_atom returns singleton", sub)
             return sub
     elif op.type in _keywords:
-        raise ExpressionError, "keyword %s while expecting atom" % op.type
+        raise ExpressionError("keyword %s while expecting atom" % op.type)
     elif op.type == 'word':
-        if compstate.debug >= 2: print "parse_atom returns", op.attr
+        if compstate.debug >= 2: print("parse_atom returns", op.attr)
         return op
 
 def parse_term(input):
-    if compstate.debug >= 2: print "entering parse_term..."
+    if compstate.debug >= 2: print("entering parse_term...")
     left = parse_atom(input)
     op = input.lex_token()
     if op.type not in _termops:
         input.push_token(op)
-        if compstate.debug >= 2: print "parse_term returns singleton", left
+        if compstate.debug >= 2: print("parse_term returns singleton", left)
         return left
     right = parse_term(input)
     expr = (op.type, left, right)
-    if compstate.debug >= 2: print "parse_term returns", expr
+    if compstate.debug >= 2: print("parse_term returns", expr)
     return expr
 
 def parse_relational(input):
-    if compstate.debug >= 2: print "entering parse_relational..."
+    if compstate.debug >= 2: print("entering parse_relational...")
     left = parse_term(input)
     op = input.lex_token()
     if op.type not in _relops:
         input.push_token(op)
-        if compstate.debug >= 2: print "parse_relational returns singleton", left
+        if compstate.debug >= 2: print("parse_relational returns singleton", left)
         return left
     right = parse_term(input)
     expr = (op.type, left, right)
-    if compstate.debug >= 2: print "parse_relational returns", expr
+    if compstate.debug >= 2: print("parse_relational returns", expr)
     return(op.type, left, right)
 
 def parse_assertion(input):
-    if compstate.debug >= 2: print "entering parse_assertion..."
+    if compstate.debug >= 2: print("entering parse_assertion...")
     negate = input.lex_token()
     if negate.type == 'not':
         return ('not', parse_relational(input))
@@ -264,65 +264,65 @@ def parse_assertion(input):
     return parse_relational(input)
 
 def parse_conjunct(input):
-    if compstate.debug >= 2: print "entering parse_conjunct..."
+    if compstate.debug >= 2: print("entering parse_conjunct...")
     left = parse_assertion(input)
     op = input.lex_token()
     if op.type !=  'and': 
         input.push_token(op)
-        if compstate.debug >= 2: print "parse_conjunct returns singleton", left
+        if compstate.debug >= 2: print("parse_conjunct returns singleton", left)
         return left
     else:
         expr = ('and', left, parse_conjunct(input))
-        if compstate.debug >= 2: print "parse_conjunct returns", expr
+        if compstate.debug >= 2: print("parse_conjunct returns", expr)
         return expr
 
 def parse_disjunct(input):
-    if compstate.debug >= 2: print "entering parse_disjunct..."
+    if compstate.debug >= 2: print("entering parse_disjunct...")
     left = parse_conjunct(input)
     op = input.lex_token()
     if op.type != 'or':
         input.push_token(op)
-        if compstate.debug >= 2: print "parse_disjunct returns singleton", left
+        if compstate.debug >= 2: print("parse_disjunct returns singleton", left)
         return left
     else:
         expr = ('or', left, parse_disjunct(input))
-        if compstate.debug >= 2: print "parse_disjunct returns", expr
+        if compstate.debug >= 2: print("parse_disjunct returns", expr)
         return expr
 
 def parse_factor(input):
     if compstate.debug >= 2:
-        print "entering parse_factor..."
+        print("entering parse_factor...")
     left = parse_disjunct(input)
     op = input.lex_token()
     if op.type != 'implies':
         input.push_token(op)
-        if compstate.debug >= 2: print "parse_factor returns singleton", left
+        if compstate.debug >= 2: print("parse_factor returns singleton", left)
         return left
     else:
         expr = ('implies', left, parse_disjunct(input))
-        if compstate.debug >= 2: print "parse_factor returns", expr
+        if compstate.debug >= 2: print("parse_factor returns", expr)
         return expr
 
 def parse_summand(input):
-    if compstate.debug >= 2: print "entering parse_summand..."
+    if compstate.debug >= 2: print("entering parse_summand...")
     left = parse_factor(input)
     op = input.lex_token()
     if op.type != '*':
         input.push_token(op)
-        if compstate.debug >= 2: print "parse_summand returns singleton", left
+        if compstate.debug >= 2: print("parse_summand returns singleton", left)
         return left
     else:
         expr = ('*', left, parse_expr_inner(input))
-        if compstate.debug >= 2: print "parse_summand returns", expr
+        if compstate.debug >= 2: print("parse_summand returns", expr)
         return expr
 
 def parse_ternary(input):
-    if compstate.debug >= 2: print "entering parse_ternary..."
+    if compstate.debug >= 2: print("entering parse_ternary...")
     guard = parse_summand(input)
     op = input.lex_token()
     if op.type != '?':
         input.push_token(op)
-        if compstate.debug >= 2: print "parse_ternary returns singleton", guard
+        if compstate.debug >= 2: print("parse_ternary returns singleton", guard)
         return guard
     else:
         trueval = parse_summand(input)
@@ -331,20 +331,20 @@ def parse_ternary(input):
             raise ExpressionError("while expecting : in ternary")
         falseval = parse_summand(input)
         expr = ('?', guard, trueval, falseval)
-        if compstate.debug >= 2: print "parse_ternary returns", expr
+        if compstate.debug >= 2: print("parse_ternary returns", expr)
         return expr
 
 def parse_expr_inner(input):
-    if compstate.debug >= 2: print "entering parse_inner_expr..."
+    if compstate.debug >= 2: print("entering parse_inner_expr...")
     left = parse_ternary(input)
     op = input.lex_token()
     if op.type not in ('+', '-'):
         input.push_token(op)
-        if compstate.debug >= 2: print "parse_expr_inner returns singleton", left
+        if compstate.debug >= 2: print("parse_expr_inner returns singleton", left)
         return left
     else:
         expr = (op.type, left, parse_expr_inner(input))
-        if compstate.debug >= 2: print "parse_expr_inner returns", expr
+        if compstate.debug >= 2: print("parse_expr_inner returns", expr)
         return expr
 
 def parse_expr(input):
@@ -352,14 +352,14 @@ def parse_expr(input):
     try:
         exp = parse_expr_inner(input)
         return exp
-    except ExpressionError, exp:
+    except ExpressionError as exp:
         input.croak(exp.args[0])
         return None
 
 def make_dependent(guard, symbol):
     "Create a dependency lnk, indirecting properly through menus."
     if compstate.debug > 0:
-        print "Making %s dependent on %s" % (symbol.name, guard.name)
+        print("Making %s dependent on %s" % (symbol.name, guard.name))
     # If symbol is a menu, we'd really like to create a dependency link
     # for each of its children.  But they won't be defined at this point
     # if the reference is forward.
@@ -385,7 +385,7 @@ def intern_symbol(input, name=None, oktypes=None, record=0):
     elif name == "n":
         return cml.n
     # If we have not seen the symbol before, create an entry for it.
-    if not rulebase.dictionary.has_key(name):
+    if name not in rulebase.dictionary:
         ref = rulebase.dictionary[name] = cml.ConfigSymbol(name,
                                             None, None, None,
                                             input.infile,
@@ -414,30 +414,30 @@ def intern_symbol_list(input, record=0):
         else:
             list.append(symbol)
     if not list:
-	input.complain("syntax error, expected a nonempty word list")
+        input.complain("syntax error, expected a nonempty word list")
     return list
 
 def parse(input, baton):
     # Parse an entire CML program
     input.source = "source"
     if compstate.debug > 2:
-    	print "Calling parse()"
-    	input.debug = 1
+        print("Calling parse()")
+        input.debug = 1
     while 1:
         if not compstate.debug and not compstate.errors:
             baton.twirl()
-	leader = input.lex_token()
-	if compstate.debug > 1: print "Parsing declaration beginning with %s..." % (leader,)
+        leader = input.lex_token()
+        if compstate.debug > 1: print("Parsing declaration beginning with %s..." % (leader,))
         # Language constructs begin here 
-	if leader.type == "EOF":
-	    break
-	elif leader.type == "start":
-	    rulebase.start = input.lex_token().attr
-	elif leader.type in ("menus", "explanations"):
+        if leader.type == "EOF":
+            break
+        elif leader.type == "start":
+            rulebase.start = input.lex_token().attr
+        elif leader.type in ("menus", "explanations"):
             input.complain("menus and explanations declarations are "
                            "obsolete, replace these keywords with `symbols'")
-	elif leader.type == "symbols":
-	    while 1:
+        elif leader.type == "symbols":
+            while 1:
                 ref = intern_symbol(input, None, None, record=1)
                 if ref == None:
                     break
@@ -449,7 +449,7 @@ def parse(input, baton):
                     rulebase.dictionary[ref.name].helptext = tok.attr
                 elif tok.type == "like":
                     target = input.lex_token()
-                    if not rulebase.dictionary.has_key(target.attr):
+                    if target.attr not in rulebase.dictionary:
                         input.complain("unknown 'like' symbol %s" % target.attr)
                     elif not rulebase.dictionary[target.attr].help():
                         input.complain("'like' symbol %s has no help" % target.attr)
@@ -457,10 +457,10 @@ def parse(input, baton):
                         rulebase.dictionary[ref.name].helptext = rulebase.dictionary[target.attr].help()
                 else:
                     input.push_token(tok)
-	    if compstate.debug:
-                print "%d symbols read" % (len(rulebase.dictionary),)
-	elif leader.type in ("unless", "when"):
-	    guard = parse_expr(input)
+            if compstate.debug:
+                print("%d symbols read" % (len(rulebase.dictionary),))
+        elif leader.type in ("unless", "when"):
+            guard = parse_expr(input)
             maybe = input.lex_token()
             if maybe == "suppress":
                 if leader.type == "when":
@@ -499,36 +499,36 @@ def parse(input, baton):
             else:
                 input.complain("expected `suppress' or `save'")
             compstate.bool_tests.append((guard, input.infile, input.lineno))
-	elif leader.type == "menu":
-	    menusym = intern_symbol(input, None, ('bool', 'menu', 'choices'), record=1)
+        elif leader.type == "menu":
+            menusym = intern_symbol(input, None, ('bool', 'menu', 'choices'), record=1)
             menusym.type = "menu"
-	    list = parse_symbol_tree(input)
+            list = parse_symbol_tree(input)
             #print "Adding %s to %s" % (list, menusym.name)
             # Add and validate items
             menusym.items += list
             for symbol in list:
                 if symbol.menu:
                     input.complain("symbol %s in %s occurs in another menu (%s)"
-				       % (symbol.name, menusym.name, symbol.menu.name))
+                                       % (symbol.name, menusym.name, symbol.menu.name))
                 else:
                     symbol.menu = menusym
-	elif leader.type == "choices":
-	    menusym = intern_symbol(input, None, ('bool', 'menu', 'choices'), record=1)
+        elif leader.type == "choices":
+            menusym = intern_symbol(input, None, ('bool', 'menu', 'choices'), record=1)
             menusym.type = "choices"
             list = parse_symbol_tree(input)
             for symbol in list:
                 symbol.type = "bool"
-                symbol.choicegroup = filter(lambda x, s=symbol: x != s, list)
+                symbol.choicegroup = list(filter(lambda x, s=symbol: x != s, list))
             dflt = input.lex_token()
             if dflt.type != 'default':
                 default = list[0].name
                 input.push_token(dflt)
             else:
                 default = intern_symbol(input, None, None, record=1)
-	    if default not in list:
-		input.complain("default %s must be in the menu" % (`default`,))
-	    else:
-		menusym.default = default
+            if default not in list:
+                input.complain("default %s must be in the menu" % (repr(default),))
+            else:
+                menusym.default = default
                 menusym.items = list
                 for symbol in list:
                     if symbol.menu:
@@ -536,16 +536,16 @@ def parse(input, baton):
                                        % (symbol.name, symbol.menu.name))
                     else:
                         symbol.menu = menusym
-	elif leader.type == "choicegroup":
-	    group = intern_symbol_list(input)
+        elif leader.type == "choicegroup":
+            group = intern_symbol_list(input)
             for symbol in group:
-                symbol.choicegroup = filter(lambda x, s=symbol: x != s, group)
-	elif leader.type == "derive":
+                symbol.choicegroup = list(filter(lambda x, s=symbol: x != s, group))
+        elif leader.type == "derive":
             symbol = intern_symbol(input)
-	    input.demand("word", "from")
+            input.demand("word", "from")
             symbol.default = parse_expr(input)
             compstate.derivations[symbol] = 1
-	elif leader.type in ("require", "prohibit"):
+        elif leader.type in ("require", "prohibit"):
             expr = parse_expr(input)
             if leader.type == "prohibit":
                 expr = ('==', expr, cml.n)
@@ -556,7 +556,7 @@ def parse(input, baton):
             else:
                 expl = input.lex_token()
                 if expl.type != 'word':
-                    input.complain("while expecting a word of explanation, I see %s" % (`expl`,))
+                    input.complain("while expecting a word of explanation, I see %s" % (repr(expl),))
                     continue
                 entry = intern_symbol(input, expl.attr)
                 if entry.type:
@@ -564,17 +564,17 @@ def parse(input, baton):
                 else:
                     entry.type = "explanation"
                 msg = entry.prompt
-	    rulebase.constraints.append(cml.Requirement(expr, msg, input.infile, input.lineno))	    
-	    compstate.bool_tests.append((expr, input.infile, input.lineno))
-	elif leader.type == "default":
-	    symbol = input.demand("word")
-	    input.demand("word", "from")
-	    expr = parse_expr(input)
+            rulebase.constraints.append(cml.Requirement(expr, msg, input.infile, input.lineno))     
+            compstate.bool_tests.append((expr, input.infile, input.lineno))
+        elif leader.type == "default":
+            symbol = input.demand("word")
+            input.demand("word", "from")
+            expr = parse_expr(input)
             entry = intern_symbol(input, symbol)
-	    if entry.default: 
-		input.complain("%s already has a default" % (symbol,))
-	    else:
-		entry.default = expr
+            if entry.default: 
+                input.complain("%s already has a default" % (symbol,))
+            else:
+                entry.default = expr
             next = input.lex_token()
             if next.type == "range":
                 entry.range = []
@@ -629,17 +629,17 @@ def parse(input, baton):
             else:
                 input.push_token(next)
                 continue
-	elif leader.type == 'give':
-	    list = intern_symbol_list(input)
+        elif leader.type == 'give':
+            list = intern_symbol_list(input)
             input.demand('property')
             label = input.lex_token()
             for symbol in list:
                 symbol.setprop(label.attr)
-	elif leader.type == 'debug':
+        elif leader.type == 'debug':
             compstate.debug = input.lex_token().attr
-	elif leader.type == 'prefix':
+        elif leader.type == 'prefix':
             rulebase.prefix = input.lex_token().attr
-	elif leader.type == 'banner':
+        elif leader.type == 'banner':
             entry = intern_symbol(input, None, record=1)
             entry.type = "message"
             rulebase.banner = entry
@@ -657,7 +657,7 @@ def parse(input, baton):
             elif switch.type == "string":
                 val = switch.attr
             elif switch.type == "trit":
-                val = resolve(switch)	# No flag is module-valued yet
+                val = resolve(switch)   # No flag is module-valued yet
             entry = intern_symbol(input, switch.attr)
             # Someday is today
             if flag == "trits":
@@ -678,7 +678,7 @@ def parse(input, baton):
             else:
                 input.complain("unknown flag %s in condition statement" % (flag,))
         elif leader.type == 'warndepend':
-	    iffy = intern_symbol_list(input)
+            iffy = intern_symbol_list(input)
             for symbol in iffy:
                 compstate.warndepend.append(symbol)
         elif leader.type == 'property':
@@ -694,15 +694,15 @@ def parse(input, baton):
                         input.push_token(alias)
                         break
                     compstate.propnames[alias.attr] = propname.attr
-	else:
-	    input.croak("syntax error, unknown statement %s" % (leader,))
+        else:
+            input.croak("syntax error, unknown statement %s" % (leader,))
 
 # Mwnu list parsing
 
 def get_symbol_declaration(input):
     # First grab a properties prefix
     global compstate
-    if compstate.debug >= 2: print "entering get_symbol_declaration..."
+    if compstate.debug >= 2: print("entering get_symbol_declaration...")
     props = []
     propflag = 1
     while 1:
@@ -720,7 +720,7 @@ def get_symbol_declaration(input):
     #if compstate.debug >= 2: print "label list is %s" % props
     # Now, we get either a subtree or a single declaration
     symbol = input.lex_token()
-    if symbol.attr == '{':		# Symbol subtree
+    if symbol.attr == '{':              # Symbol subtree
         if compstate.symbol_list and compstate.symbol_list[0].type == "string":
             input.complain("string symbol is not a legal submenu guard")
         if compstate.symbol_list:
@@ -737,8 +737,8 @@ def get_symbol_declaration(input):
             compstate.condition_stack.pop()
         compstate.property_stack.pop()
         return 0
-    elif symbol.type == 'word':		# Declaration
-        if compstate.debug >= 2: print "interning %s" % symbol.attr
+    elif symbol.type == 'word':         # Declaration
+        if compstate.debug >= 2: print("interning %s" % symbol.attr)
         entry = intern_symbol(input, symbol.attr, record=1)
         compstate.symbol_list.append(entry)
         entry.depth = len(compstate.condition_stack)
@@ -751,11 +751,11 @@ def get_symbol_declaration(input):
                 if flag:
                     propdict[property] = 1
                 else:
-                    if not propdict.has_key(property):
+                    if property not in propdict:
                         input.complain("property %s can't be removed when it's not present" % property)
                     else:
                         propdict[property] = 0
-        for (prop, val) in propdict.items():
+        for (prop, val) in list(propdict.items()):
             if val == 1 and not entry.hasprop(prop):
                 entry.setprop(prop)
             elif val == 0 and entry.hasprop(prop):
@@ -764,13 +764,13 @@ def get_symbol_declaration(input):
         if entry.type not in ("menu", "choices", "explanation", "message"):
             entry.type = "bool"
             symbol = input.lex_token()
-            if symbol.type == '?':	# This is also an operator
+            if symbol.type == '?':      # This is also an operator
                 entry.type = 'trit'
             elif symbol.attr == '%':
                 entry.type = 'decimal'
             elif symbol.attr == '@':
                 entry.type = 'hexadecimal'
-            elif symbol.type == '$':	# This is also an operator
+            elif symbol.type == '$':    # This is also an operator
                 entry.type = 'string'
             else:
                 input.push_token(symbol)
@@ -792,15 +792,15 @@ def inner_symbol_tree(input):
 
 def parse_symbol_tree(input):
     global compstate
-    if compstate.debug >= 2: print "entering parse_symbol_tree..."
+    if compstate.debug >= 2: print("entering parse_symbol_tree...")
     # Get a nonempty list of config symbols and menu ids. 
     # Interpret the {} shorthand if second argument is nonempty
-    compstate.condition_stack = []	# Stack of active conditions for {} shorthand
+    compstate.condition_stack = []      # Stack of active conditions for {} shorthand
     compstate.property_stack = []
     compstate.symbol_list = []
     inner_symbol_tree(input)
     if not list:
-	input.complain("syntax error, expected a nonempty symbol declaration list")
+        input.complain("syntax error, expected a nonempty symbol declaration list")
     if compstate.symbol_list[0].depth == 1:
         for symbol in compstate.symbol_list:
             symbol.depth -= 1
@@ -809,7 +809,7 @@ def parse_symbol_tree(input):
 def traverse_make_dep(symbol, guard, input):
     "Create the dependency relations implied by a 'suppress depend' guard."
     #print "traverse_make_dep(%s, %s)" % (symbol.name, guard)
-    if compstate.derivations.has_key(symbol):
+    if symbol in compstate.derivations:
         return  
     elif isinstance(guard, cml.trit) or (isinstance(guard, Token) and guard.attr in ("n", "m", "y")):
         return
@@ -827,7 +827,7 @@ def traverse_make_dep(symbol, guard, input):
         traverse_make_dep(symbol, guard[1], input)
         traverse_make_dep(symbol, guard[2], input)
     elif guard[0] in _boolops:
-        return		# Don't descend into disjunctions
+        return          # Don't descend into disjunctions
     else:
         input.complain("unexpected operation %s in visibility guard"%guard[0])
 
@@ -862,7 +862,7 @@ def validate_expr(expr, file, line):
             return expr.type
     elif isinstance(expr, cml.trit):
         return "trit"
-    elif type(expr) in (type(0), type(0L)):
+    elif type(expr) in (type(0), type(0)):
         return "integer"
     elif type(expr) == type(""):
         return "string"
@@ -904,10 +904,10 @@ def validate_expr(expr, file, line):
 def symbols_by_preorder(node):
     # Get a list of config symbols in natural traverse order
     if node.items:
-       sublists = map(symbols_by_preorder, node.items)
+       sublists = list(map(symbols_by_preorder, node.items))
        flattened = []
        for m in sublists:
-	   flattened = flattened + m
+           flattened = flattened + m
        return flattened
     else:
        return [node.name]
@@ -915,22 +915,22 @@ def symbols_by_preorder(node):
 def resolve(exp):
     # Replace symbols in an expr with resolved versions
     if type(exp) is type(()):
-	if exp[0] == 'not':
-	    return ('not', resolve(exp[1]))
-	elif exp[0] == '?':
-	    return ('?', resolve(exp[1]), resolve(exp[2]), resolve(exp[3]))
-	else:
-	    return (exp[0], resolve(exp[1]), resolve(exp[2]))
-    elif isinstance(exp, cml.ConfigSymbol):	# Symbol, already resolved
-	return exp
-    elif isinstance(exp, cml.trit):		# Trit, already resolved
-	return exp
-    elif type(exp) in (type(0), type("")):	# Constant, already resolved
-	return exp
+        if exp[0] == 'not':
+            return ('not', resolve(exp[1]))
+        elif exp[0] == '?':
+            return ('?', resolve(exp[1]), resolve(exp[2]), resolve(exp[3]))
+        else:
+            return (exp[0], resolve(exp[1]), resolve(exp[2]))
+    elif isinstance(exp, cml.ConfigSymbol):     # Symbol, already resolved
+        return exp
+    elif isinstance(exp, cml.trit):             # Trit, already resolved
+        return exp
+    elif type(exp) in (type(0), type("")):      # Constant, already resolved
+        return exp
     elif not hasattr(exp, "type"):
-	sys.stderr.write("Symbol %s has no type.\n" % (exp,))
-	compstate.errors = compstate.errors + 1
-	return None
+        sys.stderr.write("Symbol %s has no type.\n" % (exp,))
+        compstate.errors = compstate.errors + 1
+        return None
     elif exp.type == 'trit':
         if exp.attr == 'y':
             return cml.y
@@ -939,47 +939,47 @@ def resolve(exp):
         elif exp.attr == 'n':
             return cml.n
     elif exp.type in _atoms:
-	return exp.attr
-    elif rulebase.dictionary.has_key(exp.attr):
-	return rulebase.dictionary[exp.attr]
+        return exp.attr
+    elif exp.attr in rulebase.dictionary:
+        return rulebase.dictionary[exp.attr]
     else:
-	compstate.bad_symbols[exp.attr] = 1
-	return None
+        compstate.bad_symbols[exp.attr] = 1
+        return None
 
 def ancestry_check(symbol, counts):
     # Check for circular ancestry chains
     # print "Checking ancestry of %s: %s" % (symbol, symbol.ancestors)
     counts[symbol] = 1
     for ancestor in symbol.ancestors:
-        if counts.has_key(ancestor.name):
-            raise NameError, symbol.name + " through " + ancestor.name
+        if ancestor.name in counts:
+            raise NameError(symbol.name + " through " + ancestor.name)
         else:
-            map(lambda symbol, counts=counts: ancestry_check(symbol, counts), symbol.ancestors)
+            list(map(lambda symbol, counts=counts: ancestry_check(symbol, counts), symbol.ancestors))
 
 def circularity_check(name, exp, counts):
     # Recursive circularity check...
     # print "Expression check of %s against %s" % (name, exp)
     if type(exp) is type(()):
         if exp[0] == '?':
-	    circularity_check(name, exp[1], counts)
-	    circularity_check(name, exp[2], counts)
-	    circularity_check(name, exp[3], counts)
-	else:
-	    circularity_check(name, exp[1], counts)
-	    circularity_check(name, exp[2], counts)
+            circularity_check(name, exp[1], counts)
+            circularity_check(name, exp[2], counts)
+            circularity_check(name, exp[3], counts)
+        else:
+            circularity_check(name, exp[1], counts)
+            circularity_check(name, exp[2], counts)
     elif isinstance(exp, cml.ConfigSymbol) and name == exp.name:
-        raise NameError, name
+        raise NameError(name)
     elif hasattr(exp, "default"):
-	vars = cml.flatten_expr(exp.default)
-	# print "Components of %s default: %s" % (exp.name vars) 
-	for v in vars:
-	    if v.name == name:
-		raise NameError, name
-	    elif counts.has_key(v.name):
-		pass		# Already checked this branch
-	    else:
-		counts[v.name] = 1
-		circularity_check(name, v.name, counts)
+        vars = cml.flatten_expr(exp.default)
+        # print "Components of %s default: %s" % (exp.name vars) 
+        for v in vars:
+            if v.name == name:
+                raise NameError(name)
+            elif v.name in counts:
+                pass            # Already checked this branch
+            else:
+                counts[v.name] = 1
+                circularity_check(name, v.name, counts)
 
 def error_leader(file, line):
     return '"%s", line %d:' % (file, line)
@@ -1011,18 +1011,18 @@ def compile(debug, arguments, profile, endtok=None):
 
     # Parse everything
     try:
-	if not arguments:
-	    parse(lexwrapper(sys.stdin, endtok), baton)
-	else:
-	    for file in arguments:
-		parse(lexwrapper(open(file), endtok), baton)
-    except IOError, details:
-	sys.stderr.write("cmlcompile: I/O error, %s\n" % (details,))
-	return None
+        if not arguments:
+            parse(lexwrapper(sys.stdin, endtok), baton)
+        else:
+            for file in arguments:
+                parse(lexwrapper(open(file), endtok), baton)
+    except IOError as details:
+        sys.stderr.write("cmlcompile: I/O error, %s\n" % (details,))
+        return None
 
     if profile:
         now = time.time();
-        print "Rule parsing:", now - basetime
+        print("Rule parsing:", now - basetime)
         basetime = now
     if not debug and not compstate.errors:
         baton.twirl()
@@ -1031,32 +1031,32 @@ def compile(debug, arguments, profile, endtok=None):
 
     # We need a main menu declaration
     if not rulebase.start:
-	postcomplain("missing a start declaration.\n")
-	return None
-    elif not rulebase.dictionary.has_key(rulebase.start):
-	postcomplain("declared start menu '%s' does not exist.\n"%(rulebase.start,))
-	return None
+        postcomplain("missing a start declaration.\n")
+        return None
+    elif rulebase.start not in rulebase.dictionary:
+        postcomplain("declared start menu '%s' does not exist.\n"%(rulebase.start,))
+        return None
     if not debug and not compstate.errors:
         baton.twirl()
 
     # Check for symbols that have been forward-referenced but not declared
-    for ref in rulebase.dictionary.values():
-        if not ref.prompt and not compstate.derivations.has_key(ref):
-            postcomplain('"%s", line %d: %s in menu %s has no prompt\n' % (ref.file, ref.lineno, ref.name, `ref.menu`))
+    for ref in list(rulebase.dictionary.values()):
+        if not ref.prompt and ref not in compstate.derivations:
+            postcomplain('"%s", line %d: %s in menu %s has no prompt\n' % (ref.file, ref.lineno, ref.name, repr(ref.menu)))
 
     # Check that all symbols other than those on the right side of
     # derives are either known or themselves derived.
-    for entry in rulebase.dictionary.values():
+    for entry in list(rulebase.dictionary.values()):
         if entry.visibility:
             entry.visibility = resolve(entry.visibility)
         if entry.saveability:
             entry.saveability = resolve(entry.saveability)
-	if entry.default:
-	    entry.default = resolve(entry.default)
-    rulebase.constraints = map(lambda x: cml.Requirement(resolve(x.predicate), x.message, x.file, x.line), rulebase.constraints)
+        if entry.default:
+            entry.default = resolve(entry.default)
+    rulebase.constraints = [cml.Requirement(resolve(x.predicate), x.message, x.file, x.line) for x in rulebase.constraints]
     if compstate.bad_symbols:
-	postcomplain("%d symbols could not be resolved:\n"%(len(compstate.bad_symbols),))
-	sys.stderr.write(`compstate.bad_symbols.keys()` + "\n")
+        postcomplain("%d symbols could not be resolved:\n"%(len(compstate.bad_symbols),))
+        sys.stderr.write(repr(list(compstate.bad_symbols.keys())) + "\n")
     if not debug and not compstate.errors:
         baton.twirl()
 
@@ -1068,8 +1068,8 @@ def compile(debug, arguments, profile, endtok=None):
     # possible deductions, even in the presence of forward declarations.)
     while 1:
         deducecount = 0
-        for entry in rulebase.dictionary.values():
-            if compstate.derivations.has_key(entry) and not entry.type:
+        for entry in list(rulebase.dictionary.values()):
+            if entry in compstate.derivations and not entry.type:
                 derived_type = None
                 if entry.default == cml.m:
                     derived_type = "trit"
@@ -1087,12 +1087,12 @@ def compile(debug, arguments, profile, endtok=None):
                             derived_type = entry.default[2].type
                         elif isinstance(entry.default[2], cml.trit):
                             derived_type = "trit"
-                        elif type(entry.default[2]) in (type(0), type(0L)):
+                        elif type(entry.default[2]) in (type(0), type(0)):
                             derived_type = "decimal"
                         elif type(entry.default[2]) is type(""):
                             derived_type = "string"
                 elif type(entry.default) is type(0):
-                    derived_type = "decimal"		# Could be hex
+                    derived_type = "decimal"            # Could be hex
                 elif type(entry.default) is type(""):
                     derived_type = "string"
                 elif isinstance(entry.default, cml.ConfigSymbol):
@@ -1103,8 +1103,8 @@ def compile(debug, arguments, profile, endtok=None):
         if not deducecount:
             break
 
-    for entry in rulebase.dictionary.values():
-        if compstate.derivations.has_key(entry) and not entry.type:
+    for entry in list(rulebase.dictionary.values()):
+        if entry in compstate.derivations and not entry.type:
             postcomplain(error_leader(entry.file, entry.lineno) + \
                              'can\'t deduce type for derived symbol %s from %s\n' % (entry.name, entry.default))
     if not debug and not compstate.errors:
@@ -1117,7 +1117,7 @@ def compile(debug, arguments, profile, endtok=None):
         baton.twirl()
 
     # Handle explicit dependencies
-    for symbol in compstate.explicit_ancestors.keys():
+    for symbol in list(compstate.explicit_ancestors.keys()):
         for guard in compstate.explicit_ancestors[symbol]:
             for guardsymbol in cml.flatten_expr(resolve(guard)):
                 make_dependent(guardsymbol, symbol)
@@ -1129,12 +1129,12 @@ def compile(debug, arguments, profile, endtok=None):
     # exactly once (except explanations).  We checked for multiple
     # inclusions at parse-tree generation time.  Now...
     compstate.bad_symbols = {}
-    for entry in rulebase.dictionary.values():
-	if entry.prompt and not entry.type:
-	    compstate.bad_symbols[entry.name] = 1 
+    for entry in list(rulebase.dictionary.values()):
+        if entry.prompt and not entry.type:
+            compstate.bad_symbols[entry.name] = 1 
     if compstate.bad_symbols:
-	postcomplain("%d symbols have no references"%(len(compstate.bad_symbols),))
-        sys.stderr.write("\n" +`compstate.bad_symbols.keys()` + "\n")
+        postcomplain("%d symbols have no references"%(len(compstate.bad_symbols),))
+        sys.stderr.write("\n" +repr(list(compstate.bad_symbols.keys())) + "\n")
     if not debug and not compstate.errors:
         baton.twirl()
 
@@ -1142,13 +1142,13 @@ def compile(debug, arguments, profile, endtok=None):
     # Note: this is *not* a fatal error.
     preorder = symbols_by_preorder(rulebase.dictionary[rulebase.start])
     for i in range(len(preorder)):
-	key = preorder[i]
-	forwards = []
+        key = preorder[i]
+        forwards = []
         for guards in cml.flatten_expr(rulebase.dictionary[key].visibility):
             if guards.name in preorder[i+1:]:
                 forwards.append(guards.name)
-	if forwards:
-	    sym = rulebase.dictionary[key]
+        if forwards:
+            sym = rulebase.dictionary[key]
             postcomplain('"%s", line %d: %s in %s requires %s forward\n' % (sym.file, sym.lineno, key, sym.menu.name, forwards))
             compstate.errors -= 1
     if not debug and not compstate.errors:
@@ -1156,7 +1156,7 @@ def compile(debug, arguments, profile, endtok=None):
 
     # Check for circularities in derives and defaults.
     try:
-        for entry in rulebase.dictionary.values():
+        for entry in list(rulebase.dictionary.values()):
             if entry.default:
                 expr_counts = {}
                 circularity_check(entry.name, entry.default, expr_counts)
@@ -1167,22 +1167,22 @@ def compile(debug, arguments, profile, endtok=None):
                 ancestor_counts = {}
                 ancestry_check(entry, ancestor_counts)
     except NameError:
-	postcomplain("%s depends on itself\n"%(sys.exc_value,))
+        postcomplain("%s depends on itself\n"%(sys.exc_info()[1],))
     if not debug and not compstate.errors:
         baton.twirl()
 
     # Various small hacks combined here to save traversal overhead.
     bitch_once = {}
-    for entry in rulebase.dictionary.values():
+    for entry in list(rulebase.dictionary.values()):
         # Validate choice groups
         for symbol in entry.choicegroup:
-            if not symbol.is_logical() and not bitch_once.has_key(symbol):
+            if not symbol.is_logical() and symbol not in bitch_once:
                 postcomplain("Symbol %s in a choicegroup is not logical" % symbol.name)
                 bitch_once[symbol] = 1
         # Validate the formulas for boolean derived symbols.
-        if compstate.derivations.has_key(entry):
+        if entry in compstate.derivations:
             if entry.menu:
-		postcomplain("menu %s contains derived symbol %s\n"%(entry.menu.name, `entry`))
+                postcomplain("menu %s contains derived symbol %s\n"%(entry.menu.name, repr(entry)))
             if entry.type == "bool":
                 validate_boolean(entry.default, entry.file, entry.lineno)
             else:
@@ -1192,26 +1192,26 @@ def compile(debug, arguments, profile, endtok=None):
         #    validate_expr(entry.default, entry.file, entry.lineno)
         # Give childless menus the `message' type.  This will make
         # it easier for the front end to do special things with these objects.
-	if entry.type == 'menu':
-	    if not entry.items:
-		entry.type = 'message'
+        if entry.type == 'menu':
+            if not entry.items:
+                entry.type = 'message'
             continue
         # Check for type mismatches between symbols and their defaults.
         if entry.is_symbol() and not entry.default is None:
-            if type(entry.default) in (type(0L),type(0)) and not entry.is_numeric():
+            if type(entry.default) in (type(0),type(0)) and not entry.is_numeric():
                 postcomplain("%s is not of numeric type but has numeric constant default\n" % entry.name)
             elif type(entry.default) == type("") and not entry.type == "string":
                 postcomplain("%s is not of string type but has string constant default\n" % entry.name)
         # Symbols with decimal/hexadecimal/string type must have a default.
-	if entry.type in ("decimal", "hexadecimal", "string"):
-	    if entry.default is None:
-		postcomplain("%s needs a default\n"%(`entry`,))
+        if entry.type in ("decimal", "hexadecimal", "string"):
+            if entry.default is None:
+                postcomplain("%s needs a default\n"%(repr(entry),))
         elif entry.range:
             # This member can be used by front ends to determine whether the
             # entry's value should be queried with a pulldown of its values.
-            entry.discrete = not filter(lambda x: type(x) is type(()), entry.range)
-	    # This member can be used by front ends to determine whether the
-	    # entry's value should be queried with a pulldown of enums.
+            entry.discrete = not [x for x in entry.range if type(x) is type(())]
+            # This member can be used by front ends to determine whether the
+            # entry's value should be queried with a pulldown of enums.
             entry.enum = type(entry.range[0]) is type(()) \
                          and type(entry.range[0][0]) is type("")
         # Now hack the prompts of anything dependent on a warndepend symbol
@@ -1229,24 +1229,24 @@ def compile(debug, arguments, profile, endtok=None):
     if not compstate.errors:
         for wff in rulebase.constraints:
             if not cml.evaluate(wff.predicate, debug):
-                postcomplain(error_leader(wff.file, wff.line) + " constraint violation: %s\n" % `wff`)
+                postcomplain(error_leader(wff.file, wff.line) + " constraint violation: %s\n" % repr(wff))
         if not debug and not compstate.errors:
             baton.twirl()
 
     # Now integrate the help references
     help_dict = {}
-    for key in rulebase.dictionary.keys():
-	if help_dict.has_key(key):
-	    rulebase.dictionary[key].helptext = help_dict[key]
-	    del help_dict[key]
+    for key in list(rulebase.dictionary.keys()):
+        if key in help_dict:
+            rulebase.dictionary[key].helptext = help_dict[key]
+            del help_dict[key]
     if debug:
-	missing = []
-	for entry in rulebase.dictionary.values():
-	    if not entry.type in ("message", "menu", "choices", "explanation") and entry.prompt and not entry.help():
-		missing.append(entry.name)
-	if missing:
-	    postcomplain("The following symbols lack help entries: %s\n" % missing)
-	orphans = help_dict.keys()
+        missing = []
+        for entry in list(rulebase.dictionary.values()):
+            if not entry.type in ("message", "menu", "choices", "explanation") and entry.prompt and not entry.help():
+                missing.append(entry.name)
+        if missing:
+            postcomplain("The following symbols lack help entries: %s\n" % missing)
+        orphans = list(help_dict.keys())
         if orphans:
             postcomplain("The following help entries do not correspond to symbols: %s\n" % orphans)
     if not debug and not compstate.errors:
@@ -1254,7 +1254,7 @@ def compile(debug, arguments, profile, endtok=None):
 
     if profile:
         now = time.time();
-        print "Sanity checks:", now - basetime
+        print("Sanity checks:", now - basetime)
         basetime = now
 
     # We only need the banner string, not the banner symbol
@@ -1263,27 +1263,27 @@ def compile(debug, arguments, profile, endtok=None):
 
     # Package everything up for pickling
     if compstate.errors:
-	postcomplain("rulebase write suppressed due to errors.\n")
-	return None
+        postcomplain("rulebase write suppressed due to errors.\n")
+        return None
     else:
         rulebase.start = rulebase.dictionary[rulebase.start]
         # Precomputation to speed up the configurator's load time
-        rulebase.reduced = map(lambda x: x.predicate, rulebase.constraints)
+        rulebase.reduced = [x.predicate for x in rulebase.constraints]
         rulebase.optimize_constraint_access()
         if debug:
             cc = dc = tc = 0
-            for symbol in rulebase.dictionary.values():
-                if not compstate.derivations.has_key(entry):
+            for symbol in list(rulebase.dictionary.values()):
+                if entry not in compstate.derivations:
                     tc = tc + 1
                 if symbol.dependents:
                     dc = dc + 1
                 if symbol.constraints:
                     cc = cc + 1
-            print "%d total symbols; %d symbols are involved in constraints; %d in dependencies." % (tc, cc, dc)
+            print("%d total symbols; %d symbols are involved in constraints; %d in dependencies." % (tc, cc, dc))
 
         if profile:
             now = time.time();
-            print "Total compilation time:", now - zerotime
+            print("Total compilation time:", now - zerotime)
 
         # We have a rulebase object.
         return rulebase
@@ -1293,30 +1293,30 @@ if __name__ == '__main__':
         "Compile and write out a ruebase."
         rulebase = compile(debug, arguments, profile)
         if not rulebase:
-            raise SystemExit, 1
+            raise SystemExit(1)
         else:
             try:
-                if debug: print "cmlcompile: output directed to %s" % (outfile)
+                if debug: print("cmlcompile: output directed to %s" % (outfile))
                 out = open(outfile, "wb")
-                cPickle.dump(rulebase, out, 1)
+                pickle.dump(rulebase, out, 1)
                 out.close()
             except:
                 postcomplain('couldn\'t open output file "%s"\n' % (outfile,))
-                raise SystemExit, 1
+                raise SystemExit(1)
 
     outfile = "rules.out"
     profile = debug = 0
     (options, arguments) = getopt.getopt(sys.argv[1:], "o:Pv", "help")
     for (switch, val) in options:
-	if switch == '-o':
-	    outfile = val
-	elif switch == '-P':
-	    profile = 1
-	elif switch == '-v':
-	    debug = debug + 1
-	elif switch == '--help':
-	    sys.stdout.write(lang["CLIHELP"])
-	    raise SystemExit
+        if switch == '-o':
+            outfile = val
+        elif switch == '-P':
+            profile = 1
+        elif switch == '-v':
+            debug = debug + 1
+        elif switch == '--help':
+            sys.stdout.write(lang["CLIHELP"])
+            raise SystemExit
 
     if profile:
         import profile

--- a/contrib/cml2/cmlconfigure.py
+++ b/contrib/cml2/cmlconfigure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # cmlconfigure.py -- CML2 configurator front ends
 # by Eric S. Raymond, <esr@thyrsus.com>
@@ -8,8 +8,8 @@
 import sys
 
 if sys.version[0] < '2':
-    print "Python 2.0 or later is required for this program."
-    raise SystemExit, 1
+    print("Python 2.0 or later is required for this program.")
+    raise SystemExit(1)
 
 import os, string, getopt, cmd, re, time
 import cml, cmlsystem, webbrowser
@@ -158,7 +158,7 @@ _eng = {
     "TOOLONG":"String is too long to edit.  Use cmlconfigure -t.", 
     "TRIT":"`m' can only be applied to tristates",
     "TTYQUERY":"Type '?' at any prompt for help, 'h' for command help.",
-    "TTYSUMMARY":"		     Command summary:",
+    "TTYSUMMARY":"                   Command summary:",
     "UHELP":"u -- toggle interactive flag.",
     "UNSUPPRESSBUTTON":"Unsuppress",
     "UNKNOWN":"Unknown command %s -- type `h' for a command summary",
@@ -348,7 +348,7 @@ def cgenvalue(symbol):
     elif symbol.type == "message":
         return ""
     elif symbol.type == "menu":
-        return "-->"		# Effective only in menuconfig
+        return "-->"            # Effective only in menuconfig
     elif symbol.type in ("decimal", "string"):
         return str(value)
     elif symbol.type == "hexadecimal":
@@ -381,18 +381,18 @@ class tty_style_base(cmd.Cmd):
         "Set the value of a symbol -- line-oriented error messages."
         if symbol.is_numeric() and symbol.range:
             if not configuration.range_check(symbol, value):
-                print lang["OUTOFBOUNDS"] % (value, symbol.range,)
+                print(lang["OUTOFBOUNDS"] % (value, symbol.range,))
                 return
-	(ok, effects, violations) = configuration.set_symbol(symbol, value, freeze)
+        (ok, effects, violations) = configuration.set_symbol(symbol, value, freeze)
         if effects:
-            print lang["EFFECTS"]
+            print(lang["EFFECTS"])
             sys.stdout.write(string.join(effects, "\n") + "\n\n")
         if ok:
             if not interactively_visible(symbol):
-                print lang["INVISOUT"] % symbol.name
+                print(lang["INVISOUT"] % symbol.name)
         else:
-	    print lang["ROLLBACK"] % (symbol.name, value)
-            sys.stdout.write(string.join(map(repr, violations), "\n") + "\n")
+            print(lang["ROLLBACK"] % (symbol.name, value))
+            sys.stdout.write(string.join(list(map(repr, violations)), "\n") + "\n")
 
     def page(self, text):
         text = string.split(text, "\n")
@@ -407,44 +407,44 @@ class tty_style_base(cmd.Cmd):
                 for i in range(base, base+pagedepth):
                     if i >= len(text):
                         break;
-                    print text[i]
+                    print(text[i])
                 base = base + pagedepth
-                raw_input(lang["PAGEPROMPT"])
+                input(lang["PAGEPROMPT"])
         except KeyboardInterrupt:
-            print ""
+            print("")
 
     def __init__(self, config, mybanner):
         cmd.Cmd.__init__(self)
-	self.config = config
+        self.config = config
         if mybanner and configuration.banner.find("%s") > -1:
             self.banner = configuration.banner % mybanner
         elif mybanner:
             self.banner = mybanner
         else:
             self.banner = configuration.banner
-	self.current = configuration.start;
+        self.current = configuration.start;
 
     def do_g(self, line):
-	if configuration.dictionary.has_key(line):
-	    self.current = configuration.dictionary[line]
+        if line in configuration.dictionary:
+            self.current = configuration.dictionary[line]
             configuration.visit(self.current)
             if not interactively_visible(self.current) and not self.current.frozen():
-                print lang["SUPPRESSOFF"]
+                print(lang["SUPPRESSOFF"])
                 self.suppressions = 0
-	    if self.current.type in ("menu", "message"):
-		self.skip_to_query(configuration.next_node, 1)
-	else:
-	    print lang["NONEXIST"] % line
+            if self.current.type in ("menu", "message"):
+                self.skip_to_query(configuration.next_node, 1)
+        else:
+            print(lang["NONEXIST"] % line)
     def do_i(self, line):
         file = string.strip(line)
         try:
             (changes, errors) = configuration.load(file, freeze=0)
         except IOError:
-            print lang["LOADFAIL"] % file
+            print(lang["LOADFAIL"] % file)
         else:
             if errors:
-                print errors
-            print lang["INCCHANGES"] % (changes,file)
+                print(errors)
+            print(lang["INCCHANGES"] % (changes,file))
             if configuration.side_effects:
                 sys.stdout.write(string.join(configuration.side_effects, "\n") + "\n")
     def do_I(self, line):
@@ -452,11 +452,11 @@ class tty_style_base(cmd.Cmd):
         try:
             (changes, errors) = configuration.load(file, freeze=1)
         except IOError:
-            print lang["LOADFAIL"] % file
+            print(lang["LOADFAIL"] % file)
         else:
             if errors:
-                print errors
-            print lang["INCCHANGES"] % (changes,file)
+                print(errors)
+            print(lang["INCCHANGES"] % (changes,file))
             if configuration.side_effects:
                 sys.stdout.write(string.join(configuration.side_effects, "\n") + "\n")
     def do_y(self, line):
@@ -465,16 +465,16 @@ class tty_style_base(cmd.Cmd):
         else: 
             # Undocumented feature -- "y FOO" sets FOO to y.
             line = string.strip(line)
-            if not configuration.dictionary.has_key(line):
-                print lang["NONEXIST"] % line
+            if line not in configuration.dictionary:
+                print(lang["NONEXIST"] % line)
                 return
             else:
                 target = configuration.dictionary[line]
-	if not target.type in ("trit", "bool"):
-	    print lang["YNOTVALID"] % (target.name)
-	else:
-	    self.set_symbol(target, cml.y)
-	return None
+        if not target.type in ("trit", "bool"):
+            print(lang["YNOTVALID"] % (target.name))
+        else:
+            self.set_symbol(target, cml.y)
+        return None
     def do_Y(self, line):
         self.do_y(line)
     def do_m(self, line):
@@ -483,18 +483,18 @@ class tty_style_base(cmd.Cmd):
         else:
             # Undocumented feature -- "m FOO" sets FOO to m.
             line = string.strip(line)
-            if not configuration.dictionary.has_key(line):
-                print lang["NONEXIST"] % line
+            if line not in configuration.dictionary:
+                print(lang["NONEXIST"] % line)
                 return
             else:
                 target = configuration.dictionary[line]
-	if not target.type == "trit":
-	    print lang["MNOTVALID"] % (target.name)
+        if not target.type == "trit":
+            print(lang["MNOTVALID"] % (target.name))
         elif not configuration.trits_enabled:
-	    print lang["MNOTVALID"] % (target.name)
-	else:
-	    self.set_symbol(target, cml.m)
-	return None
+            print(lang["MNOTVALID"] % (target.name))
+        else:
+            self.set_symbol(target, cml.m)
+        return None
     def do_M(self, line):
         self.do_m(line)
     def do_n(self, line):
@@ -503,33 +503,33 @@ class tty_style_base(cmd.Cmd):
         else:
             # Undocumented feature -- "n FOO" sets FOO to n.
             line = string.strip(line)
-            if not configuration.dictionary.has_key(line):
-                print lang["NONEXIST"] % line
+            if line not in configuration.dictionary:
+                print(lang["NONEXIST"] % line)
                 return
             else:
                 target = configuration.dictionary[line]
-	if not target.type in ("trit", "bool"):
-	    print lang["NNOTVALID"] % (target.name)
-	else:
-	    self.set_symbol(target, cml.n)
-	return None
+        if not target.type in ("trit", "bool"):
+            print(lang["NNOTVALID"] % (target.name))
+        else:
+            self.set_symbol(target, cml.n)
+        return None
     def do_N(self, line):
         self.do_n(line)
     def do_s(self, line):
-	file = string.strip(line)
+        file = string.strip(line)
         failure = configuration.save(file, cml.Baton(lang["SAVESTART"] % file, lang["SAVEEND"]))
         if failure:
-            print failure
+            print(failure)
     def do_x(self, dummy):
-	# Terminate this cmd instance, saving configuration
+        # Terminate this cmd instance, saving configuration
         self.do_s(config)
-	return 1
+        return 1
     def do_C(self, line):
         # Show constraints (all, or all including specified symbol).
         filter = None
         if line:
             line = line.strip()
-            if configuration.dictionary.has_key(line):
+            if line in configuration.dictionary:
                 filter = configuration.dictionary[line]
         for i in range(len(configuration.constraints)):
             constraint = configuration.constraints[i].predicate
@@ -539,121 +539,121 @@ class tty_style_base(cmd.Cmd):
             if filter and filter not in cml.flatten_expr(constraint):
                 continue
             if constraint == reduced:
-                print cml.display_expression(reduced)[1:-1]
+                print(cml.display_expression(reduced)[1:-1])
             else:
-                print "%s -> %s" % (constraint,cml.display_expression(reduced)[1:-1])
+                print("%s -> %s" % (constraint,cml.display_expression(reduced)[1:-1]))
         return 0
     def do_q(self, line):
-	# Terminate this cmd instance, not saving configuration
-	raise SystemExit, 1
+        # Terminate this cmd instance, not saving configuration
+        raise SystemExit(1)
 
     def do_v(self, line):
-	# Set the debug flag
+        # Set the debug flag
         if not line:
             configuration.debug += 1
         else:
             configuration.debug = int(line)
-        print lang["VERBOSITY"] % configuration.debug
-	return 0
+        print(lang["VERBOSITY"] % configuration.debug)
+        return 0
     def do_e(self, line):
-	# Examine the state of a given symbol
-	symbol = string.strip(line)
-	if configuration.dictionary.has_key(symbol):
-	    entry = configuration.dictionary[symbol]
-	    print entry
+        # Examine the state of a given symbol
+        symbol = string.strip(line)
+        if symbol in configuration.dictionary:
+            entry = configuration.dictionary[symbol]
+            print(entry)
             if entry.constraints:
-                print lang["CONSTRAINTS"]
+                print(lang["CONSTRAINTS"])
                 for wff in entry.constraints:
-                    print cml.display_expression(wff)
+                    print(cml.display_expression(wff))
             if interactively_visible(entry):
-                print lang["VISIBLE"]
+                print(lang["VISIBLE"])
             elif entry.visibility is None:
-                print lang["INVISINONE"]
+                print(lang["INVISINONE"])
             elif configuration.eval_frozen(entry.visibility):
-                print lang["INVISIBLE"] + lang["INVISILOCK"]
+                print(lang["INVISIBLE"] + lang["INVISILOCK"])
             else:
-                print lang["INVISIBLE"]
+                print(lang["INVISIBLE"])
             if entry.saveability == None:
-                print lang["NOSAVEP"]
+                print(lang["NOSAVEP"])
             if configuration.saveable(entry):
-                print lang["SAVEABLE"]
+                print(lang["SAVEABLE"])
             else:
-                print lang["UNSAVEABLE"]
+                print(lang["UNSAVEABLE"])
             if entry.setcount:
-                print lang["SETCOUNT"] % entry.setcount
-	else:
-	    print lang["NOSUCHAS"], symbol 
-	return 0
+                print(lang["SETCOUNT"] % entry.setcount)
+        else:
+            print(lang["NOSUCHAS"], symbol) 
+        return 0
     def do_E(self, dummy):
         # Dump the state of the bindings stack
-        print configuration.binddump()
+        print(configuration.binddump())
         return 0
     def do_S(self, dummy):
         # Toggle the suppressions flag
         configuration.suppressions = not configuration.suppressions
         if configuration.suppressions:
-            print lang["SUPPRESSON"]
+            print(lang["SUPPRESSON"])
         else:
-            print lang["SUPPRESSOFF"]
-	return 0
+            print(lang["SUPPRESSOFF"])
+        return 0
     def help_e(self):
-	print lang["EHELP"]
+        print(lang["EHELP"])
     def help_E(self):
-	print lang["ECAPHELP"]
+        print(lang["ECAPHELP"])
     def help_g(self):
-	print lang["GHELP"]
+        print(lang["GHELP"])
     def help_i(self):
-	print lang["IHELP"]
+        print(lang["IHELP"])
     def help_I(self):
-	print lang["ICAPHELP"]
+        print(lang["ICAPHELP"])
     def help_y(self):
-	print lang["YHELP"]
+        print(lang["YHELP"])
     def help_m(self):
-	print lang["MHELP"]
+        print(lang["MHELP"])
     def help_n(self):
-	print lang["NHELP"]
+        print(lang["NHELP"])
     def help_s(self):
-	print lang["SHELP"]
+        print(lang["SHELP"])
     def help_q(self):
-	print lang["QHELP"]
+        print(lang["QHELP"])
     def help_v(self):
-	print lang["VHELP"]
+        print(lang["VHELP"])
     def help_x(self):
-	print lang["XHELP"]
+        print(lang["XHELP"])
     def do_help(self, line):
         line = line.strip()
-        if configuration.dictionary.has_key(line):
+        if line in configuration.dictionary:
             target = configuration.dictionary[line]
         else:
             target = self.current
         help = target.help()
-	if help:
-	    self.page(help)
-	else:
-	    print lang["NOHELP"] % (self.current.name,)
+        if help:
+            self.page(help)
+        else:
+            print(lang["NOHELP"] % (self.current.name,))
 
 class tty_style_menu(tty_style_base):
     "Interface for configuring with line-oriented commands."
     def skip_to_query(self, function, showbase=0):
         configuration.debug_emit(2, lang["SKIPCALLED"] % (self.current.name,))
         if showbase:
-	    if self.current.type == "menu":
-		self.menu_banner(self.current)
+            if self.current.type == "menu":
+                self.menu_banner(self.current)
                 configuration.visit(self.current)
-	while 1:
-	    self.current = function(self.current)
+        while 1:
+            self.current = function(self.current)
             if self.current == configuration.start:
                 break;
             elif self.current.is_symbol() and self.current.frozen():
                 # sys.stdout.write(self.generate_prompt(self.current) + lang["FREEZELABEL"] + "\n")
                 continue
-	    elif not interactively_visible(self.current):
-		continue
-	    elif self.current.type in ("menu", "choices"):
-		self.menu_banner(self.current)
+            elif not interactively_visible(self.current):
+                continue
+            elif self.current.type in ("menu", "choices"):
+                self.menu_banner(self.current)
                 configuration.visit(self.current)
-	    if not self.current.type in ("message", "menu"):
-		break;
+            if not self.current.type in ("message", "menu"):
+                break;
         configuration.debug_emit(2, lang["SKIPEXIT"] % (self.current.name,))
         if self.current == configuration.start:
             self.do_s(config)
@@ -663,7 +663,7 @@ class tty_style_menu(tty_style_base):
         sys.stdout.write("*\n* %s: %s\n*\n" % (menu.name, menu.prompt))
 
     def generate_prompt(self, symbol):
-	leader = "   " * symbol.depth
+        leader = "   " * symbol.depth
         genpart = cgenvalue(symbol)
         if symbol.help and not symbol.frozen():
             havehelp = "?"
@@ -671,8 +671,8 @@ class tty_style_menu(tty_style_base):
             havehelp = ""
         if configuration.is_new(symbol):
             genpart += " " + lang["NEW"]
-	if symbol.type in ("bool", "trit"):
-	    return leader+"%s: %s %s%s: " % (symbol.name, cgenprompt(symbol), genpart, havehelp)
+        if symbol.type in ("bool", "trit"):
+            return leader+"%s: %s %s%s: " % (symbol.name, cgenprompt(symbol), genpart, havehelp)
         elif symbol.enum:
             dflt = cml.evaluate(symbol, debug)
             if symbol.frozen():
@@ -685,12 +685,12 @@ class tty_style_menu(tty_style_base):
                     selected = "(" + label + ")"
             if not symbol.frozen():
                 p = p + leader + "%2d: %s\n" % (value, label)
-	    return p + leader + "%s: %s %s%s: " % (symbol.name, cgenprompt(symbol),selected, havehelp)
+            return p + leader + "%s: %s %s%s: " % (symbol.name, cgenprompt(symbol),selected, havehelp)
 
-	elif symbol.type in ("decimal", "hexadecimal", "string"):
+        elif symbol.type in ("decimal", "hexadecimal", "string"):
             dflt = cml.evaluate(symbol, debug)
-	    return leader + "%s: %s (%s)%s: "  % (symbol.name, cgenprompt(symbol), cgenvalue(symbol), havehelp)
-	elif symbol.type == "choices":
+            return leader + "%s: %s (%s)%s: "  % (symbol.name, cgenprompt(symbol), cgenvalue(symbol), havehelp)
+        elif symbol.type == "choices":
             if symbol.frozen():
                 p = ""
             else:
@@ -703,7 +703,7 @@ class tty_style_menu(tty_style_base):
                     p = p + leader + "%2d: %s%s%s\n" % (index, v.name, " " * (32 - len(v.name)), v.prompt)
                 if v.eval():
                     selected = v.name
-	    return p + leader + "%s: %s (%s)%s: " % (symbol.name, cgenprompt(symbol),selected, havehelp)
+            return p + leader + "%s: %s (%s)%s: " % (symbol.name, cgenprompt(symbol),selected, havehelp)
 
     def __init__(self, config=None, mybanner=""):
         tty_style_base.__init__(self, config=config, mybanner=mybanner)
@@ -713,7 +713,7 @@ class tty_style_menu(tty_style_base):
 
     def do_p(self, dummy):
         self.skip_to_query(configuration.previous_node)
-	return None
+        return None
 
     def do_y(self, line):
         tty_style_base.do_y(self, line)
@@ -729,30 +729,29 @@ class tty_style_menu(tty_style_base):
             self.skip_to_query(configuration.next_node)
 
     def do_h(self, dummy):
-        self.page(string.join(map(lambda x: lang[x],
-                                  ("TTYSUMMARY",
+        self.page(string.join([lang[x] for x in ("TTYSUMMARY",
                                    "GHELP", "IHELP", "ICAPHELP", "YHELP",
                                    "MHELP", "NHELP", "PHELP", "SHELP",
-                                   "QHELP", "XHELP", "TTYHELP")), "\n"))
+                                   "QHELP", "XHELP", "TTYHELP")], "\n"))
     def default(self, line):
         v = string.strip(line)
-	if self.current.type == 'choices':
-	    try:
-		ind = string.atoi(v)
-	    except ValueError:
-		ind = -1
-	    if ind <= 0 or ind > len(self.current.items):
-		print lang["RADIOBAD"]
-	    else:
-		# print lang["TTYSETTING"] % (`self.current.items[ind - 1]`)
-		self.set_symbol(self.current.items[ind - 1], cml.y)
-		self.skip_to_query(configuration.next_node)
+        if self.current.type == 'choices':
+            try:
+                ind = string.atoi(v)
+            except ValueError:
+                ind = -1
+            if ind <= 0 or ind > len(self.current.items):
+                print(lang["RADIOBAD"])
+            else:
+                # print lang["TTYSETTING"] % (`self.current.items[ind - 1]`)
+                self.set_symbol(self.current.items[ind - 1], cml.y)
+                self.skip_to_query(configuration.next_node)
         elif self.current.type in ("bool", "trit"):
-	    print lang["CANNOTSET"]
-	else:
-	    self.set_symbol(self.current, v)
-	    self.skip_to_query(configuration.next_node)
-	return None
+            print(lang["CANNOTSET"])
+        else:
+            self.set_symbol(self.current, v)
+            self.skip_to_query(configuration.next_node)
+        return None
 
     def emptyline(self):
         if self.current and self.current.type == "choices":
@@ -760,16 +759,16 @@ class tty_style_menu(tty_style_base):
                 # print lang["TTYSETTING"] % (`self.current.default`)
                 self.set_symbol(self.current.default, cml.y)
         self.skip_to_query(configuration.next_node)
-	return 0
+        return 0
 
     def help_p(self):
-	print lang["PHELP"]
+        print(lang["PHELP"])
 
     def postcmd(self, stop, dummy):
-	if stop:
-	    return stop
+        if stop:
+            return stop
         self.prompt = self.generate_prompt(self.current)
-	return None
+        return None
 
 class debugger_style_menu(tty_style_base):
     "Ruleset-debugger class."
@@ -784,98 +783,97 @@ class debugger_style_menu(tty_style_base):
         if newsystem:
             global configuration
             configuration = cmlsystem.CMLSystem(newsystem)
-            print lang["COMPILEOK"]
+            print(lang["COMPILEOK"])
         else:
-            print lang["COMPILEFAIL"]
+            print(lang["COMPILEFAIL"])
         return 0
 
     def do_V(self,line):
-        print "V",line
+        print("V",line)
         for setting in line.split():
             symbol,expected=setting.split('=')
-            if not configuration.dictionary.has_key(symbol):
+            if symbol not in configuration.dictionary:
                 sys.stderr.write((lang["NONEXIST"] % symbol) + "\n")
-                print lang["NONEXIST"] % line
+                print(lang["NONEXIST"] % line)
                 continue
             dictsym = configuration.dictionary[symbol]
             dictval = cml.evaluate(dictsym)
             if dictval != \
                configuration.value_from_string(dictsym,expected):
                 errstr = lang["BADVERIFY"] % (symbol,expected,dictval)
-                print errstr
+                print(errstr)
                 sys.stderr.write(errstr + '\n')
         return 0
         
     def do_y(self, line):
-        print line + "=y"
+        print(line + "=y")
         if not line:
-            print lang["NOSYMBOL"]
+            print(lang["NOSYMBOL"])
         else:
             tty_style_base.do_y(self, line)
             if configuration.debug:
-                print configuration.binddump()
+                print(configuration.binddump())
     def do_m(self, line):
-        print line + "=m"
+        print(line + "=m")
         if not line:
-            print lang["NOSYMBOL"]
+            print(lang["NOSYMBOL"])
         else:
             tty_style_base.do_m(self, line)
             if configuration.debug:
-                print configuration.binddump()
+                print(configuration.binddump())
     def do_n(self, line):
-        print line + "=n"
+        print(line + "=n")
         if not line:
-            print lang["NOSYMBOL"]
+            print(lang["NOSYMBOL"])
         else:
             tty_style_base.do_n(self, line)
             if configuration.debug:
-                print configuration.binddump()
+                print(configuration.binddump())
 
     def do_f(self, line):
-        print "f", line
+        print("f", line)
         line = line.strip()
         if not line:
-            print lang["NOSYMBOL"]
-        elif not configuration.dictionary.has_key(line):
-            print lang["NONEXIST"] % line
+            print(lang["NOSYMBOL"])
+        elif line not in configuration.dictionary:
+            print(lang["NONEXIST"] % line)
         else:
             configuration.dictionary[line].freeze()
         return None
 
     def do_c(self, line):
-        print "c", line
+        print("c", line)
         configuration.clear()
-	return None
+        return None
 
     def do_p(self, line):
-        print "p", line
+        print("p", line)
         configuration.save(sys.stdout, baton=None, all=1)
-	return None
+        return None
 
     def do_u(self, line):
-        print "u", line
+        print("u", line)
         configuration.interactive = not configuration.interactive
-	return None
+        return None
 
     def do_h(self, line):
-        print string.join(map(lambda x: lang[x],
-                              ("TTYSUMMARY",
+        print(string.join([lang[x] for x in ("TTYSUMMARY",
                                "YHELP", "MHELP", "NHELP", "PDHELP",
                                "FHELP", "CHELP",
                                "EHELP", "ECAPHELP", "CCAPHELP",
                                "IHELP", "ICAPHELP", "SHELP", "UHELP",
-                               "QHELP", "XHELP", "VCAPHELP", "VHELP")), "\n")
+                               "QHELP", "XHELP", "VCAPHELP", "VHELP")], "\n"))
 
     def default(self, line):
         if line.strip()[0] == "#":
-            print line
+            print(line)
         else:
-            print "?"
+            print("?")
         return 0
 
     def emptyline(self):
-        print ""
-	return 0
+        print("")
+        return 0
 
     def do_help(self, line):
         if not line:
@@ -885,19 +883,19 @@ class debugger_style_menu(tty_style_base):
         return None
 
     def help_f(self):
-	print lang["FHELP"]
+        print(lang["FHELP"])
 
     def help_c(self):
-	print lang["CHELP"]
+        print(lang["CHELP"])
 
     def help_V(self):
-	print lang["VCAPHELP"]
+        print(lang["VCAPHELP"])
 
     def help_p(self):
-	print lang["PDHELP"]
+        print(lang["PDHELP"])
 
     def do_EOF(self, line):
-        print ""
+        print("")
         self.do_q(line)
         return 1
 
@@ -920,7 +918,7 @@ class MenuBrowser:
     def push(self, browseable, selected=None):
         "Push a browseable object onto the location stack."
         if self.debug:
-            self.errout.write("MenuBrowser.push(): pushing %s=@%d, selection=%s\n" % (browseable, id(browseable), `selected`))
+            self.errout.write("MenuBrowser.push(): pushing %s=@%d, selection=%s\n" % (browseable, id(browseable), repr(selected)))
         selnum = 0
         if selected == None:
             if self.debug:
@@ -1058,7 +1056,7 @@ class MenuBrowser:
         for i in range(len(self.page_stack)):
             self.errout.write("Page: %d\n" % (i,))
             self.errout.write("Selection: %d\n" % (self.selection_stack[i],))
-            self.errout.write(`self.page_stack[i]` + "\n");
+            self.errout.write(repr(self.page_stack[i]) + "\n");
 
     def next(self, wrap=0):
         return self.move(1, wrap)
@@ -1119,7 +1117,7 @@ class WindowBaton:
 class curses_style_menu:
     "Command interpreter for line-oriented configurator."
     input_nmatch = re.compile(r">>>.*\(([0-9]+)\)$")
-    valwidth = 8	# This is a constant
+    valwidth = 8        # This is a constant
 
     def __init__(self, stdscr, config, mybanner):
         if mybanner and configuration.banner.find("%s") > -1:
@@ -1194,7 +1192,7 @@ class curses_style_menu:
             configuration.errout.write("***" + lang[instructions] + "\n")
             configuration.errout.write(string.join(msglist, "\n"))
         msgwidth = 0
-        pad = 2		# constant, must be >= 1
+        pad = 2         # constant, must be >= 1
         msgparts = []
         for line in msglist:
             unemitted = line
@@ -1273,7 +1271,7 @@ class curses_style_menu:
         else:
             effects.append("\n")
             self.help_popup("PRESSANY",
-                       effects + [lang["BADREQUIRE"]] + map(repr, violations), beep=1)
+                       effects + [lang["BADREQUIRE"]] + list(map(repr, violations)), beep=1)
 
     # User interaction
 
@@ -1288,9 +1286,9 @@ class curses_style_menu:
         # to be done here because the visibility of stuff
         # in a menu may depend on a choice submenu before
         # it, so we need the default value to be hardened,
-        map(configuration.visit, here.items)
+        list(map(configuration.visit, here.items))
         # Now compute visibilities.
-        visible = filter(lambda x, m=here: hasattr(m, 'nosuppressions') or interactively_visible(x), here.items)
+        visible = list(filter(lambda x, m=here: hasattr(m, 'nosuppressions') or interactively_visible(x), here.items))
         lookingat = self.menus.selected()
         if lookingat in visible:
             selected = self.menus.selected()
@@ -1307,7 +1305,7 @@ class curses_style_menu:
             self.menus.push(here.items, selected)
         # We've recomputed the top-of-stack item,
         # so we must regenerate all associated prompts.
-        self.values = map(cgenvalue, self.menus.top())
+        self.values = list(map(cgenvalue, self.menus.top()))
 
     def redisplay(self, repaint):
         "Repaint the screen."
@@ -1327,7 +1325,7 @@ class curses_style_menu:
         screenlines = self.menus.list()
         if self.in_menu():
             screenvals = self.values[self.menus.viewbase():self.menus.viewbase()+self.menus.viewport_height]
-            configuration.debug_emit(1, "screenvals: " + `screenvals`)
+            configuration.debug_emit(1, "screenvals: " + repr(screenvals))
         else:
             current_prompt = None
 
@@ -1471,7 +1469,7 @@ class curses_style_menu:
             elif operand.type == "trit":
                 self.set_symbol(operand, cml.m)
             elif operand.type == "bool":
-                self.set_symbol(operand, cml.y)	# Shortcut from old menuconfig
+                self.set_symbol(operand, cml.y) # Shortcut from old menuconfig
             else:
                 self.help_popup("PRESSANY", (lang["TRIT"],))
             recompute = 1
@@ -1481,7 +1479,7 @@ class curses_style_menu:
             if not self.in_menu():
                 self.help_popup("PRESSANY", (lang["NOSYMBOL"],))
             elif operand.type in ("bool", "trit") and \
-            				operand.menu.type != "choices":
+                                        operand.menu.type != "choices":
                 self.set_symbol(operand, cml.n)
             else:
                 self.help_popup("PRESSANY", (lang["BOOLEAN"],))
@@ -1526,17 +1524,17 @@ class curses_style_menu:
         elif cmd == ord('/'):
             pattern = self.query_popup(lang["SEARCHSYMBOLS"])
             if pattern:
-		try:
-		    hits = configuration.symbolsearch(pattern)
-		except re.error, detail:
-		    self.help_popup("PRESSANY",
+                try:
+                    hits = configuration.symbolsearch(pattern)
+                except re.error as detail:
+                    self.help_popup("PRESSANY",
                                     (lang["SEARCHINVAL"], str(detail)))
-		else:
-		    configuration.debug_emit(1, "hits: " + str(hits)) 
-		    if len(hits.items):
-			self.menus.push(hits.items)
-		    else:
-			self.help_popup("PRESSANY", (lang["SEARCHFAIL"],))
+                else:
+                    configuration.debug_emit(1, "hits: " + str(hits)) 
+                    if len(hits.items):
+                        self.menus.push(hits.items)
+                    else:
+                        self.help_popup("PRESSANY", (lang["SEARCHFAIL"],))
             recompute = 1
         elif cmd == ord('s'):
             failure = configuration.save(config,
@@ -1561,10 +1559,10 @@ class curses_style_menu:
         while not interactively_visible(self.menus.selected()):
             if not self.menus.move(1):
                 self.help_popup("PRESSANY", (lang["NOVISIBLE"],), beep=1)
-                raise SystemExit, 1
+                raise SystemExit(1)
         recompute = 1
         repaint = ["main"]
-        #curses.ungetch(curses.ascii.TAB)		# Get to a help screen.
+        #curses.ungetch(curses.ascii.TAB)               # Get to a help screen.
         while 1:
             if isinstance(self.menus.selected(), cml.ConfigSymbol):
                 # In theory we could optimize this by only computing
@@ -1668,7 +1666,7 @@ class curses_style_menu:
                         self.help_popup("PRESSANY", (str(sel_symbol),), beep=0)
                 elif cmd == ord('g'):
                     symname = self.query_popup(lang["GPROMPT"])
-                    if not configuration.dictionary.has_key(symname):
+                    if symname not in configuration.dictionary:
                         self.help_popup("PRESSANY", (lang["NONEXIST"] % symname,))
                     else:
                         entry = configuration.dictionary[symname]
@@ -1740,7 +1738,7 @@ class curses_style_menu:
                         break
                     cmd = self.help_popup("EXITCONFIRM", (lang["REALLY"],), beep=0)
                     if cmd == ord('q'):
-                        raise SystemExit, 1
+                        raise SystemExit(1)
                 elif cmd in (curses.KEY_ENTER,ord(' '),ord('\r'),ord('\n'),curses.KEY_RIGHT) :
                     # Operate on the current object
                     if sel_symbol.type == "message":
@@ -1786,7 +1784,7 @@ class curses_style_menu:
 # This is wrapped in try/expect in case the Tkinter import fails.
 # We need the import here because these classes have Frame as a parent.
 try:
-    from Tkinter import *
+    from tkinter import *
     from tree import *
 
     class ValidatedField(Frame):
@@ -1823,7 +1821,7 @@ try:
                             banner=self.symbol.name,
                             text=lang["CHARINVAL"])
                     return
-            apply(self.hook, (self.symbol, result))
+            self.hook(*(self.symbol, result))
         def error_popup(self, title, mybanner, text):
             self.errorwin = Toplevel()
             self.errorwin.title(title) 
@@ -1861,20 +1859,20 @@ try:
             self.master.menuframe.resetscroll()
             self.master.refresh()
         def dispatch(self, dummy=None):
-            apply(self.command, (self.fieldval.get(),))
+            self.command(*(self.fieldval.get(),))
             # if PromptGo is implemented as top level widget this is not
             # sufficient:
             #self.promptframe.destroy()
             # instead the top level widget must be destroyed
             self.promptframe.master.destroy()
         def handleDestroy(self, dummy=None):
-            apply(self.command, (None,))
+            self.command(*(None,))
 
 
     class ScrolledFrame(Frame):
         "A Frame object with a scrollbar on the right."
         def __init__(self, master, **kw):
-            apply(Frame.__init__, (self, master), kw)
+            Frame.__init__(*(self, master), **kw)
 
             self.scrollbar = Scrollbar(self, orient=VERTICAL)
             self.canvas = Canvas(self, yscrollcommand=self.scrollbar.set)
@@ -1910,7 +1908,7 @@ try:
 
     class ScrolledText(Frame):
         def __init__(self,parent=None,text=None,file=None,height=10,**kw):
-            apply(Frame.__init__,(self,parent),kw)
+            Frame.__init__(*(self,parent), **kw)
             self.makewidgets(height)
             self.settext(text,file)
         def makewidgets(self,ht):
@@ -1942,20 +1940,20 @@ try:
     def my_get_contents(node):
         menus=[]
         options=[]
-        cmlnode=node.id 	
+        cmlnode=node.id         
         for child in cmlnode.items:
             if interactively_visible(child):
                 if child.type =="menu" and cmlnode.items :
                     menus.append((child.prompt, child, shut_icon, open_icon))
                 else:
-                    options.append((child.prompt, child, file_icon, None))	
+                    options.append((child.prompt, child, file_icon, None))      
         menus.sort()
         options.sort()
         return options+menus 
 
     class myTree(Tree):
         def __init__(self,master,**kw):
-            apply(Tree.__init__,(self,master),kw)
+            Tree.__init__(*(self,master), **kw)
     
         def update_node(self,node=None):
             if node==None:
@@ -2005,7 +2003,7 @@ try:
         makehelpwin.textwidget.tag_bind('url', '<Enter>', lambda event, x=makehelpwin.textwidget: x.config(cursor='hand2'))
         makehelpwin.textwidget.tag_bind('url', '<Leave>', lambda event, x=makehelpwin.textwidget: x.config(cursor='xterm'))
         tag_urls(makehelpwin.textwidget, text)
-        makehelpwin.textwidget.config(state=DISABLED)	# prevent editing
+        makehelpwin.textwidget.config(state=DISABLED)   # prevent editing
         makehelpwin.lift()
 
     def tag_urls(textwidget, text):
@@ -2097,7 +2095,7 @@ try:
             self.master.iconname(announce)
             self.master.resizable(FALSE, TRUE)
             Pack.config(self, fill=BOTH, expand=YES)
-            self.keepalive = []	# Use this to anchor the PhotoImage object
+            self.keepalive = [] # Use this to anchor the PhotoImage object
             if configuration.icon:
                 make_icon_window(self, configuration.icon)
             ## Test icon display with the following:
@@ -2214,7 +2212,7 @@ try:
                          default = 0,
                          strings = (lang["FREEZEBUTTON"], lang["CANCEL"]))
             if ans.num == 0:
-                for key in configuration.dictionary.keys():
+                for key in list(configuration.dictionary.keys()):
                     entry = configuration.dictionary[key]
                     if entry.eval():
                         entry.freeze()
@@ -2257,7 +2255,7 @@ try:
                          strings = (lang["EXIT"], lang["CANCEL"]))
                 if ans.num == 0:
                     self.quit()
-                    raise SystemExit, 1
+                    raise SystemExit(1)
 
         # Navigation menu options
 
@@ -2289,7 +2287,7 @@ try:
             PromptGo(self, "GOTOBYNAME", self.goto_internal)
         def goto_internal(self, symname):
             if symname:
-                if not configuration.dictionary.has_key(symname):
+                if symname not in configuration.dictionary:
                     Dialog(self,
                              title = lang["PROBLEM"],
                              text = lang["NONEXIST"] % symname,
@@ -2298,7 +2296,7 @@ try:
                              strings = (lang["DONE"],))
                 else:
                     symbol = configuration.dictionary[symname]
-                    print symbol
+                    print(symbol)
                     # We can't go to a symbol in a choices menu directly;
                     # instead we must go to its parent. 
                     if symbol.menu and symbol.menu.type == "choices":
@@ -2335,7 +2333,7 @@ try:
                     hits.inspected = 0
                     if hits.items:
                         self.push(hits)
-                        print hits
+                        print(hits)
                     else:
                         Dialog(self,
                                title = lang["PROBLEM"],
@@ -2587,7 +2585,7 @@ try:
                     pass    
         
                 #fill in the menu value    
-                if self.ties.has_key(node.name):
+                if node.name in self.ties:
                     if node.type =="choices":
                         self.ties[node.name].set(node.menuvalue.name)
                     elif node.type in ("string","decimal") or \
@@ -2644,7 +2642,7 @@ try:
                     explain = lang["EFFECTS"] + "\n" \
                             + string.join(effects, "\n") + "\n"
                 explain += lang["ROLLBACK"] % (symbol.name, value) + \
-                    "\n" + string.join(map(repr, violations), "\n") + "\n"
+                    "\n" + string.join(list(map(repr, violations)), "\n") + "\n"
                 Dialog(self, \
                     title = lang["PROBLEM"], \
                     text = explain, \
@@ -2662,7 +2660,7 @@ try:
                 if violations:
                     Dialog(self,
                         title = lang["SIDEEFFECTS"],
-                        text = string.join(map(repr, violations), "\n"),
+                        text = string.join(list(map(repr, violations)), "\n"),
                         bitmap = 'info', 
                         default = 0,
                         strings = (lang["DONE"],))
@@ -2681,7 +2679,7 @@ try:
             Frame.__init__(self, master=None)
             ConfigMenu.__init__(self, menu, config, mybanner)
             
-	    self.menuframe = ScrolledFrame(self)
+            self.menuframe = ScrolledFrame(self)
             self.menuframe.pack(side=BOTTOM, fill=BOTH, expand=YES)
             
             self.menustack = []
@@ -2779,7 +2777,7 @@ try:
                     self.ties[node.name] = StringVar(self.workframe)
                     for value in node.range:
                         if node.type == "decimal":
-                            label=`value`
+                            label=repr(value)
                         elif node.type == "hexadecimal":
                             label = "0x%x" % value
                         cmenu.add_radiobutton(label=label, value=label,
@@ -2873,7 +2871,7 @@ try:
             else:
                 newwidth = self.workframe.winfo_width()
                 newheight = widgetheight + \
-                	self.menubar.winfo_height()+self.menubar.winfo_height()
+                        self.menubar.winfo_height()+self.menubar.winfo_height()
             # Following four lines center the window.
             #topx = (self.winfo_screenwidth() - newwidth) / 2
             #topy = (self.winfo_screenheight() - newheight) / 2
@@ -2885,7 +2883,7 @@ try:
 
         def display(self):
             menu = self.menustack[-1]
-            newvisible = filter(lambda x, m=menu: hasattr(m, 'nosuppressions') or interactively_visible(x), menu.items)
+            newvisible = list(filter(lambda x, m=menu: hasattr(m, 'nosuppressions') or interactively_visible(x), menu.items))
             # Insert all widgets that must newly become visible 
             for symbol in menu.items:
                 # Color the menu text
@@ -2899,7 +2897,7 @@ try:
                     if symbol.setcount or symbol.included:
                         textpart.config(fg='dark green')
                 # Fill in the menu value
-                if self.ties.has_key(symbol.name):
+                if symbol.name in self.ties:
                     if symbol.type == "choices":
                         self.ties[symbol.name].set(symbol.menuvalue.name)
                     elif symbol.type in ("string", "decimal") or symbol.enum:
@@ -2978,7 +2976,7 @@ try:
                     explain = lang["EFFECTS"] + "\n" \
                               + string.join(effects, "\n") + "\n"
                 explain += lang["ROLLBACK"] % (symbol.name, value) + \
-                           "\n" + string.join(map(repr, violations), "\n") + "\n"
+                           "\n" + string.join(list(map(repr, violations)), "\n") + "\n"
                 Dialog(self,
                          title = lang["PROBLEM"],
                          text = explain,
@@ -3035,27 +3033,27 @@ def tkinter_qplus_style_menu(config, mybanner):
 def menu_tree_list(node, indent):
     "Print a map of a menu subtree."
     totalindent = (indent + 4 * node.depth)
-    trailer = (" " * (40 - totalindent - len(node.name))) + `node.prompt`
-    print " " * totalindent, node.name, trailer
+    trailer = (" " * (40 - totalindent - len(node.name))) + repr(node.prompt)
+    print(" " * totalindent, node.name, trailer)
     if configuration.debug:
-	if node.visibility:
-	    print " " * 41, lang["VISIBILITY"], cml.display_expression(node.visibility)
-	if node.default:
-	    print " " * 41, lang["DEFAULT"], cml.display_expression(node.default)
+        if node.visibility:
+            print(" " * 41, lang["VISIBILITY"], cml.display_expression(node.visibility))
+        if node.default:
+            print(" " * 41, lang["DEFAULT"], cml.display_expression(node.default))
     if node.items:
-	for child in node.items:
-	    menu_tree_list(child, indent + 4)
+        for child in node.items:
+            menu_tree_list(child, indent + 4)
 
 # Environment probes
 
 def is_under_X():
     # It would be nice to just check WINDOWID, but some terminal
     # emulators don't set it. One of those is kvt.
-    if os.environ.has_key("WINDOWID"):
+    if "WINDOWID" in os.environ:
         return 1
     else:
-        import commands
-        (status, output) = commands.getstatusoutput("xdpyinfo")
+        import subprocess
+        (status, output) = subprocess.getstatusoutput("xdpyinfo")
         return status == 0
 
 # Rulebase loading and option processing
@@ -3071,9 +3069,9 @@ def load_system(cmd_options, cmd_arguments):
     else:
         rulebase = cmd_arguments[0]
     try:
-	open(rulebase, 'rb')
+        open(rulebase, 'rb')
     except IOError:
-        print lang["NOFILE"] % (rulebase,)
+        print(lang["NOFILE"] % (rulebase,))
         raise SystemExit
     configuration = cmlsystem.CMLSystem(rulebase)
 
@@ -3097,25 +3095,25 @@ def process_include(configuration, file, freeze):
     try:
         (changes, errors) = configuration.load(file, freeze)
     except IOError:
-        print lang["LOADFAIL"] % file
+        print(lang["LOADFAIL"] % file)
         return
     if errors:
-        print errors
+        print(errors)
     elif configuration.side_effects:
-        print lang["SIDEFROM"] % file
+        print(lang["SIDEFROM"] % file)
         sys.stdout.write(string.join(configuration.side_effects, "\n") + "\n")
 
 def process_define(configuration, val, freeze):
     "Process a -d=xxx or -D=xxx option."
     parts = string.split(val, "=")
     sym = parts[0]
-    if configuration.dictionary.has_key(sym):
+    if sym in configuration.dictionary:
         sym = configuration.dictionary[sym]
     else:
-        configuration.errout.write(lang["SYMUNKNOWN"] % (`sym`,))
+        configuration.errout.write(lang["SYMUNKNOWN"] % (repr(sym),))
         sys.exit(1)
     if sym.is_derived():
-        configuration.debug_emit(1, lang["DERIVED"] % (`sym`,))
+        configuration.debug_emit(1, lang["DERIVED"] % (repr(sym),))
         sys.exit(1)
     elif sym.is_logical():
         if len(parts) == 1:
@@ -3128,10 +3126,10 @@ def process_define(configuration, val, freeze):
         elif parts[1] == 'n':
             val = 'n'
         else:
-            print lang["BADBOOL"]
+            print(lang["BADBOOL"])
             sys.exit(1)
     elif len(parts) == 1:
-        print lang["NOCMDLINE"] % (`sym`,)
+        print(lang["NOCMDLINE"] % (repr(sym),))
         sys.exit(1)
     else:
         val = parts[1]
@@ -3139,10 +3137,10 @@ def process_define(configuration, val, freeze):
                                  configuration.value_from_string(sym, val),
                                  freeze)
     if effects:
-        print lang["EFFECTS"]
+        print(lang["EFFECTS"])
         sys.stdout.write(string.join(effects,"\n")+"\n")
     if not ok:
-        print lang["ROLLBACK"] % (sym.name, val)
+        print(lang["ROLLBACK"] % (sym.name, val))
         sys.stdout.write("\n".join(map(repr, violations))+"\n")
 
 def process_options(configuration, options):
@@ -3152,29 +3150,29 @@ def process_options(configuration, options):
     global readlog, banner
     config = "config.out"
     for (switch, val) in options:
-	if switch == '-b':
-	    force_batch = 1
-	elif switch == '-B':
-	    banner = val
-	elif switch == '-d':
+        if switch == '-b':
+            force_batch = 1
+        elif switch == '-B':
+            banner = val
+        elif switch == '-d':
             process_define(configuration, val, freeze=0)
-	elif switch == '-D':
+        elif switch == '-D':
             process_define(configuration, val, freeze=1)
-	elif switch == '-i':
+        elif switch == '-i':
             process_include(configuration, val, freeze=0)
-	elif switch == '-I':
+        elif switch == '-I':
             process_include(configuration, val, freeze=1)
-	elif switch == '-l':
-	    list = 1
-	elif switch == '-o':
-	    config = val
-	elif switch == '-v':
-	    debug = debug + 1
+        elif switch == '-l':
+            list = 1
+        elif switch == '-o':
+            config = val
+        elif switch == '-v':
+            debug = debug + 1
             configuration.debug = configuration.debug + 1
-	elif switch == '-S':
-	    configuration.suppressions = 0
-	elif switch == '-R':
-	    readlog = open(val, "r")
+        elif switch == '-S':
+            configuration.suppressions = 0
+        elif switch == '-R':
+            readlog = open(val, "r")
 
 # Main sequence -- isolated here so we can profile it
 
@@ -3191,12 +3189,12 @@ def main(options, arguments):
         try:
             menu_tree_list(configuration.start, 0)
         except EnvironmentError:
-            pass	# Don't emit a traceback when we interrupt the listing
-	raise SystemExit
+            pass        # Don't emit a traceback when we interrupt the listing
+        raise SystemExit
     # Perhaps we're in batchmode.  If so, only process options. 
     if force_batch:
         # Have to realize all choices values first...
-        for entry in configuration.dictionary.values():
+        for entry in list(configuration.dictionary.values()):
             if entry.type == "choices":
                 configuration.visit(entry)
         configuration.save(config)
@@ -3218,49 +3216,49 @@ def main(options, arguments):
             curses.wrapper(curses_style_menu, config, banner)
             return
         except "TERMTOOSMALL":
-            print lang["TERMTOOSMALL"]
+            print(lang["TERMTOOSMALL"])
             force_tty = 1
 
     # If both failed, go glass-tty
     if force_debugger:
-        print lang["DEBUG"] % configuration.banner
+        print(lang["DEBUG"] % configuration.banner)
         debugger_style_menu(config, banner).cmdloop()        
     elif force_tty:
-        print lang["WELCOME"]%(configuration.banner,) + lang["VERSION"]%(cml.version,)
+        print(lang["WELCOME"]%(configuration.banner,) + lang["VERSION"]%(cml.version,))
         configuration.errout = sys.stdout
-        print lang["TTYQUERY"]
+        print(lang["TTYQUERY"])
         tty_style_menu(config, banner).cmdloop()
 
 if __name__ == '__main__':
     try:
         runopts = "bB:cD:d:h:i:I:lo:P:qR:SstVvWx"
-	(options,arguments) = getopt.getopt(sys.argv[1:], runopts, "help")
-        if os.environ.has_key("CML2OPTIONS"):
+        (options,arguments) = getopt.getopt(sys.argv[1:], runopts, "help")
+        if "CML2OPTIONS" in os.environ:
             (envopts, envargs) = getopt.getopt(
                 os.environ["CML2OPTIONS"].split(),
                 runopts)
             options = envopts + options
     except:
-	print lang["BADOPTION"]
-        print lang["CLIHELP"]
-	sys.exit(1)
+        print(lang["BADOPTION"])
+        print(lang["CLIHELP"])
+        sys.exit(1)
 
     for (switch, val) in options:
         if switch == "-V":
-            print "cmlconfigure", cml.version
+            print("cmlconfigure", cml.version)
             raise SystemExit
-	elif switch == '-P':
-	    proflog = val
-	elif switch == '-x':
-	    force_x = 1
-	elif switch == '-q':
-	    force_q = 1
-	elif switch == '-t':
-	    force_tty = 1
-	elif switch == '-c':
-	    force_curses = 1
-	elif switch == '-s':
-	    force_debugger = force_tty = 1
+        elif switch == '-P':
+            proflog = val
+        elif switch == '-x':
+            force_x = 1
+        elif switch == '-q':
+            force_q = 1
+        elif switch == '-t':
+            force_tty = 1
+        elif switch == '-c':
+            force_curses = 1
+        elif switch == '-s':
+            force_debugger = force_tty = 1
         elif switch == '--help':
             sys.stdout.write(lang["CLIHELP"])
             raise SystemExit
@@ -3272,27 +3270,27 @@ if __name__ == '__main__':
     # Do we see X capability?
     if force_x or force_q:
         try:
-            from Tkinter import *
-            from Dialog import *
+            from tkinter import *
+            from tkinter.dialog import *
         except:
-            print lang["NOTKINTER"]
+            print(lang["NOTKINTER"])
             time.sleep(5)
             force_curses = 1
             force_x = force_q = 0
 
     # Probe the environment to see if we can come up in ncurses mode
     if not force_tty and not force_x and not force_q:
-	if not os.environ.has_key('TERM'):
-	    print lang["TERMNOTSET"]
-	    force_tty = 1
-	else:
+        if 'TERM' not in os.environ:
+            print(lang["TERMNOTSET"])
+            force_tty = 1
+        else:
             import traceback
             try:
                 import curses, curses.textpad, curses.wrapper
                 force_curses = 1
             except:
                 ImportError
-                print lang["NOCURSES"]
+                print(lang["NOCURSES"])
                 force_tty = 1
 
     if force_tty or force_debugger:
@@ -3313,11 +3311,11 @@ if __name__ == '__main__':
     except KeyboardInterrupt:
         #if configuration.commits > 0:
         #    print lang["NOTSAVED"]
-        print lang["ABORTED"]
-        raise SystemExit, 2
+        print(lang["ABORTED"])
+        raise SystemExit(2)
     except "UNSATISFIABLE":
         #configuration.save("post.mortem")
-        print lang["POSTMORTEM"]
-        raise SystemExit, 3
+        print(lang["POSTMORTEM"])
+        raise SystemExit(3)
 
 # That's all, folks!

--- a/contrib/cml2/configtrans.py
+++ b/contrib/cml2/configtrans.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 configtrans.py -- translate between CML1 and CML2 config formats.
 
@@ -89,19 +89,19 @@ if __name__ == '__main__':
     include = defconfig = translate = None
     (options, arguments) = getopt.getopt(sys.argv[1:], "h:s:t")
     for (switch, val) in options:
-	if switch == '-h':
-	    includefile = val
+        if switch == '-h':
+            includefile = val
             try:
                 os.rename(val, val + ".old")
             except OSError:
                 pass
-	elif switch == '-s':
-	    defconfig = val
+        elif switch == '-s':
+            defconfig = val
             try:
                 os.rename(val, val + ".old")
             except OSError:
                 pass
-	elif switch == '-t':
+        elif switch == '-t':
             translate = 1
     if len(arguments) > 0:
         try:
@@ -109,14 +109,14 @@ if __name__ == '__main__':
                 linetrans(write_include, arguments[0], includefile, "#define AUTOCONF_INCLUDED\n")
             if defconfig:
                 linetrans(write_defconfig, arguments[0], defconfig)
-        except IOError, args:
+        except IOError as args:
             sys.stderr.write("configtrans: " + args[1] + "\n");
-            raise SystemExit, 1
+            raise SystemExit(1)
     elif translate:
         linetrans(revert, sys.stdin, sys.stdout)
     else:
-        print "usage: configtrans.py -t [-h includefile] [-s defconfig] file"
-        raise SystemExit, 1
+        print("usage: configtrans.py -t [-h includefile] [-s defconfig] file")
+        raise SystemExit(1)
 
 # That's all, folks!
 


### PR DESCRIPTION
## Summary
- modernize CML2 python utilities for Python 3
- update shebang lines

## Testing
- `python3 -m py_compile contrib/cml2/cmlcompile.py contrib/cml2/cmlconfigure.py contrib/cml2/configtrans.py`