### PR TITLE
Fix userlib paths in CMake

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -13,8 +13,8 @@ $ cmake --build .
 ```
 
 The default target compiles the example `string.o` object, builds the
-kernel using the Makefile under `kernel/` and builds the userland
-libraries from `src-userland/lib`.
+ kernel using the Makefile under `kernel/` and builds the userland
+ libraries from `user/lib`.
 
 To build individual pieces you can specify the targets explicitly:
 

--- a/src-userland/lib/CMakeLists.txt
+++ b/src-userland/lib/CMakeLists.txt
@@ -1,11 +1,11 @@
 # Build userland static libraries
 
 add_library(useripc STATIC
-    ipc/user_ipc.cc
+    ${CMAKE_SOURCE_DIR}/user/lib/ipc/user_ipc.cc
 )
 
 add_library(sched STATIC
-    sched/sched_client.cc
+    ${CMAKE_SOURCE_DIR}/user/lib/sched/sched_client.cc
 )
 
 # Include directories match the Makefile


### PR DESCRIPTION
## Summary
- cmake: refer to user lib sources via absolute paths
- docs: reference new user/lib location

## Testing
- `cmake ..`
- `cmake --build .`
