### PR TITLE
Fix 64‑bit build

### DIFF
--- a/contrib/cml2/cml.py
+++ b/contrib/cml2/cml.py
@@ -14,7 +14,7 @@ class trit:
         self.value = value
     def __repr__(self):
         return "nmy"[self.value]
-    def __nonzero__(self):
+    def __bool__(self):
         return self.value
     def __hash__(self):
         return self.value	# This magic needed to make trits valid dictionary keys
@@ -100,12 +100,12 @@ class ConfigSymbol:
                     result = (result != n)
             if debug > 3:
                 sys.stderr.write("...eval(%s)->%s (through default %s)\n" % \
-                                 (`self`, result, self.default))
+                                 (repr(self), result, self.default))
             return result
         else:
             if debug > 2:
                 sys.stderr.write("...eval(%s)->None (default empty)\n" % \
-                                 (`self`))
+                                 (repr(self)))
             return None
 
     # Access to help.
@@ -156,13 +156,13 @@ class ConfigSymbol:
 
     # Property functions
     def hasprop(self, prop):
-        return self.properties.has_key(prop)
+        return prop in self.properties
     def setprop(self, prop, val=1):
         self.properties[prop] = val
     def delprop(self, prop):
         del self.properties[prop]
     def showprops(self,):
-        return ", ".join(self.properties.keys())
+        return ", ".join(list(self.properties.keys()))
 
     def __repr__(self):
         # So the right thing happens when we print symbols in expressions
@@ -188,7 +188,7 @@ class ConfigSymbol:
         if self.saveability is not None:
             res = res + " saveability %s," % (display_expression(self.saveability),)
         if self.default is not None:
-            res = res + " default %s," % (`self.default`,)
+            res = res + " default %s," % (repr(self.default),)
         if self.items:
             res = res + " items %s," % (self.items,)
         if self.properties:
@@ -242,16 +242,16 @@ class CMLRulebase:
         self.reduced = []
     def __repr__(self):
         res = "Start menu = %s\n" % (self.start,)
-        for k in self.dictionary.keys():
+        for k in list(self.dictionary.keys()):
             res = res + str(self.dictionary[k]) + "\n"
         if self.prefix:
-            res = res + "Prefix:" + `self.prefix`
+            res = res + "Prefix:" + repr(self.prefix)
         if self.banner:
-            res = res + "Banner:" + `self.banner`
+            res = res + "Banner:" + repr(self.banner)
         return res
     def optimize_constraint_access(self):
         "Assign constraints to their associated symbols."
-        for entry in self.dictionary.values():
+        for entry in list(self.dictionary.values()):
             entry.constraints = []
         for requirement in self.reduced:
             for symbol in flatten_expr(requirement):
@@ -268,7 +268,7 @@ def evaluate(exp, debug=0):
         else:
             return n
     if debug > 2:
-        sys.stderr.write("evaluate(%s) begins...\n" % (`exp`,))
+        sys.stderr.write("evaluate(%s) begins...\n" % (repr(exp),))
     if type(exp) is type(()):
         # Ternary operator
         if exp[0] == '?':
@@ -311,16 +311,16 @@ def evaluate(exp, debug=0):
             else:
                 return left
         elif exp[0] == '+':
-            return long(evaluate(exp[1],debug)) + long(evaluate(exp[2],debug))
+            return int(evaluate(exp[1],debug)) + int(evaluate(exp[2],debug))
         elif exp[0] == '-':
-            return long(evaluate(exp[1],debug)) - long(evaluate(exp[2],debug))
+            return int(evaluate(exp[1],debug)) - int(evaluate(exp[2],debug))
         elif exp[0] == '*':
-            return long(evaluate(exp[1],debug)) * long(evaluate(exp[2],debug))
+            return int(evaluate(exp[1],debug)) * int(evaluate(exp[2],debug))
         else:
-            raise SyntaxError, "Unknown operation %s in expression" % (exp[0],)
-    elif isinstance(exp, trit) or type(exp) in (type(""), type(0), type(0L)):
+            raise SyntaxError("Unknown operation %s in expression" % (exp[0],))
+    elif isinstance(exp, trit) or type(exp) in (type(""), type(0), type(0)):
         if debug > 2:
-            sys.stderr.write("...evaluate(%s) returns itself\n" % (`exp`,))
+            sys.stderr.write("...evaluate(%s) returns itself\n" % (repr(exp),))
         return exp
     elif isinstance(exp, ConfigSymbol):
         result = exp.eval(debug)
@@ -329,12 +329,12 @@ def evaluate(exp, debug=0):
         else:
             return n
     else:
-        raise ValueError,"unknown object %s %s in expression" % (exp,type(exp))
+        raise ValueError("unknown object %s %s in expression" % (exp,type(exp)))
 
 def flatten_expr(node):
     "Flatten an expression -- skips the operators"
     if type(node) is type(()) or type(node) is type([]):
-       sublists = map(flatten_expr, node)
+       sublists = list(map(flatten_expr, node))
        flattened = []
        for item in sublists:
            flattened = flattened + item
@@ -359,7 +359,7 @@ def display_expression(exp):
     elif isinstance(exp, ConfigSymbol):
         return exp.name
     else:
-        return `exp`
+        return repr(exp)
 
 class Baton:
     "Ship progress indication to stdout."
@@ -413,26 +413,26 @@ if __name__ == "__main__":
     t2 = trit(2)
 
     if not (t0 < t1 < t2 and t2 > t1 > t0) or t0 == t1 or t0 == t2 or t1 == t2:
-        print "trit compare failed"
+        print("trit compare failed")
 
     if t0 < None:
-        print "a trit is less than None?  Comparison failed"
+        print("a trit is less than None?  Comparison failed")
 
     if None > t0:
-        print "None is greater than a trit?  Comparison failed"
+        print("None is greater than a trit?  Comparison failed")
 
     if id(a) > id(b):
         if a < b > a:
-            print "a/b comparison failed"
+            print("a/b comparison failed")
     elif b < a > b:
-        print "a/b comparison failed"
+        print("a/b comparison failed")
 
 
     # Simulate standard no-cmp() behavior for non-trits
     if id(a) > id(t0):
         if a < t0:
-            print "a/t0 comparison failed (id(a) greater)"
+            print("a/t0 comparison failed (id(a) greater)")
     elif t0 < a:
-        print "a/t0 comparison failed"
+        print("a/t0 comparison failed")
 
 # cml.py ends here.

--- a/contrib/cml2/cmlcompile.py
+++ b/contrib/cml2/cmlcompile.py
@@ -76,7 +76,7 @@ class Token:
     def __init__(self, type, attr=None):
         self.type = type
         self.attr = attr
-        if compstate.debug > 1: print("CML token: ", repr(self))
+        if compstate.debug > 1: print(("CML token: ", repr(self)))
     def __repr__(self):
         if self.type == "EOF":
             return "EOF"
@@ -213,7 +213,7 @@ def parse_atom(input):
     if compstate.debug >= 2: print("entering parse_atom...")
     op = input.lex_token()
     if op.type in _atoms:
-        if compstate.debug >= 2: print("parse_atom returns", op.attr)
+        if compstate.debug >= 2: print(("parse_atom returns", op.attr))
         return op
     elif op.type == '(':
         sub = parse_expr_inner(input)
@@ -221,12 +221,12 @@ def parse_atom(input):
         if close != ')':
             raise ExpressionError("while expecting a close paren")
         else:
-            if compstate.debug >= 2: print("parse_atom returns singleton", sub)
+            if compstate.debug >= 2: print(("parse_atom returns singleton", sub))
             return sub
     elif op.type in _keywords:
         raise ExpressionError("keyword %s while expecting atom" % op.type)
     elif op.type == 'word':
-        if compstate.debug >= 2: print("parse_atom returns", op.attr)
+        if compstate.debug >= 2: print(("parse_atom returns", op.attr))
         return op
 
 def parse_term(input):
@@ -235,11 +235,11 @@ def parse_term(input):
     op = input.lex_token()
     if op.type not in _termops:
         input.push_token(op)
-        if compstate.debug >= 2: print("parse_term returns singleton", left)
+        if compstate.debug >= 2: print(("parse_term returns singleton", left))
         return left
     right = parse_term(input)
     expr = (op.type, left, right)
-    if compstate.debug >= 2: print("parse_term returns", expr)
+    if compstate.debug >= 2: print(("parse_term returns", expr))
     return expr
 
 def parse_relational(input):
@@ -248,11 +248,11 @@ def parse_relational(input):
     op = input.lex_token()
     if op.type not in _relops:
         input.push_token(op)
-        if compstate.debug >= 2: print("parse_relational returns singleton", left)
+        if compstate.debug >= 2: print(("parse_relational returns singleton", left))
         return left
     right = parse_term(input)
     expr = (op.type, left, right)
-    if compstate.debug >= 2: print("parse_relational returns", expr)
+    if compstate.debug >= 2: print(("parse_relational returns", expr))
     return(op.type, left, right)
 
 def parse_assertion(input):
@@ -269,11 +269,11 @@ def parse_conjunct(input):
     op = input.lex_token()
     if op.type !=  'and': 
         input.push_token(op)
-        if compstate.debug >= 2: print("parse_conjunct returns singleton", left)
+        if compstate.debug >= 2: print(("parse_conjunct returns singleton", left))
         return left
     else:
         expr = ('and', left, parse_conjunct(input))
-        if compstate.debug >= 2: print("parse_conjunct returns", expr)
+        if compstate.debug >= 2: print(("parse_conjunct returns", expr))
         return expr
 
 def parse_disjunct(input):
@@ -282,11 +282,11 @@ def parse_disjunct(input):
     op = input.lex_token()
     if op.type != 'or':
         input.push_token(op)
-        if compstate.debug >= 2: print("parse_disjunct returns singleton", left)
+        if compstate.debug >= 2: print(("parse_disjunct returns singleton", left))
         return left
     else:
         expr = ('or', left, parse_disjunct(input))
-        if compstate.debug >= 2: print("parse_disjunct returns", expr)
+        if compstate.debug >= 2: print(("parse_disjunct returns", expr))
         return expr
 
 def parse_factor(input):
@@ -296,11 +296,11 @@ def parse_factor(input):
     op = input.lex_token()
     if op.type != 'implies':
         input.push_token(op)
-        if compstate.debug >= 2: print("parse_factor returns singleton", left)
+        if compstate.debug >= 2: print(("parse_factor returns singleton", left))
         return left
     else:
         expr = ('implies', left, parse_disjunct(input))
-        if compstate.debug >= 2: print("parse_factor returns", expr)
+        if compstate.debug >= 2: print(("parse_factor returns", expr))
         return expr
 
 def parse_summand(input):
@@ -309,11 +309,11 @@ def parse_summand(input):
     op = input.lex_token()
     if op.type != '*':
         input.push_token(op)
-        if compstate.debug >= 2: print("parse_summand returns singleton", left)
+        if compstate.debug >= 2: print(("parse_summand returns singleton", left))
         return left
     else:
         expr = ('*', left, parse_expr_inner(input))
-        if compstate.debug >= 2: print("parse_summand returns", expr)
+        if compstate.debug >= 2: print(("parse_summand returns", expr))
         return expr
 
 def parse_ternary(input):
@@ -322,7 +322,7 @@ def parse_ternary(input):
     op = input.lex_token()
     if op.type != '?':
         input.push_token(op)
-        if compstate.debug >= 2: print("parse_ternary returns singleton", guard)
+        if compstate.debug >= 2: print(("parse_ternary returns singleton", guard))
         return guard
     else:
         trueval = parse_summand(input)
@@ -331,7 +331,7 @@ def parse_ternary(input):
             raise ExpressionError("while expecting : in ternary")
         falseval = parse_summand(input)
         expr = ('?', guard, trueval, falseval)
-        if compstate.debug >= 2: print("parse_ternary returns", expr)
+        if compstate.debug >= 2: print(("parse_ternary returns", expr))
         return expr
 
 def parse_expr_inner(input):
@@ -340,11 +340,11 @@ def parse_expr_inner(input):
     op = input.lex_token()
     if op.type not in ('+', '-'):
         input.push_token(op)
-        if compstate.debug >= 2: print("parse_expr_inner returns singleton", left)
+        if compstate.debug >= 2: print(("parse_expr_inner returns singleton", left))
         return left
     else:
         expr = (op.type, left, parse_expr_inner(input))
-        if compstate.debug >= 2: print("parse_expr_inner returns", expr)
+        if compstate.debug >= 2: print(("parse_expr_inner returns", expr))
         return expr
 
 def parse_expr(input):
@@ -359,7 +359,7 @@ def parse_expr(input):
 def make_dependent(guard, symbol):
     "Create a dependency lnk, indirecting properly through menus."
     if compstate.debug > 0:
-        print("Making %s dependent on %s" % (symbol.name, guard.name))
+        print(("Making %s dependent on %s" % (symbol.name, guard.name)))
     # If symbol is a menu, we'd really like to create a dependency link
     # for each of its children.  But they won't be defined at this point
     # if the reference is forward.
@@ -406,16 +406,16 @@ def intern_symbol(input, name=None, oktypes=None, record=0):
 
 def intern_symbol_list(input, record=0):
     "Get a list of symbols (terminate on keyword)."
-    list = []
+    symlist = []
     while 1:
         symbol = intern_symbol(input, None, None, record)
         if symbol == None:
             break
         else:
-            list.append(symbol)
-    if not list:
+            symlist.append(symbol)
+    if not symlist:
         input.complain("syntax error, expected a nonempty word list")
-    return list
+    return symlist
 
 def parse(input, baton):
     # Parse an entire CML program
@@ -427,7 +427,7 @@ def parse(input, baton):
         if not compstate.debug and not compstate.errors:
             baton.twirl()
         leader = input.lex_token()
-        if compstate.debug > 1: print("Parsing declaration beginning with %s..." % (leader,))
+        if compstate.debug > 1: print(("Parsing declaration beginning with %s..." % (leader,)))
         # Language constructs begin here 
         if leader.type == "EOF":
             break
@@ -458,7 +458,7 @@ def parse(input, baton):
                 else:
                     input.push_token(tok)
             if compstate.debug:
-                print("%d symbols read" % (len(rulebase.dictionary),))
+                print(("%d symbols read" % (len(rulebase.dictionary),)))
         elif leader.type in ("unless", "when"):
             guard = parse_expr(input)
             maybe = input.lex_token()
@@ -471,9 +471,9 @@ def parse(input, baton):
                     make_dep = 1
                 else:
                     input.push_token(dependent)
-                list = intern_symbol_list(input)
-                list.reverse()
-                for symbol in list:
+                symlist = intern_symbol_list(input)
+                symlist.reverse()
+                for symbol in symlist:
                     if make_dep:
                         traverse_make_dep(symbol, guard, input)
                     # Add it to ordinary visibility constraints
@@ -484,9 +484,9 @@ def parse(input, baton):
             elif maybe == "save":
                 if leader.type == "unless":
                     guard = ("==", guard, cml.n)
-                list = intern_symbol_list(input)
-                list.reverse()
-                for symbol in list:
+                symlist = intern_symbol_list(input)
+                symlist.reverse()
+                for symbol in symlist:
                     if symbol.saveability:
                         symbol.saveability = ('and', guard, symbol.saveability)
                     else:
@@ -502,35 +502,35 @@ def parse(input, baton):
         elif leader.type == "menu":
             menusym = intern_symbol(input, None, ('bool', 'menu', 'choices'), record=1)
             menusym.type = "menu"
-            list = parse_symbol_tree(input)
-            #print "Adding %s to %s" % (list, menusym.name)
+            items = parse_symbol_tree(input)
+            #print "Adding %s to %s" % (items, menusym.name)
             # Add and validate items
-            menusym.items += list
-            for symbol in list:
+            menusym.items += items
+            for symbol in items:
                 if symbol.menu:
-                    input.complain("symbol %s in %s occurs in another menu (%s)"
+                    input.complain("symbol %s in %s occurs in another menu (%s)" 
                                        % (symbol.name, menusym.name, symbol.menu.name))
                 else:
                     symbol.menu = menusym
         elif leader.type == "choices":
             menusym = intern_symbol(input, None, ('bool', 'menu', 'choices'), record=1)
             menusym.type = "choices"
-            list = parse_symbol_tree(input)
-            for symbol in list:
+            items = parse_symbol_tree(input)
+            for symbol in items:
                 symbol.type = "bool"
-                symbol.choicegroup = list(filter(lambda x, s=symbol: x != s, list))
+                symbol.choicegroup = list(filter(lambda x, s=symbol: x != s, items))
             dflt = input.lex_token()
             if dflt.type != 'default':
-                default = list[0].name
+                default = items[0].name
                 input.push_token(dflt)
             else:
                 default = intern_symbol(input, None, None, record=1)
-            if default not in list:
+            if default not in items:
                 input.complain("default %s must be in the menu" % (repr(default),))
             else:
                 menusym.default = default
-                menusym.items = list
-                for symbol in list:
+                menusym.items = items
+                for symbol in items:
                     if symbol.menu:
                         input.complain("symbol %s occurs in another menu (%s)"
                                        % (symbol.name, symbol.menu.name))
@@ -630,10 +630,10 @@ def parse(input, baton):
                 input.push_token(next)
                 continue
         elif leader.type == 'give':
-            list = intern_symbol_list(input)
+            symlist = intern_symbol_list(input)
             input.demand('property')
             label = input.lex_token()
-            for symbol in list:
+            for symbol in symlist:
                 symbol.setprop(label.attr)
         elif leader.type == 'debug':
             compstate.debug = input.lex_token().attr
@@ -738,7 +738,7 @@ def get_symbol_declaration(input):
         compstate.property_stack.pop()
         return 0
     elif symbol.type == 'word':         # Declaration
-        if compstate.debug >= 2: print("interning %s" % symbol.attr)
+        if compstate.debug >= 2: print(("interning %s" % symbol.attr))
         entry = intern_symbol(input, symbol.attr, record=1)
         compstate.symbol_list.append(entry)
         entry.depth = len(compstate.condition_stack)
@@ -1022,7 +1022,7 @@ def compile(debug, arguments, profile, endtok=None):
 
     if profile:
         now = time.time();
-        print("Rule parsing:", now - basetime)
+        print(("Rule parsing:", now - basetime))
         basetime = now
     if not debug and not compstate.errors:
         baton.twirl()
@@ -1254,7 +1254,7 @@ def compile(debug, arguments, profile, endtok=None):
 
     if profile:
         now = time.time();
-        print("Sanity checks:", now - basetime)
+        print(("Sanity checks:", now - basetime))
         basetime = now
 
     # We only need the banner string, not the banner symbol
@@ -1279,11 +1279,11 @@ def compile(debug, arguments, profile, endtok=None):
                     dc = dc + 1
                 if symbol.constraints:
                     cc = cc + 1
-            print("%d total symbols; %d symbols are involved in constraints; %d in dependencies." % (tc, cc, dc))
+            print(("%d total symbols; %d symbols are involved in constraints; %d in dependencies." % (tc, cc, dc)))
 
         if profile:
             now = time.time();
-            print("Total compilation time:", now - zerotime)
+            print(("Total compilation time:", now - zerotime))
 
         # We have a rulebase object.
         return rulebase
@@ -1296,7 +1296,7 @@ if __name__ == '__main__':
             raise SystemExit(1)
         else:
             try:
-                if debug: print("cmlcompile: output directed to %s" % (outfile))
+                if debug: print(("cmlcompile: output directed to %s" % (outfile)))
                 out = open(outfile, "wb")
                 pickle.dump(rulebase, out, 1)
                 out.close()

--- a/contrib/cml2/cmlconfigure.py
+++ b/contrib/cml2/cmlconfigure.py
@@ -381,17 +381,17 @@ class tty_style_base(cmd.Cmd):
         "Set the value of a symbol -- line-oriented error messages."
         if symbol.is_numeric() and symbol.range:
             if not configuration.range_check(symbol, value):
-                print(lang["OUTOFBOUNDS"] % (value, symbol.range,))
+                print((lang["OUTOFBOUNDS"] % (value, symbol.range,)))
                 return
         (ok, effects, violations) = configuration.set_symbol(symbol, value, freeze)
         if effects:
-            print(lang["EFFECTS"])
+            print((lang["EFFECTS"]))
             sys.stdout.write(string.join(effects, "\n") + "\n\n")
         if ok:
             if not interactively_visible(symbol):
-                print(lang["INVISOUT"] % symbol.name)
+                print((lang["INVISOUT"] % symbol.name))
         else:
-            print(lang["ROLLBACK"] % (symbol.name, value))
+            print((lang["ROLLBACK"] % (symbol.name, value)))
             sys.stdout.write(string.join(list(map(repr, violations)), "\n") + "\n")
 
     def page(self, text):
@@ -407,9 +407,9 @@ class tty_style_base(cmd.Cmd):
                 for i in range(base, base+pagedepth):
                     if i >= len(text):
                         break;
-                    print(text[i])
+                    print((text[i]))
                 base = base + pagedepth
-                input(lang["PAGEPROMPT"])
+                eval(input(lang["PAGEPROMPT"]))
         except KeyboardInterrupt:
             print("")
 
@@ -429,22 +429,22 @@ class tty_style_base(cmd.Cmd):
             self.current = configuration.dictionary[line]
             configuration.visit(self.current)
             if not interactively_visible(self.current) and not self.current.frozen():
-                print(lang["SUPPRESSOFF"])
+                print((lang["SUPPRESSOFF"]))
                 self.suppressions = 0
             if self.current.type in ("menu", "message"):
                 self.skip_to_query(configuration.next_node, 1)
         else:
-            print(lang["NONEXIST"] % line)
+            print((lang["NONEXIST"] % line))
     def do_i(self, line):
         file = string.strip(line)
         try:
             (changes, errors) = configuration.load(file, freeze=0)
         except IOError:
-            print(lang["LOADFAIL"] % file)
+            print((lang["LOADFAIL"] % file))
         else:
             if errors:
                 print(errors)
-            print(lang["INCCHANGES"] % (changes,file))
+            print((lang["INCCHANGES"] % (changes,file)))
             if configuration.side_effects:
                 sys.stdout.write(string.join(configuration.side_effects, "\n") + "\n")
     def do_I(self, line):
@@ -452,11 +452,11 @@ class tty_style_base(cmd.Cmd):
         try:
             (changes, errors) = configuration.load(file, freeze=1)
         except IOError:
-            print(lang["LOADFAIL"] % file)
+            print((lang["LOADFAIL"] % file))
         else:
             if errors:
                 print(errors)
-            print(lang["INCCHANGES"] % (changes,file))
+            print((lang["INCCHANGES"] % (changes,file)))
             if configuration.side_effects:
                 sys.stdout.write(string.join(configuration.side_effects, "\n") + "\n")
     def do_y(self, line):
@@ -466,12 +466,12 @@ class tty_style_base(cmd.Cmd):
             # Undocumented feature -- "y FOO" sets FOO to y.
             line = string.strip(line)
             if line not in configuration.dictionary:
-                print(lang["NONEXIST"] % line)
+                print((lang["NONEXIST"] % line))
                 return
             else:
                 target = configuration.dictionary[line]
         if not target.type in ("trit", "bool"):
-            print(lang["YNOTVALID"] % (target.name))
+            print((lang["YNOTVALID"] % (target.name)))
         else:
             self.set_symbol(target, cml.y)
         return None
@@ -484,14 +484,14 @@ class tty_style_base(cmd.Cmd):
             # Undocumented feature -- "m FOO" sets FOO to m.
             line = string.strip(line)
             if line not in configuration.dictionary:
-                print(lang["NONEXIST"] % line)
+                print((lang["NONEXIST"] % line))
                 return
             else:
                 target = configuration.dictionary[line]
         if not target.type == "trit":
-            print(lang["MNOTVALID"] % (target.name))
+            print((lang["MNOTVALID"] % (target.name)))
         elif not configuration.trits_enabled:
-            print(lang["MNOTVALID"] % (target.name))
+            print((lang["MNOTVALID"] % (target.name)))
         else:
             self.set_symbol(target, cml.m)
         return None
@@ -504,12 +504,12 @@ class tty_style_base(cmd.Cmd):
             # Undocumented feature -- "n FOO" sets FOO to n.
             line = string.strip(line)
             if line not in configuration.dictionary:
-                print(lang["NONEXIST"] % line)
+                print((lang["NONEXIST"] % line))
                 return
             else:
                 target = configuration.dictionary[line]
         if not target.type in ("trit", "bool"):
-            print(lang["NNOTVALID"] % (target.name))
+            print((lang["NNOTVALID"] % (target.name)))
         else:
             self.set_symbol(target, cml.n)
         return None
@@ -539,9 +539,9 @@ class tty_style_base(cmd.Cmd):
             if filter and filter not in cml.flatten_expr(constraint):
                 continue
             if constraint == reduced:
-                print(cml.display_expression(reduced)[1:-1])
+                print((cml.display_expression(reduced)[1:-1]))
             else:
-                print("%s -> %s" % (constraint,cml.display_expression(reduced)[1:-1]))
+                print(("%s -> %s" % (constraint,cml.display_expression(reduced)[1:-1])))
         return 0
     def do_q(self, line):
         # Terminate this cmd instance, not saving configuration
@@ -553,7 +553,7 @@ class tty_style_base(cmd.Cmd):
             configuration.debug += 1
         else:
             configuration.debug = int(line)
-        print(lang["VERBOSITY"] % configuration.debug)
+        print((lang["VERBOSITY"] % configuration.debug))
         return 0
     def do_e(self, line):
         # Examine the state of a given symbol
@@ -562,64 +562,64 @@ class tty_style_base(cmd.Cmd):
             entry = configuration.dictionary[symbol]
             print(entry)
             if entry.constraints:
-                print(lang["CONSTRAINTS"])
+                print((lang["CONSTRAINTS"]))
                 for wff in entry.constraints:
-                    print(cml.display_expression(wff))
+                    print((cml.display_expression(wff)))
             if interactively_visible(entry):
-                print(lang["VISIBLE"])
+                print((lang["VISIBLE"]))
             elif entry.visibility is None:
-                print(lang["INVISINONE"])
+                print((lang["INVISINONE"]))
             elif configuration.eval_frozen(entry.visibility):
-                print(lang["INVISIBLE"] + lang["INVISILOCK"])
+                print((lang["INVISIBLE"] + lang["INVISILOCK"]))
             else:
-                print(lang["INVISIBLE"])
+                print((lang["INVISIBLE"]))
             if entry.saveability == None:
-                print(lang["NOSAVEP"])
+                print((lang["NOSAVEP"]))
             if configuration.saveable(entry):
-                print(lang["SAVEABLE"])
+                print((lang["SAVEABLE"]))
             else:
-                print(lang["UNSAVEABLE"])
+                print((lang["UNSAVEABLE"]))
             if entry.setcount:
-                print(lang["SETCOUNT"] % entry.setcount)
+                print((lang["SETCOUNT"] % entry.setcount))
         else:
-            print(lang["NOSUCHAS"], symbol) 
+            print((lang["NOSUCHAS"], symbol)) 
         return 0
     def do_E(self, dummy):
         # Dump the state of the bindings stack
-        print(configuration.binddump())
+        print((configuration.binddump()))
         return 0
     def do_S(self, dummy):
         # Toggle the suppressions flag
         configuration.suppressions = not configuration.suppressions
         if configuration.suppressions:
-            print(lang["SUPPRESSON"])
+            print((lang["SUPPRESSON"]))
         else:
-            print(lang["SUPPRESSOFF"])
+            print((lang["SUPPRESSOFF"]))
         return 0
     def help_e(self):
-        print(lang["EHELP"])
+        print((lang["EHELP"]))
     def help_E(self):
-        print(lang["ECAPHELP"])
+        print((lang["ECAPHELP"]))
     def help_g(self):
-        print(lang["GHELP"])
+        print((lang["GHELP"]))
     def help_i(self):
-        print(lang["IHELP"])
+        print((lang["IHELP"]))
     def help_I(self):
-        print(lang["ICAPHELP"])
+        print((lang["ICAPHELP"]))
     def help_y(self):
-        print(lang["YHELP"])
+        print((lang["YHELP"]))
     def help_m(self):
-        print(lang["MHELP"])
+        print((lang["MHELP"]))
     def help_n(self):
-        print(lang["NHELP"])
+        print((lang["NHELP"]))
     def help_s(self):
-        print(lang["SHELP"])
+        print((lang["SHELP"]))
     def help_q(self):
-        print(lang["QHELP"])
+        print((lang["QHELP"]))
     def help_v(self):
-        print(lang["VHELP"])
+        print((lang["VHELP"]))
     def help_x(self):
-        print(lang["XHELP"])
+        print((lang["XHELP"]))
     def do_help(self, line):
         line = line.strip()
         if line in configuration.dictionary:
@@ -630,7 +630,7 @@ class tty_style_base(cmd.Cmd):
         if help:
             self.page(help)
         else:
-            print(lang["NOHELP"] % (self.current.name,))
+            print((lang["NOHELP"] % (self.current.name,)))
 
 class tty_style_menu(tty_style_base):
     "Interface for configuring with line-oriented commands."
@@ -741,13 +741,13 @@ class tty_style_menu(tty_style_base):
             except ValueError:
                 ind = -1
             if ind <= 0 or ind > len(self.current.items):
-                print(lang["RADIOBAD"])
+                print((lang["RADIOBAD"]))
             else:
                 # print lang["TTYSETTING"] % (`self.current.items[ind - 1]`)
                 self.set_symbol(self.current.items[ind - 1], cml.y)
                 self.skip_to_query(configuration.next_node)
         elif self.current.type in ("bool", "trit"):
-            print(lang["CANNOTSET"])
+            print((lang["CANNOTSET"]))
         else:
             self.set_symbol(self.current, v)
             self.skip_to_query(configuration.next_node)
@@ -762,7 +762,7 @@ class tty_style_menu(tty_style_base):
         return 0
 
     def help_p(self):
-        print(lang["PHELP"])
+        print((lang["PHELP"]))
 
     def postcmd(self, stop, dummy):
         if stop:
@@ -783,18 +783,18 @@ class debugger_style_menu(tty_style_base):
         if newsystem:
             global configuration
             configuration = cmlsystem.CMLSystem(newsystem)
-            print(lang["COMPILEOK"])
+            print((lang["COMPILEOK"]))
         else:
-            print(lang["COMPILEFAIL"])
+            print((lang["COMPILEFAIL"]))
         return 0
 
     def do_V(self,line):
-        print("V",line)
+        print(("V",line))
         for setting in line.split():
             symbol,expected=setting.split('=')
             if symbol not in configuration.dictionary:
                 sys.stderr.write((lang["NONEXIST"] % symbol) + "\n")
-                print(lang["NONEXIST"] % line)
+                print((lang["NONEXIST"] % line))
                 continue
             dictsym = configuration.dictionary[symbol]
             dictval = cml.evaluate(dictsym)
@@ -806,63 +806,63 @@ class debugger_style_menu(tty_style_base):
         return 0
         
     def do_y(self, line):
-        print(line + "=y")
+        print((line + "=y"))
         if not line:
-            print(lang["NOSYMBOL"])
+            print((lang["NOSYMBOL"]))
         else:
             tty_style_base.do_y(self, line)
             if configuration.debug:
-                print(configuration.binddump())
+                print((configuration.binddump()))
     def do_m(self, line):
-        print(line + "=m")
+        print((line + "=m"))
         if not line:
-            print(lang["NOSYMBOL"])
+            print((lang["NOSYMBOL"]))
         else:
             tty_style_base.do_m(self, line)
             if configuration.debug:
-                print(configuration.binddump())
+                print((configuration.binddump()))
     def do_n(self, line):
-        print(line + "=n")
+        print((line + "=n"))
         if not line:
-            print(lang["NOSYMBOL"])
+            print((lang["NOSYMBOL"]))
         else:
             tty_style_base.do_n(self, line)
             if configuration.debug:
-                print(configuration.binddump())
+                print((configuration.binddump()))
 
     def do_f(self, line):
-        print("f", line)
+        print(("f", line))
         line = line.strip()
         if not line:
-            print(lang["NOSYMBOL"])
+            print((lang["NOSYMBOL"]))
         elif line not in configuration.dictionary:
-            print(lang["NONEXIST"] % line)
+            print((lang["NONEXIST"] % line))
         else:
             configuration.dictionary[line].freeze()
         return None
 
     def do_c(self, line):
-        print("c", line)
+        print(("c", line))
         configuration.clear()
         return None
 
     def do_p(self, line):
-        print("p", line)
+        print(("p", line))
         configuration.save(sys.stdout, baton=None, all=1)
         return None
 
     def do_u(self, line):
-        print("u", line)
+        print(("u", line))
         configuration.interactive = not configuration.interactive
         return None
 
     def do_h(self, line):
-        print(string.join([lang[x] for x in ("TTYSUMMARY",
+        print((string.join([lang[x] for x in ("TTYSUMMARY",
                                "YHELP", "MHELP", "NHELP", "PDHELP",
                                "FHELP", "CHELP",
                                "EHELP", "ECAPHELP", "CCAPHELP",
                                "IHELP", "ICAPHELP", "SHELP", "UHELP",
-                               "QHELP", "XHELP", "VCAPHELP", "VHELP")], "\n"))
+                               "QHELP", "XHELP", "VCAPHELP", "VHELP")], "\n")))
 
     def default(self, line):
         if line.strip()[0] == "#":
@@ -883,16 +883,16 @@ class debugger_style_menu(tty_style_base):
         return None
 
     def help_f(self):
-        print(lang["FHELP"])
+        print((lang["FHELP"]))
 
     def help_c(self):
-        print(lang["CHELP"])
+        print((lang["CHELP"]))
 
     def help_V(self):
-        print(lang["VCAPHELP"])
+        print((lang["VCAPHELP"]))
 
     def help_p(self):
-        print(lang["PDHELP"])
+        print((lang["PDHELP"]))
 
     def do_EOF(self, line):
         print("")
@@ -1139,7 +1139,7 @@ class curses_style_menu:
 
         (self.lines, self.columns) = self.window.getmaxyx()
         if self.lines < 9 or self.columns < 60:
-            raise "TERMTOOSMALL"
+            raise Exception("TERMTOOSMALL")
         self.menus.viewport_height = self.lines-2 + (not configuration.expert_tie or cml.evaluate(configuration.expert_tie) != cml.n)
         if curses.has_colors():
             curses.init_pair(curses.COLOR_CYAN, curses.COLOR_CYAN, curses.COLOR_BLACK)
@@ -3034,12 +3034,12 @@ def menu_tree_list(node, indent):
     "Print a map of a menu subtree."
     totalindent = (indent + 4 * node.depth)
     trailer = (" " * (40 - totalindent - len(node.name))) + repr(node.prompt)
-    print(" " * totalindent, node.name, trailer)
+    print((" " * totalindent, node.name, trailer))
     if configuration.debug:
         if node.visibility:
-            print(" " * 41, lang["VISIBILITY"], cml.display_expression(node.visibility))
+            print((" " * 41, lang["VISIBILITY"], cml.display_expression(node.visibility)))
         if node.default:
-            print(" " * 41, lang["DEFAULT"], cml.display_expression(node.default))
+            print((" " * 41, lang["DEFAULT"], cml.display_expression(node.default)))
     if node.items:
         for child in node.items:
             menu_tree_list(child, indent + 4)
@@ -3071,7 +3071,7 @@ def load_system(cmd_options, cmd_arguments):
     try:
         open(rulebase, 'rb')
     except IOError:
-        print(lang["NOFILE"] % (rulebase,))
+        print((lang["NOFILE"] % (rulebase,)))
         raise SystemExit
     configuration = cmlsystem.CMLSystem(rulebase)
 
@@ -3095,12 +3095,12 @@ def process_include(configuration, file, freeze):
     try:
         (changes, errors) = configuration.load(file, freeze)
     except IOError:
-        print(lang["LOADFAIL"] % file)
+        print((lang["LOADFAIL"] % file))
         return
     if errors:
         print(errors)
     elif configuration.side_effects:
-        print(lang["SIDEFROM"] % file)
+        print((lang["SIDEFROM"] % file))
         sys.stdout.write(string.join(configuration.side_effects, "\n") + "\n")
 
 def process_define(configuration, val, freeze):
@@ -3126,10 +3126,10 @@ def process_define(configuration, val, freeze):
         elif parts[1] == 'n':
             val = 'n'
         else:
-            print(lang["BADBOOL"])
+            print((lang["BADBOOL"]))
             sys.exit(1)
     elif len(parts) == 1:
-        print(lang["NOCMDLINE"] % (repr(sym),))
+        print((lang["NOCMDLINE"] % (repr(sym),)))
         sys.exit(1)
     else:
         val = parts[1]
@@ -3137,10 +3137,10 @@ def process_define(configuration, val, freeze):
                                  configuration.value_from_string(sym, val),
                                  freeze)
     if effects:
-        print(lang["EFFECTS"])
+        print((lang["EFFECTS"]))
         sys.stdout.write(string.join(effects,"\n")+"\n")
     if not ok:
-        print(lang["ROLLBACK"] % (sym.name, val))
+        print((lang["ROLLBACK"] % (sym.name, val)))
         sys.stdout.write("\n".join(map(repr, violations))+"\n")
 
 def process_options(configuration, options):
@@ -3216,17 +3216,17 @@ def main(options, arguments):
             curses.wrapper(curses_style_menu, config, banner)
             return
         except "TERMTOOSMALL":
-            print(lang["TERMTOOSMALL"])
+            print((lang["TERMTOOSMALL"]))
             force_tty = 1
 
     # If both failed, go glass-tty
     if force_debugger:
-        print(lang["DEBUG"] % configuration.banner)
+        print((lang["DEBUG"] % configuration.banner))
         debugger_style_menu(config, banner).cmdloop()        
     elif force_tty:
-        print(lang["WELCOME"]%(configuration.banner,) + lang["VERSION"]%(cml.version,))
+        print((lang["WELCOME"]%(configuration.banner,) + lang["VERSION"]%(cml.version,)))
         configuration.errout = sys.stdout
-        print(lang["TTYQUERY"])
+        print((lang["TTYQUERY"]))
         tty_style_menu(config, banner).cmdloop()
 
 if __name__ == '__main__':
@@ -3239,13 +3239,13 @@ if __name__ == '__main__':
                 runopts)
             options = envopts + options
     except:
-        print(lang["BADOPTION"])
-        print(lang["CLIHELP"])
+        print((lang["BADOPTION"]))
+        print((lang["CLIHELP"]))
         sys.exit(1)
 
     for (switch, val) in options:
         if switch == "-V":
-            print("cmlconfigure", cml.version)
+            print(("cmlconfigure", cml.version))
             raise SystemExit
         elif switch == '-P':
             proflog = val
@@ -3273,7 +3273,7 @@ if __name__ == '__main__':
             from tkinter import *
             from tkinter.dialog import *
         except:
-            print(lang["NOTKINTER"])
+            print((lang["NOTKINTER"]))
             time.sleep(5)
             force_curses = 1
             force_x = force_q = 0
@@ -3281,7 +3281,7 @@ if __name__ == '__main__':
     # Probe the environment to see if we can come up in ncurses mode
     if not force_tty and not force_x and not force_q:
         if 'TERM' not in os.environ:
-            print(lang["TERMNOTSET"])
+            print((lang["TERMNOTSET"]))
             force_tty = 1
         else:
             import traceback
@@ -3290,7 +3290,7 @@ if __name__ == '__main__':
                 force_curses = 1
             except:
                 ImportError
-                print(lang["NOCURSES"])
+                print((lang["NOCURSES"]))
                 force_tty = 1
 
     if force_tty or force_debugger:
@@ -3311,11 +3311,11 @@ if __name__ == '__main__':
     except KeyboardInterrupt:
         #if configuration.commits > 0:
         #    print lang["NOTSAVED"]
-        print(lang["ABORTED"])
+        print((lang["ABORTED"]))
         raise SystemExit(2)
     except "UNSATISFIABLE":
         #configuration.save("post.mortem")
-        print(lang["POSTMORTEM"])
+        print((lang["POSTMORTEM"]))
         raise SystemExit(3)
 
 # That's all, folks!

--- a/contrib/cml2/cmlsystem.py
+++ b/contrib/cml2/cmlsystem.py
@@ -83,7 +83,7 @@ class CMLSystem(cml.CMLRulebase):
 
     def clear(self):
         "Clear the runtime value state."
-        for entry in self.dictionary.values():
+        for entry in list(self.dictionary.values()):
             entry.iced = 0		# True if it has been frozen
             if entry.type == "choices":
                 entry.menuvalue = entry.default
@@ -101,8 +101,8 @@ class CMLSystem(cml.CMLRulebase):
         "Make a configuration state object from a compiled rulebase."
         # Interpret a string as the name of a file containing pickled rules.
         if type(rules) == type(""):
-            import cPickle
-            rules = cPickle.load(open(rules, "rb"))
+            import pickle
+            rules = pickle.load(open(rules, "rb"))
 
         # Copy the symbol table.   Since a python object's members are all
         # stored in a single hash table, we can steal its contents and
@@ -181,7 +181,7 @@ class CMLSystem(cml.CMLRulebase):
 
         if rules.version != cml.version:
             sys.stderr.write(self.lang["BADVERSION"] % (rules.version, cml.version))
-            raise SystemExit, 1
+            raise SystemExit(1)
 
     def is_new(self, symbol):
         return self.inclusions and not symbol.included and symbol.is_symbol()
@@ -233,11 +233,11 @@ class CMLSystem(cml.CMLRulebase):
             menu = menu.menu
     def __bindsymbol(self, symbol, value, source=None, sort=0, suppress=0):
         "Bind symbol to a given value."
-        self.debug_emit(2, "    %sbindsymbol(%s, %s, %s, %s)" % (' '*self.cdepth,symbol.name, value, `source`, sort))
+        self.debug_emit(2, "    %sbindsymbol(%s, %s, %s, %s)" % (' '*self.cdepth,symbol.name, value, repr(source), sort))
         if not source:
             source = symbol
         # Avoid creating duplicate bindings.
-        if self.newbindings.has_key(source):
+        if source in self.newbindings:
             bindings = self.newbindings[source]
             while bindings:
                 if bindings.symbol == symbol and bindings.value == value:
@@ -250,7 +250,7 @@ class CMLSystem(cml.CMLRulebase):
             if source == None or source == symbol:
                 side = ""
             else:
-                side = self.lang["SIDEEFFECT"] % (`source`,)
+                side = self.lang["SIDEEFFECT"] % (repr(source),)
             side = self.lang["SETTING"] % (symbol.name, value) + side
             if source and source != symbol and not suppress:
                 self.side_effects.append(side)
@@ -297,7 +297,7 @@ class CMLSystem(cml.CMLRulebase):
         undo = []
         # When we undo side-effects from a choice symbol, all the side-effects
         # from setting its siblings have to be backed out too.
-        for primary in self.newbindings.keys():
+        for primary in list(self.newbindings.keys()):
             if primary.menu.type == "choices":
                 undo.extend(primary.menu.items)
             else:
@@ -334,10 +334,10 @@ class CMLSystem(cml.CMLRulebase):
         res = ""
         if context == None:
             context=self.oldbindings
-        for (primary, bindings) in context.items():
+        for (primary, bindings) in list(context.items()):
             res = res + "# %s(%s, touched=%d): " % (primary.name,("inactive","active")[bindings.visible], primary in self.touched)
             while bindings:
-                res = res + `bindings` + ", "
+                res = res + repr(bindings) + ", "
                 bindings = bindings.link
             res = res[:-2] + "\n"
         return res
@@ -413,7 +413,7 @@ class CMLSystem(cml.CMLRulebase):
             # Now parse ordinary symbol sets
             if len(self.prefix) and symname[0:len(self.prefix)] == self.prefix:
                 symname = symname[len(self.prefix):]
-            if self.dictionary.has_key(symname):
+            if symname in self.dictionary:
                 symbol = self.dictionary[symname]
             else:
                 symbol = None
@@ -520,9 +520,9 @@ class CMLSystem(cml.CMLRulebase):
             self.__save_recurse(self.start, outfp, baton, mode)
             # Write all derived symbols
             if mode != "list":
-                if filter(lambda x: x.is_derived(), self.dictionary.values()):
+                if [x for x in list(self.dictionary.values()) if x.is_derived()]:
                     outfp.write(self.lang["SHDERIVED"])
-                for entry in self.dictionary.values():
+                for entry in list(self.dictionary.values()):
                     if entry.is_derived():
                         if baton:
                             baton.twirl()
@@ -540,12 +540,12 @@ class CMLSystem(cml.CMLRulebase):
                     os.rename(shelltemp, outfile)
                 except OSError:
                     reason  = self.lang["RENAME"] % (shelltemp, outfile,)
-                    raise IOError, reason
+                    raise IOError(reason)
             self.commits = 0
             if baton:
                 baton.end()
             return None
-        except IOError, details:
+        except IOError as details:
             return details.args[0]
 
     def save_symbol(self, symbol, shellstream, label=""):
@@ -560,18 +560,18 @@ class CMLSystem(cml.CMLRulebase):
             elif symbol.type == "string":
                 shellstream.write("%s=\"%s\"" % (symname, value))
             elif symbol.type in ("bool", "trit"):
-                shellstream.write("%s=%s" % (symname, `value`))
+                shellstream.write("%s=%s" % (symname, repr(value)))
             elif value == None and symbol.is_logical():
                 shellstream.write("%s=n" % (symname,))
             else:
-                raise ValueError, self.lang["VALUNKNOWN"] % (symbol,symbol.type,value)
+                raise ValueError(self.lang["VALUNKNOWN"] % (symbol,symbol.type,value))
             if label:
                 shellstream.write("\t# " + label)
             shellstream.write("\n")
         except:
             (errtype, errval, errtrace) = sys.exc_info()
-            print "Internal error %s while writing %s." % (errtype, symbol)
-            raise SystemExit, 1
+            print("Internal error %s while writing %s." % (errtype, symbol))
+            raise SystemExit(1)
 
     def __save_recurse(self, node, shellstream, baton=None, mode="normal"):
         saveable = self.saveable(node, mode)
@@ -695,7 +695,7 @@ class CMLSystem(cml.CMLRulebase):
                 break
         else:
             return 1	# Tricky use of for-else
-        self.debug_emit(2, self.lang["EXCLUDED"] % (`symbol`, `cml.trit(value)`, `ancestor`))
+        self.debug_emit(2, self.lang["EXCLUDED"] % (repr(symbol), repr(cml.trit(value)), repr(ancestor)))
         return 0
 
     def __dep_visible(self, symbol):
@@ -713,7 +713,7 @@ class CMLSystem(cml.CMLRulebase):
 
     def __dep_force_ancestors(self, dependent, source, dependvalue, ancestor):
         "Force a symbol's ancestors up, based on the symbol's value."
-        self.debug_emit(2, "    dep_force_ancestors(%s, %s, %s, %s)" % (`dependent`, `source`, `dependvalue`, `ancestor`))
+        self.debug_emit(2, "    dep_force_ancestors(%s, %s, %s, %s)" % (repr(dependent), repr(source), repr(dependvalue), repr(ancestor)))
         if dependent.is_logical() and ancestor.is_logical():
             anctype = ancestor.type
             if dependvalue > cml.n:
@@ -738,7 +738,7 @@ class CMLSystem(cml.CMLRulebase):
 
     def __dep_force_dependents(self, guard, source, guardvalue, dependent):
         "Force a symbol's descendents down, based on the symbol's value."
-        self.debug_emit(2, "    dep_force_dependents(%s, %s, %s, %s)" % (`guard`, `source`, `guardvalue`, `dependent`))
+        self.debug_emit(2, "    dep_force_dependents(%s, %s, %s, %s)" % (repr(guard), repr(source), repr(guardvalue), repr(dependent)))
         if guard.is_logical() and dependent.is_logical():
             deptype = dependent.type
             depvalue = cml.evaluate(dependent)
@@ -767,9 +767,9 @@ class CMLSystem(cml.CMLRulebase):
     #
     def __rollback(self):
         "Roll back all new bindings."
-        self.debug_emit(1, self.lang["ROLLBACK"] + `self.touched`)
+        self.debug_emit(1, self.lang["ROLLBACK"] + repr(self.touched))
         self.touched = []
-        for symbol in self.newbindings.keys():
+        for symbol in list(self.newbindings.keys()):
             self.__unbindsymbol(symbol, self.newbindings)
         self.side_effects = []
 
@@ -781,7 +781,7 @@ class CMLSystem(cml.CMLRulebase):
             self.debug_emit(1, self.lang["COMMIT"])
             if self.trit_tie and self.trit_tie in self.touched:
                 self.trits_enabled = cml.evaluate(self.trit_tie)
-                self.debug_emit(1, self.lang["TRITFLAG"] % (`cml.trit(self.trits_enabled)`,))
+                self.debug_emit(1, self.lang["TRITFLAG"] % (repr(cml.trit(self.trits_enabled)),))
             if self.help_tie and self.help_tie in self.touched:
                 self.debug_emit(1, self.lang["HELPFLAG"] % self.help_tie.eval())
         for entry in self.touched:
@@ -843,7 +843,7 @@ class CMLSystem(cml.CMLRulebase):
 
     def __set_symbol_internal(self, symbol, value, source=None, sort=0):
         "Recursively bind a symbol, with side effects."
-        self.debug_emit(2, "    %sset_symbol_internal(%s, %s, %s, %s)" % (' ' * self.cdepth, symbol.name, value, `source`, sort))
+        self.debug_emit(2, "    %sset_symbol_internal(%s, %s, %s, %s)" % (' ' * self.cdepth, symbol.name, value, repr(source), sort))
         self.cdepth += 1
         if not source:
             source = symbol
@@ -877,9 +877,9 @@ class CMLSystem(cml.CMLRulebase):
         # but only if the attempt comes from a different source,
         # because ancestry forcing will often result in the same symbol
         # being changed multiple times in succession from the same source.
-        if self.chilled.has_key(symbol) and self.chilled[symbol] != source:
+        if symbol in self.chilled and self.chilled[symbol] != source:
             self.__bindsymbol(symbol, value, source)	# record for debugging
-            raise "UNSATISFIABLE"
+            raise Exception("UNSATISFIABLE")
         # Membership in chilled means we should treat the binding as frozen for
         # simplification purposes.  It has to be turned off when the current
         # call to set_symbol is done; otherwise side effects from inclusion
@@ -905,7 +905,7 @@ class CMLSystem(cml.CMLRulebase):
                 self.__set_symbol_internal(sibling, cml.n, source)
         # Other side effects...
         if self.trit_tie and symbol == self.trit_tie and value == cml.n:
-            for entry in self.dictionary.values():
+            for entry in list(self.dictionary.values()):
                 if entry.type == "trit" and not entry.is_derived() and entry.eval() == cml.m:
                     self.__set_symbol_internal(entry, cml.y, source)
         # Now propagate the value change through ancestry chains.
@@ -952,15 +952,15 @@ class CMLSystem(cml.CMLRulebase):
         elif sym.type == "decimal":
             val = int(val)
         elif sym.type == "hexadecimal":
-            val = long(val, 16)
+            val = int(val, 16)
         return val
 
     def eval_frozen(self, wff):
         "Test whether a given expr is entirely constant, chilled or frozen."
-        if isinstance(wff,cml.trit) or type(wff) in (type(0),type(0L),type("")):
+        if isinstance(wff,cml.trit) or type(wff) in (type(0),type(0),type("")):
             return wff
         elif isinstance(wff, cml.ConfigSymbol):
-            if wff.frozen() or self.chilled.has_key(wff):
+            if wff.frozen() or wff in self.chilled:
                 return wff.eval()
             elif wff.is_derived():
                 return self.eval_frozen(wff.default)
@@ -1020,7 +1020,7 @@ class CMLSystem(cml.CMLRulebase):
 
     def __constrain(self, wff, source, fixedval=cml.y):
         "Set symbols based on asserted equalities or inequalities."
-        self.debug_emit(2, self.lang["BINDING"] % (self.cdepth*' ', cml.display_expression(wff), fixedval, `source`))
+        self.debug_emit(2, self.lang["BINDING"] % (self.cdepth*' ', cml.display_expression(wff), fixedval, repr(source)))
         self.cdepth += 1
         ret = self.__inner_constrain(wff, source, fixedval)
         self.cdepth -= 1
@@ -1061,7 +1061,7 @@ class CMLSystem(cml.CMLRulebase):
         elif fixedval == cml.n and op == 'or':
             return self.__constrain(left, source, fixedval) + \
                    self.__constrain(right, source, fixedval)
-        elif op in CMLSystem.relational_map.keys() \
+        elif op in list(CMLSystem.relational_map.keys()) \
              and (isinstance(left, cml.trit) or (isinstance(left, cml.ConfigSymbol) and left.is_logical())) \
              and (isinstance(right, cml.trit) or (isinstance(right, cml.ConfigSymbol) and right.is_logical())):
             if fixedval == cml.n:
@@ -1145,7 +1145,7 @@ class CMLSystem(cml.CMLRulebase):
             except IndexError:
                 # Kluge -- if we find no visible items, turn off suppressions
                 # and drop back to the original default.
-                self.debug_emit(1, self.lang["NOVISIBLE"] % (`entry`,))
+                self.debug_emit(1, self.lang["NOVISIBLE"] % (repr(entry),))
                 ind = base
                 self.suppressions = 0
             self.set_symbol(entry.items[ind], cml.y)
@@ -1189,7 +1189,7 @@ class CMLSystem(cml.CMLRulebase):
         "Return a menu composed of symbols matching a given regexp."
         regexp = re.compile(pattern)
         hits = cml.ConfigSymbol("search", "menu")
-        for entry in self.dictionary.values():
+        for entry in list(self.dictionary.values()):
             if entry.prompt and entry.type != "message":
                 text = hook(entry)
                 if text == None:
@@ -1229,7 +1229,7 @@ class CMLSystem(cml.CMLRulebase):
                     return 1
         else:
             for span in symbol.range:
-                if type(span) in (type(0), type(0L)):
+                if type(span) in (type(0), type(0)):
                     if value == span:
                         return 1
                 elif value >= span[0] and value <= span[1]:

--- a/contrib/cml2/tree.py
+++ b/contrib/cml2/tree.py
@@ -5,7 +5,7 @@
 # 99/??/?? CEC release to comp.lang.python.announce
 # Trimmed for CML2 by ESR, December 2001 (cut-paste support removed).
 import os, string
-from Tkinter import *
+from tkinter import *
 
 # this is initialized later, after Tkinter is started
 open_icon=None
@@ -216,7 +216,7 @@ class Node:
         self.widget.configure(scrollregion=(x1, y1, x2+5, y2+5))
         # call customization hook
         if self.widget.after_hook:
-            print 'calling after_hook'
+            print('calling after_hook')
             self.widget.after_hook(self)
         # release mutex
         self.spinlock=0
@@ -231,8 +231,8 @@ class Node:
             for n in self.subnodes:
                 if n.id == dirs[0]:
                     return n.expand(dirs[1:])
-            print "Can't find path %s in %s" % (dirs, self.id)
-            print "- Available subnodes: %s" % map(lambda n: n.id, self.subnodes)
+            print("Can't find path %s in %s" % (dirs, self.id))
+            print("- Available subnodes: %s" % [n.id for n in self.subnodes])
         return self
     
     # handle mouse clicks by moving cursor and toggling folder state
@@ -241,7 +241,7 @@ class Node:
         self.toggle_state()
 
     # return next lower visible node
-    def next(self):
+    def __next__(self):
         n=self
         if n.subnodes:
             # if you can go right, do so
@@ -280,7 +280,7 @@ class Tree(Canvas):
                  distx=15, disty=15, textoff=10, lineflag=1, **kw_args):
         global open_icon, shut_icon, file_icon,yes_icon,no_icon
         # pass args to superclass
-        apply(Canvas.__init__, (self, master), kw_args)
+        Canvas.__init__(*(self, master), **kw_args)
         # try creating an image, work around Tkinter bug
         # ('global' should do it, but it doesn't)
         if open_icon is not None:
@@ -288,7 +288,7 @@ class Tree(Canvas):
                 item = self.create_image(0,0,image=open_icon)
                 self.delete(item)
             except:
-                print "recreating Tree PhotoImages"
+                print("recreating Tree PhotoImages")
                 open_icon = None # need to recreate PhotoImages
         # default images (BASE64-encoded GIF files)
         # we have to delay initialization until Tk starts up or PhotoImage()
@@ -316,7 +316,7 @@ class Tree(Canvas):
             'gjUIAolILpDB70zxxnieJBxl6n1FiGLiuW4tgJcSGuKRI/h/oAX8FADs=')
         # function to return subnodes (not very much use w/o this)
         if not getcontents:
-            raise ValueError, 'must have "get_contents" function'
+            raise ValueError('must have "get_contents" function')
         self.get_contents=getcontents
         # horizontal distance that subtrees are indented
         self.distx=distx
@@ -360,7 +360,7 @@ class Tree(Canvas):
         self.bind('<Next>', self.pagedown)
         self.bind('<Prior>', self.pageup)
         # arrow-up/arrow-down
-        self.bind('<Down>', self.next)
+        self.bind('<Down>', self.__next__)
         self.bind('<Up>', self.prev)
         # arrow-left/arrow-right
         self.bind('<Left>', self.ascend)
@@ -374,7 +374,7 @@ class Tree(Canvas):
 
     # scroll (in a series of nudges) so items are visible
     def see(self, *items):
-        x1, y1, x2, y2=apply(self.bbox, items)
+        x1, y1, x2, y2=self.bbox(*items)
         while x2 > self.canvasx(0)+self.winfo_width():
             old=self.canvasx(0)
             self.xview('scroll', 1, 'units')
@@ -423,7 +423,7 @@ class Tree(Canvas):
 
     # move to next lower visible node
     def next(self, event=None):
-        self.move_cursor(self.pos.next())
+        self.move_cursor(next(self.pos))
             
     # move to next higher visible node
     def prev(self, event=None):
@@ -443,7 +443,7 @@ class Tree(Canvas):
             self.move_cursor(self.pos.subnodes[0])
         else:
             # if no subnodes, move to next sibling
-            self.next()
+            next(self)
 
     # go to root
     def first(self, event=None):
@@ -472,7 +472,7 @@ class Tree(Canvas):
         n=self.pos
         j=self.winfo_height()/self.disty
         for i in range(j-3):
-            n=n.next()
+            n=next(n)
         self.yview('scroll', 1, 'pages')
         self.move_cursor(n)
 

--- a/kernel/Mk/Makeconf
+++ b/kernel/Mk/Makeconf
@@ -190,7 +190,7 @@ ifeq ("$(CONFIG_DEBUG_SYMBOLS)","y")
 CCFLAGS  += -g
 endif
 
-CFLAGS = -ffreestanding $(CCFLAGS) -std=c23
+CFLAGS = -ffreestanding $(CCFLAGS) -std=c2x
 
 # these for assembly files only
 ASMFLAGS += $(ASMFLAGS_$(PLATFORM)) $(ASMFLAGS_$(ARCH)) $(ASMFLAGS_$(CPU))


### PR DESCRIPTION
## Summary
- modernize cml2 python scripts for Python 3
- update kernel build rules to use `-std=c2x`

## Testing
- `cmake --build .`
- `python3 -m unittest tests.test_subdomain`