### PR TITLE
Add ticket lock TLA+ model and CI check

### DIFF
--- a/.github/workflows/tla-model-check.yml
+++ b/.github/workflows/tla-model-check.yml
@@ -1,0 +1,26 @@
+name: tla-model-check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  tlc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Java and TLA+
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y default-jre unzip wget
+          wget -q https://github.com/tlaplus/tlaplus/releases/latest/download/tlaplus.zip
+          unzip -q tlaplus.zip -d $HOME/tla
+          echo "$HOME/tla" >> $GITHUB_PATH
+      - name: Run TLC
+        run: |
+          java -cp "$HOME/tla/lib/*" tlc2.TLC -deadlock tla/TicketLock.tla

--- a/README
+++ b/README
@@ -113,3 +113,11 @@ database path::
 
     $ clang-tidy -p user path/to/file.cc
 
+
+Model checking
+--------------
+A collection of TLA+ specifications lives in the `tla/` directory. The
+`TicketLock.tla` model can be explored locally with TLC once Java and
+the TLA+ tools are installed::
+
+    $ java -cp /path/to/tla/lib/* tlc2.TLC -deadlock tla/TicketLock.tla

--- a/tla/TicketLock.cfg
+++ b/tla/TicketLock.cfg
@@ -1,0 +1,2 @@
+CONSTANTS N = 3
+INVARIANTS MutualExclusion FairnessInv

--- a/tla/TicketLock.tla
+++ b/tla/TicketLock.tla
@@ -1,0 +1,52 @@
+---- MODULE TicketLock ----
+EXTENDS Naturals, TLC
+
+CONSTANTS N
+
+VARIABLES pc, ticket, next, owner
+
+ProcSet == 0..N-1
+
+vars == << pc, ticket, next, owner >>
+
+Init == 
+    /\ pc = [i \in ProcSet |-> "try"]
+    /\ ticket = [i \in ProcSet |-> -1]
+    /\ next = 0
+    /\ owner = 0
+
+Acquire(i) ==
+    /\ i \in ProcSet
+    /\ pc[i] = "try"
+    /\ pc' = [pc EXCEPT ![i] = "wait"]
+    /\ ticket' = [ticket EXCEPT ![i] = next]
+    /\ next' = next + 1
+    /\ UNCHANGED owner
+
+Wait(i) ==
+    /\ i \in ProcSet
+    /\ pc[i] = "wait"
+    /\ owner = ticket[i]
+    /\ pc' = [pc EXCEPT ![i] = "cs"]
+    /\ UNCHANGED <<ticket, next, owner>>
+
+Release(i) ==
+    /\ i \in ProcSet
+    /\ pc[i] = "cs"
+    /\ pc' = [pc EXCEPT ![i] = "done"]
+    /\ owner' = owner + 1
+    /\ UNCHANGED <<ticket, next>>
+
+Next ==
+    \E i \in ProcSet: Acquire(i) \/ Wait(i) \/ Release(i)
+
+Spec == Init /\ [][Next]_vars
+
+MutualExclusion ==
+    \A i,j \in ProcSet: (i # j) => ~(pc[i] = "cs" /\ pc[j] = "cs")
+
+FairnessInv ==
+    \A i,j \in ProcSet:
+        (ticket[i] < ticket[j] /\ pc[j] = "cs") => pc[i] = "done"
+
+====


### PR DESCRIPTION
## Summary
- model ticket lock in TLA+
- check mutual exclusion and fairness
- run TLC in CI for pushes and PRs
- document local model checking

## Testing
- `pytest -q`
