### PR TITLE
Add C++23 SVR4 machdep module

### DIFF
--- a/contrib/include/svr4_machdep.hpp
+++ b/contrib/include/svr4_machdep.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace svr4 {
+
+// Register indices for general purpose registers on x86 when
+// communicating with SVR4 user space components. Matches the
+// traditional SVR4 layout but expressed using an enum class
+// for type safety.
+enum class Reg : std::size_t {
+    GS, FS, ES, DS,
+    EDI, ESI, EBP, ESP,
+    EBX, EDX, ECX, EAX,
+    TRAPNO, ERR, EIP, CS,
+    EFL, UESP, SS,
+    MAXREG
+};
+
+using greg_t = int;
+using gregset_t = std::array<greg_t, static_cast<std::size_t>(Reg::MAXREG)>;
+
+struct fregset_t {
+    std::array<int, 62>  x87{};   // x87 registers
+    std::array<long, 33> weitek{}; // weitek registers
+};
+
+struct mcontext_t {
+    gregset_t  greg{};
+    fregset_t  freg{};
+};
+
+inline constexpr int UC_MACHINE_PAD = 5;
+
+// Numbers used with the sysarch() system call
+enum class Sysarch : int {
+    FPHW = 40,
+    DSCR = 75
+};
+
+struct ssd {
+    unsigned int selector;
+    unsigned int base;
+    unsigned int limit;
+    unsigned int access1;
+    unsigned int access2;
+};
+
+// Processor trap identifiers
+enum class Trap : int {
+    DIVIDE      = 0,
+    TRCTRAP     = 1,
+    NMI         = 2,
+    BPTFLT      = 3,
+    OFLOW       = 4,
+    BOUND       = 5,
+    PRIVINFLT   = 6,
+    DNA         = 7,
+    DOUBLEFLT   = 8,
+    FPOPFLT     = 9,
+    TSSFLT      = 10,
+    SEGNPFLT    = 11,
+    STKFLT      = 12,
+    PROTFLT     = 13,
+    PAGEFLT     = 14,
+    ALIGNFLT    = 17
+};
+
+// Fast system call gate identifiers
+enum class FastTrap : int {
+    FNULL       = 0, // Null trap, for testing
+    FGETFP      = 1, // Get emulated FP context
+    FSETFP      = 2, // Set emulated FP context
+    GETHRTIME   = 3, // implements gethrtime(2)
+    GETHRVTIME  = 4, // implements gethrvtime(2)
+    GETHRESTIME = 5  // clock_gettime(CLOCK_REALTIME, tp)
+};
+
+struct proc; // forward declaration from the kernel
+
+void syscall_intern(proc*);
+
+} // namespace svr4
+

--- a/docs/building.md
+++ b/docs/building.md
@@ -97,4 +97,9 @@ so that formatting and linting tools run automatically.
 Further notes on PowerPC cross compilation can be found in
 `doc/notes/ppc-build.txt`.
 
+The `contrib/include` directory also provides `svr4_machdep.hpp`, a
+header that translates the historic SVR4 machine dependencies into a
+typed C++23 interface.  A short usage sample lives in
+`docs/svr4_machdep_cpp23.cpp`.
+
 See the top-level LICENSE file for the project's terms.

--- a/docs/svr4_machdep_cpp23.cpp
+++ b/docs/svr4_machdep_cpp23.cpp
@@ -1,0 +1,14 @@
+// Example use of the C++23 SVR4 compatibility header.
+// This demonstrates how the modernised definitions can be
+// consumed from regular C++ code.
+
+#include <iostream>
+#include <svr4_machdep.hpp>
+
+int main() {
+    svr4::mcontext_t ctx{};
+    ctx.greg[static_cast<std::size_t>(svr4::Reg::EIP)] = 0xdeadbeef;
+    std::cout << "EIP: 0x" << std::hex
+              << ctx.greg[static_cast<std::size_t>(svr4::Reg::EIP)]
+              << std::dec << '\n';
+}


### PR DESCRIPTION
## Summary
- add a header-only C++23 wrapper for `svr4_machdep.h`
- provide usage example under docs
- mention new header in the build instructions

## Testing
- `python -m pytest -q tests/test_subdomain.py`