### PR TITLE
Fix userlib paths in CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y build-essential
+      - name: Install pre-commit
+        run: |
+          python3 -m pip install --user pre-commit
       - name: Configure userland
         run: |
           mkdir build
@@ -42,6 +45,9 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y build-essential
+      - name: Install pre-commit
+        run: |
+          python3 -m pip install --user pre-commit
       - name: Build kernel
         run: |
           make -C kernel BUILDDIR=$PWD/kernel-build

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -26,9 +26,12 @@ jobs:
           - { id: "ruff",        cmd: "ruff --output-format=github ." }
           - { id: "clang-tidy",  cmd: "clang-tidy $(git ls-files '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hpp') --quiet" }
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-    - uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - uses: actions/setup-python@v5
+      - name: Install pre-commit
+        run: |
+          python3 -m pip install --user pre-commit
 
     - name: Install linter runtime deps
       run: |

--- a/docs/building.md
+++ b/docs/building.md
@@ -13,8 +13,8 @@ $ cmake --build .
 ```
 
 The default target compiles the example `string.o` object, builds the
-kernel using the Makefile under `kernel/` and builds the userland
-libraries from `src-userland/lib`.
+ kernel using the Makefile under `kernel/` and builds the userland
+ libraries from `user/lib`.
 
 To build individual pieces you can specify the targets explicitly:
 

--- a/src-userland/lib/CMakeLists.txt
+++ b/src-userland/lib/CMakeLists.txt
@@ -1,11 +1,11 @@
 # Build userland static libraries
 
 add_library(useripc STATIC
-    ipc/user_ipc.cc
+    ${CMAKE_SOURCE_DIR}/user/lib/ipc/user_ipc.cc
 )
 
 add_library(sched STATIC
-    sched/sched_client.cc
+    ${CMAKE_SOURCE_DIR}/user/lib/sched/sched_client.cc
 )
 
 # Include directories match the Makefile


### PR DESCRIPTION
## Summary
- cmake: refer to user lib sources via absolute paths
- docs: reference new user/lib location
- ci: install pre-commit for workflows

## Testing
- `cmake ..`
- `cmake --build .`
- `pre-commit` *(fails: command not found)*