### PR TITLE
Add CMake cache variables for cross builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
 project(pistachio C CXX)
 
+# Allow passing cross build settings through CMake
+set(TOOLPREFIX "" CACHE STRING "Prefix for cross compilation tools")
+set(SUBARCH "" CACHE STRING "Kernel sub-architecture")
+set(ARCH "" CACHE STRING "Kernel architecture")
+
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_CXX_STANDARD 23)
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -34,6 +34,19 @@ These commands simply invoke the existing Makefiles so any custom
 settings in `kernel/Makeconf.local` or environment variables are still
 honoured.
 
+### Cross compiling
+
+`cmake` can forward build variables to these Makefiles.  The most
+useful are `TOOLPREFIX`, `ARCH` and `SUBARCH`:
+
+```bash
+$ cmake -DTOOLPREFIX=/usr/bin/powerpc-linux-gnu- \
+        -DARCH=powerpc -DSUBARCH=none ..
+$ cmake --build .
+```
+
+Adjust the values for your toolchain and desired target.
+
 =======
 # Building Pistachio
 

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,13 +1,17 @@
 # Wrap the existing kernel Makefile
 
+set(TOOLPREFIX "" CACHE STRING "Prefix for cross compilation tools")
+set(SUBARCH "" CACHE STRING "Kernel sub-architecture")
+set(ARCH "" CACHE STRING "Kernel architecture")
+
 add_custom_target(kernel_target ALL
-    COMMAND ${CMAKE_MAKE_PROGRAM}
+    COMMAND ${CMAKE_MAKE_PROGRAM} TOOLPREFIX=${TOOLPREFIX} SUBARCH=${SUBARCH} ARCH=${ARCH}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Building kernel via Makefile"
 )
 
 add_custom_target(kernel_clean
-    COMMAND ${CMAKE_MAKE_PROGRAM} clean
+    COMMAND ${CMAKE_MAKE_PROGRAM} TOOLPREFIX=${TOOLPREFIX} SUBARCH=${SUBARCH} ARCH=${ARCH} clean
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Cleaning kernel build"
 )


### PR DESCRIPTION
## Summary
- add `TOOLPREFIX`, `SUBARCH` and `ARCH` cache variables in the root and kernel CMake builds
- pass those variables to the kernel Makefile
- document cross building with these variables

## Testing
- `python -m unittest discover -v tests`