### PR TITLE
Fix compiler flags for modern GCC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS ?= -std=c23
+CFLAGS ?= -std=c2x
 CXXFLAGS ?= -std=c++23
 
 build/string.o: user/contrib/elf-loader/platform/amd64-pc99/string.cc

--- a/kernel/Mk/Makeconf
+++ b/kernel/Mk/Makeconf
@@ -190,7 +190,7 @@ ifeq ("$(CONFIG_DEBUG_SYMBOLS)","y")
 CCFLAGS  += -g
 endif
 
-CFLAGS = -ffreestanding $(CCFLAGS) -std=c23
+CFLAGS = -ffreestanding $(CCFLAGS) -std=c2x
 
 # these for assembly files only
 ASMFLAGS += $(ASMFLAGS_$(PLATFORM)) $(ASMFLAGS_$(ARCH)) $(ASMFLAGS_$(CPU))

--- a/kernel/Mk/Makeconf.x86
+++ b/kernel/Mk/Makeconf.x86
@@ -37,8 +37,8 @@ endif
 UNDEFS	 += $(SUBARCH)
 DEFINES	 += __SUBARCH__=$(SUBARCH)
 
-CFLAGS_x86_x32	+= -O2 -m32 -mpreferred-stack-boundary=2 
-CFLAGS_x86_x64  += -O2 -m64 -mcmodel=kernel -mno-red-zone 
+CFLAGS_x86_x32	+= -O2 -m32 -mpreferred-stack-boundary=2  -fno-pie -fno-pic
+CFLAGS_x86_x64  += -O2 -m64 -mcmodel=kernel -mno-red-zone -fno-pie -fno-pic
 CFLAGS_x86	+= $(CFLAGS_x86_$(SUBARCH)) -mno-mmx -mno-sse -mno-sse2 -mno-sse3
 LDFLAGS_x86_x32	+= -melf_i386 
 LDFLAGS_x86_x64	+= -melf_x86_64 -n -z max-page-size=4096

--- a/user/Mk/l4.build.mk
+++ b/user/Mk/l4.build.mk
@@ -59,7 +59,7 @@ OBJS+=		${filter %crt0.o crt0%, $(_OBJS)} \
 
 .c.o:	$(MKFILE_DEPS)
 	@$(ECHO_MSG) `echo $< | sed s,^$(top_srcdir)/,,`
-	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c23 -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -std=c2x -c $< -o $@
 
 .S.o:	$(MKFILE_DEPS)
 	@$(ECHO_MSG) `echo $< | sed s,^$(top_srcdir)/,,`

--- a/user/README.HG
+++ b/user/README.HG
@@ -2,7 +2,7 @@ Build Requirements
 ==================
 
 This repository ships a lightweight `configure` script in the `user`
-directory.  A POSIX shell and a compiler supporting the `-std=c23`
+directory.  A POSIX shell and a compiler supporting the `-std=c2x`
 option are sufficient.  Detailed kernel and user land instructions are
 available in `../docs/building.md`.
 

--- a/user/config.mk
+++ b/user/config.mk
@@ -48,7 +48,7 @@ SHELL=		/bin/sh
 CC=		cc
 CXX=		$(CC) -x c++
 AS=		$(CC)
-CFLAGS=		-std=c23
+CFLAGS=		-std=c2x
 CXXFLAGS=       $(CXXSTD) -fno-exceptions
 CXXSTD=	-std=c++23
 LDFLAGS=	

--- a/user/configure
+++ b/user/configure
@@ -71,17 +71,17 @@ esac
 
 CC=${CC:-cc}
 
-printf "checking whether $CC accepts -std=c23... "
+printf "checking whether $CC accepts -std=c2x... "
 cat > conftest.c <<'EOT'
 int main(void){return 0;}
 EOT
-if $CC -std=c23 -c conftest.c -o conftest.o >/dev/null 2>&1; then
+if $CC -std=c2x -c conftest.c -o conftest.o >/dev/null 2>&1; then
     echo yes
-    STD_CFLAG=-std=c23
+    STD_CFLAG=-std=c2x
 else
     echo no
     rm -f conftest.c conftest.o
-    echo "$CC does not support -std=c23" >&2
+    echo "$CC does not support -std=c2x" >&2
     exit 1
 fi
 rm -f conftest.c conftest.o

--- a/user/configure.in
+++ b/user/configure.in
@@ -139,25 +139,25 @@ AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 AC_PROG_LN_S
 AC_PROG_AWK
-AC_MSG_CHECKING([whether $CC supports -std=c23])
+AC_MSG_CHECKING([whether $CC supports -std=c2x])
 ac_save_CFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS -std=c23"
+CFLAGS="$CFLAGS -std=c2x"
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
         [ac_c23=yes],
         [ac_c23=no])
 CFLAGS="$ac_save_CFLAGS"
 if test "$ac_c23" != yes; then
-  AC_MSG_ERROR([compiler does not support -std=c23])
+  AC_MSG_ERROR([compiler does not support -std=c2x])
 fi
 AC_MSG_RESULT([$ac_c23])
 
-dnl Check if the compiler supports -std=c23
-AC_MSG_CHECKING([whether $CC accepts -std=c23])
+dnl Check if the compiler supports -std=c2x
+AC_MSG_CHECKING([whether $CC accepts -std=c2x])
 save_CFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS -std=c23"
+CFLAGS="$CFLAGS -std=c2x"
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
     [AC_MSG_RESULT([yes])],
-    [AC_MSG_FAILURE([$CC does not support -std=c23])])
+    [AC_MSG_FAILURE([$CC does not support -std=c2x])])
 CFLAGS="$save_CFLAGS"
 
 AC_MSG_CHECKING([whether $CC accepts -std=c++23])


### PR DESCRIPTION
## Summary
- update C standard to use `-std=c2x`
- add `-fno-pie` flags for kernel x86 builds
- adjust configure scripts and docs accordingly

## Testing
- `pytest -q`
