### PR TITLE
Run compiledb & configuredb via pip in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,12 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y build-essential
-      - name: Install pre-commit
+      - name: Install Python tools
         run: |
-          python3 -m pip install --user pre-commit
+          python3 -m pip install --user pre-commit compiledb configuredb
+          pre-commit --version
+          compiledb --version
+          configuredb --help
       - name: Configure userland
         run: |
           mkdir build
@@ -45,9 +48,12 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y build-essential
-      - name: Install pre-commit
+      - name: Install Python tools
         run: |
-          python3 -m pip install --user pre-commit
+          python3 -m pip install --user pre-commit compiledb configuredb
+          pre-commit --version
+          compiledb --version
+          configuredb --help
       - name: Build kernel
         run: |
           make -C kernel BUILDDIR=$PWD/kernel-build

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -29,9 +29,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
       - uses: actions/setup-python@v5
-      - name: Install pre-commit
+      - name: Install Python tools
         run: |
-          python3 -m pip install --user pre-commit
+          python3 -m pip install --user pre-commit compiledb configuredb
+          pre-commit --version
+          compiledb --version
+          configuredb --help
 
     - name: Install linter runtime deps
       run: |

--- a/setup.sh
+++ b/setup.sh
@@ -193,6 +193,7 @@ fi
 # Ensure critical Python tooling is present even if package installs were skipped
 for pip_pkg in \
   pre-commit \
+  compiledb \
   configuredb \
   pytest \
   pyyaml \
@@ -205,6 +206,8 @@ if ! python3 -m pre_commit --version >/dev/null 2>&1; then
   pip3 install --no-index pre-commit && python3 -m pre_commit --version >/dev/null 2>&1 && echo "pre-commit installed from local cache" >>"$FAIL_LOG"
 fi
 python3 -m pre_commit --version >/dev/null 2>&1 || echo "pre-commit not available" | tee -a "$FAIL_LOG"
+compiledb --version >/dev/null 2>&1 || echo "compiledb not available" | tee -a "$FAIL_LOG"
+configuredb --help >/dev/null 2>&1 || echo "configuredb not available" | tee -a "$FAIL_LOG"
 
 # Create a minimal pre-commit configuration if one does not already exist
 if [ ! -f .pre-commit-config.yaml ]; then


### PR DESCRIPTION
## Summary
- install more Python tools in CI
- verify `pre-commit`, `compiledb`, and `configuredb` run
- install the same tools in the setup script

## Testing
- `pytest -q`
- `bash setup.sh` *(fails: externally-managed-environment)*