### PR TITLE
Add CPU tuning flags and CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,20 @@ permissions:
 jobs:
   build-userland:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - host: x86_64-linux-gnu
+            cflags: "-march=x86-64"
+          - host: i686-linux-gnu
+            cflags: "-m32 -march=i686"
     steps:
       - uses: actions/checkout@v4
       - name: Install build tools
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y build-essential
+          sudo apt-get install -y build-essential gcc-multilib g++-multilib
       - name: Install Python tools
         run: |
           python3 -m pip install --user pre-commit compiledb configuredb
@@ -29,11 +37,12 @@ jobs:
         run: |
           mkdir build
           cd build
-          ../user/configure
+          CFLAGS="${{ matrix.cflags }}" CXXFLAGS="${{ matrix.cflags }}" \
+          ../user/configure --host=${{ matrix.host }}
       - name: Build userland
         run: |
           cd build
-          make -j$(nproc)
+          make -j$(nproc) CPU_CFLAGS="${{ matrix.cflags }}"
       - name: Run tests
         run: |
           pip install pytest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,17 @@ set(ARCH "" CACHE STRING "Kernel architecture")
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_CXX_STANDARD 23)
 
+# CPU tuning flags. Default to -march=native but allow overrides via
+# -DTUNE_CPU=<cpu> or explicit -DCMAKE_C_FLAGS_RELEASE.
+set(TUNE_CPU "native" CACHE STRING "CPU microarchitecture for -march")
+set(CPU_CFLAGS "-march=${TUNE_CPU}")
+if("${CMAKE_C_FLAGS_RELEASE}" STREQUAL "")
+    set(CMAKE_C_FLAGS_RELEASE "${CPU_CFLAGS}")
+endif()
+if("${CMAKE_CXX_FLAGS_RELEASE}" STREQUAL "")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CPU_CFLAGS}")
+endif()
+
 # Build the string.o example from the legacy Makefile
 add_library(string_obj OBJECT
     user/contrib/elf-loader/platform/amd64-pc99/string.cc

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 CFLAGS ?= -std=c2x
 CXXFLAGS ?= -std=c++23
+CPU_CFLAGS ?= -march=native
+CFLAGS += $(CPU_CFLAGS)
+CXXFLAGS += $(CPU_CFLAGS)
 
 build/string.o: user/contrib/elf-loader/platform/amd64-pc99/string.cc
 	echo Building string.o

--- a/docs/building.md
+++ b/docs/building.md
@@ -159,6 +159,33 @@ ARM builds are similar.  For 64‑bit ARM:
 
 These examples mirror the toolchains installed by `setup.sh`.
 
+### CPU tuning flags
+
+Both the CMake and Makefile builds use `-march=native` by default.  The
+target CPU can be overridden with the `TUNE_CPU` option when invoking
+CMake or by setting `CPU_CFLAGS` for the Makefile.
+
+**x86 example**
+
+```bash
+$ cmake -DTUNE_CPU=skylake ..
+$ make CPU_CFLAGS="-march=skylake"
+```
+
+**ARM example**
+
+```bash
+$ cmake -DTUNE_CPU=cortex-a53 ..
+$ make CPU_CFLAGS="-march=armv8-a"
+```
+
+**PowerPC example**
+
+```bash
+$ cmake -DTUNE_CPU=power9 ..
+$ make CPU_CFLAGS="-march=power9"
+```
+
 The `contrib/include` directory also provides `svr4_machdep.hpp`, a
 header that translates the historic SVR4 machine dependencies into a
 typed C++23 interface.  A short usage sample lives in


### PR DESCRIPTION
## Summary
- default to -march=native via `TUNE_CPU` in CMake and Makefile
- allow overriding CPU flag with `TUNE_CPU`/`CPU_CFLAGS`
- document CPU tuning examples for x86, ARM and PowerPC
- build userland in CI for 32‑bit and 64‑bit with tuning flags enabled

## Testing
- `make check`
- ❌ `pre-commit` *(failed: command not found)*