### PR TITLE
Implement safe pointer conversions and std memory ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ set(ARCH "" CACHE STRING "Kernel architecture")
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_CXX_STANDARD 23)
 
+# Enable common warnings and treat them as errors
+add_compile_options(-Wall -Werror)
+
 # Build the string.o example from the legacy Makefile
 add_library(string_obj OBJECT
     user/contrib/elf-loader/platform/amd64-pc99/string.cc

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CFLAGS ?= -std=c2x
-CXXFLAGS ?= -std=c++23
+CFLAGS ?= -std=c2x -Wall -Werror
+CXXFLAGS ?= -std=c++23 -Wall -Werror
 
 build/string.o: user/contrib/elf-loader/platform/amd64-pc99/string.cc
 	echo Building string.o

--- a/kernel/src/arch/powerpc64/rtas.cc
+++ b/kernel/src/arch/powerpc64/rtas.cc
@@ -37,6 +37,7 @@
 #include INC_GLUE(hwspace.h)
 #include <stdarg.h>
 #include <debug.h>
+#include <cstdint>
 
 /* The RTAS structure */
 rtas_t rtas;
@@ -101,7 +102,10 @@ void SECTION(".init") rtas_t::init_arch( void )
 
 	this->size = rtas_size;
 
-	rtas_alloc_size = (word_t)addr_align_up ((addr_t)(word_t)rtas_size, POWERPC64_PAGE_SIZE);
+        rtas_alloc_size = static_cast<word_t>(
+            addr_align_up(
+                reinterpret_cast<addr_t>(static_cast<std::uintptr_t>(rtas_size)),
+                POWERPC64_PAGE_SIZE));
 	
 	total_mem = (word_t)kip_get_phys_mem(kip);
 

--- a/kernel/src/generic/acpi.h
+++ b/kernel/src/generic/acpi.h
@@ -256,11 +256,14 @@ public:
 	acpi_thead_t *head = nullptr;
 	for (word_t i = 0; i < ((header.len-sizeof(header))/sizeof(ptrs[0])) && !head; i++)
 	{
-	    acpi_thead_t* t= (acpi_thead_t*)(acpi_remap((addr_t)(word_t)ptrs[i]));
+            acpi_thead_t* t= reinterpret_cast<acpi_thead_t*>(
+                acpi_remap(reinterpret_cast<addr_t>(
+                    static_cast<std::uintptr_t>(ptrs[i]))));
 
 	    if (t->sig[0] == sig[0] && t->sig[1] == sig[1] && 
 		t->sig[2] == sig[2] && t->sig[3] == sig[3])
-		head = (acpi_thead_t*)(addr_t)(word_t)ptrs[i];
+                head = reinterpret_cast<acpi_thead_t*>(
+                    static_cast<std::uintptr_t>(ptrs[i]));
 	    acpi_remap(myself_phys);
 	}
 	return head;
@@ -269,7 +272,9 @@ public:
     void list(addr_t myself_phys) {
 	for (word_t i = 0; i < ((header.len-sizeof(header))/sizeof(ptrs[0])); i++)
 	{
-	    UNUSED acpi_thead_t* t= (acpi_thead_t*)(acpi_remap((addr_t)ptrs[i]));
+            UNUSED acpi_thead_t* t= reinterpret_cast<acpi_thead_t*>(
+                acpi_remap(reinterpret_cast<addr_t>(
+                    static_cast<std::uintptr_t>(ptrs[i]))));
 	    TRACE_INIT("\t%c%c%c%c is at %p\n",
 		       t->sig[0], t->sig[1], t->sig[2], t->sig[3], ptrs[i]);
 	    acpi_remap(myself_phys);
@@ -305,7 +310,8 @@ public:
 	    csum += ((char*)this)[i];
 	if (csum != 0)
 	    return nullptr;
-	return (acpi_rsdt_t*) (word_t)rsdt_ptr;
+        return reinterpret_cast<acpi_rsdt_t*>(
+            static_cast<std::uintptr_t>(rsdt_ptr));
     };
     acpi_xsdt_t* xsdt() {
 	/* check version - only ACPI 2.0 knows about an XSDT */
@@ -318,7 +324,8 @@ public:
 	    csum += ((char*)this)[i];
 	if (csum != 0)
 	    return nullptr;
-	return (acpi_xsdt_t*) (word_t)xsdt_ptr;
+        return reinterpret_cast<acpi_xsdt_t*>(
+            static_cast<std::uintptr_t>(xsdt_ptr));
     };
 
     friend class kdb_t;

--- a/kernel/src/generic/lib.cc
+++ b/kernel/src/generic/lib.cc
@@ -30,6 +30,7 @@
  *                
  ********************************************************************/
 #include <debug.h>
+#include <cstring>
 
 /*
  * Declare as weak to allow overloading by optimized processor
@@ -38,22 +39,11 @@
 
 extern "C" WEAK void * memcpy (void * dst, const void * src, unsigned int len)
 {
-    u8_t *d = (u8_t *) dst;
-    u8_t *s = (u8_t *) src;
-
-    while (len-- > 0)
-	*d++ = *s++;
-
-    return dst;
+    return std::memcpy(dst, src, len);
 }
 
 extern "C" WEAK void * memset (void * dst, unsigned int c, unsigned int len)
 {
-    u8_t *s = (u8_t *) dst;
-
-    while (len-- > 0)
-	*s++ = c;
-
-    return dst;
+    return std::memset(dst, c, len);
 }
 

--- a/kernel/src/generic/types.h
+++ b/kernel/src/generic/types.h
@@ -36,6 +36,7 @@
 #if !defined(ASSEMBLY)
 
 #include INC_ARCH(types.h)
+#include <cstdint>
 /* At this point we should have word_t defined */
 
 #if defined(CONFIG_IS_32BIT)
@@ -71,7 +72,9 @@ typedef word_t		addr_word_t;
  */
 INLINE addr_t addr_offset(addr_t addr, addr_t off)
 {
-    return (addr_t)((word_t)addr + (word_t)off);
+    return reinterpret_cast<addr_t>(
+        reinterpret_cast<std::uintptr_t>(addr) +
+        reinterpret_cast<std::uintptr_t>(off));
 }
 #endif
 
@@ -83,7 +86,8 @@ INLINE addr_t addr_offset(addr_t addr, addr_t off)
  */
 INLINE addr_t addr_offset(addr_t addr, word_t off)
 {
-    return (addr_t)((word_t)addr + off);
+    return reinterpret_cast<addr_t>(
+        reinterpret_cast<std::uintptr_t>(addr) + off);
 }
 
 /**
@@ -94,7 +98,8 @@ INLINE addr_t addr_offset(addr_t addr, word_t off)
  */
 INLINE addr_t addr_mask (addr_t addr, word_t mask)
 {
-    return (addr_t) ((word_t) addr & mask);
+    return reinterpret_cast<addr_t>(
+        reinterpret_cast<std::uintptr_t>(addr) & mask);
 }
 
 /**

--- a/user/apps/bench/pingpong/pingpong.cc
+++ b/user/apps/bench/pingpong/pingpong.cc
@@ -37,6 +37,7 @@
 #include <l4/kdebug.h>
 #include <l4io.h>
 #include <l4/arch.h>
+#include <cstring>
 
 #if defined(L4_ARCH_POWERPC64)
 extern long _start_pager;
@@ -82,8 +83,7 @@ static L4_Word_t page_bits;
 
 extern "C" void memset (char * p, char c, int size)
 {
-    for (;size--;)
-	*(p++)=c;
+    std::memset(p, c, size);
 }
 
 

--- a/user/contrib/elf-loader/platform/csb337/main.cc
+++ b/user/contrib/elf-loader/platform/csb337/main.cc
@@ -32,6 +32,7 @@
 
 #include <l4io.h>
 #include <elf-loader.h>
+#include <cstring>
 
 #define PHYS_OFFSET 0x00000000
 
@@ -49,20 +50,13 @@ extern "C" void putc(int c)
 
 extern "C" void memset (char * p, char c, int size)
 {
-    for (;size--;)
-        *(p++)=c;
+    std::memset(p, c, size);
 }
 
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)                    
-        *d++ = *s++;
-
-    return dst;                          
+    return std::memcpy(dst, src, len);
 }
 
 void start_kernel(L4_Word_t bootaddr)

--- a/user/contrib/elf-loader/platform/erpcn01/main.cc
+++ b/user/contrib/elf-loader/platform/erpcn01/main.cc
@@ -31,6 +31,7 @@
  ********************************************************************/
 
 #include "elf-loader.h"
+#include <cstring>
 
 #define PHYS_OFFSET 0xffffffff80000000
 
@@ -46,20 +47,13 @@ extern "C" void putc(char c)
 
 extern "C" void memset (char * p, char c, int size)
 {
-    for (;size--;)
-	*(p++)=c;
+    std::memset(p, c, size);
 }
 
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)
-	*d++ = *s++;
-
-    return dst;
+    return std::memcpy(dst, src, len);
 }
 
 

--- a/user/contrib/elf-loader/platform/innovator/main.cc
+++ b/user/contrib/elf-loader/platform/innovator/main.cc
@@ -33,6 +33,7 @@
 
 #include <l4io.h>
 #include <elf-loader.h>
+#include <cstring>
 #include "io.h"
 
 #define PHYS_OFFSET 0x00000000
@@ -50,20 +51,13 @@ extern "C" void putc(int c)
 
 extern "C" void memset (char * p, char c, int size)
 {
-    for (;size--;)
-        *(p++)=c;
+    std::memset(p, c, size);
 }
 
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)                    
-        *d++ = *s++;
-
-    return dst;                          
+    return std::memcpy(dst, src, len);
 }
 
 void start_kernel(L4_Word_t bootaddr)

--- a/user/contrib/elf-loader/platform/ixdp425/main.cc
+++ b/user/contrib/elf-loader/platform/ixdp425/main.cc
@@ -32,6 +32,7 @@
 
 #include <l4io.h>
 #include <elf-loader.h>
+#include <cstring>
 
 #define PHYS_OFFSET 0x00000000
 
@@ -49,20 +50,13 @@ extern "C" void putc(int c)
 
 extern "C" void memset (char * p, char c, int size)
 {
-    for (;size--;)
-        *(p++)=c;
+    std::memset(p, c, size);
 }
 
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)                    
-        *d++ = *s++;
-
-    return dst;                          
+    return std::memcpy(dst, src, len);
 }
 
 void start_kernel(L4_Word_t bootaddr)

--- a/user/contrib/elf-loader/platform/ofsparc64/main.cc
+++ b/user/contrib/elf-loader/platform/ofsparc64/main.cc
@@ -38,6 +38,7 @@
 #include <openfirmware/console.h>
 #include <openfirmware/device_tree.h>
 #include <openfirmware/openfirmware.h>
+#include <cstring>
 
 #warning awiggins (14-08-03): This needs to be fixed up to make KIP_ADDR phys!
 void * kip_paddr = (void *)(KIP_ADDR - 0xFFFFF80000000000);
@@ -93,12 +94,6 @@ main(void)
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)      
-	*d++ = *s++;
-
-    return dst;
+    return std::memcpy(dst, src, len);
 
 } // memcpy()

--- a/user/contrib/elf-loader/platform/pleb/main.cc
+++ b/user/contrib/elf-loader/platform/pleb/main.cc
@@ -32,6 +32,7 @@
 
 #include <l4io.h>
 #include <elf-loader.h>
+#include <cstring>
 
 #define PHYS_OFFSET 0x00000000
 
@@ -49,20 +50,13 @@ extern "C" void putc(int c)
 
 extern "C" void memset (char * p, char c, int size)
 {
-    for (;size--;)
-        *(p++)=c;
+    std::memset(p, c, size);
 }
 
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)                    
-        *d++ = *s++;
-
-    return dst;                          
+    return std::memcpy(dst, src, len);
 }
 
 void start_kernel(L4_Word_t bootaddr)

--- a/user/contrib/elf-loader/platform/pleb2/main.cc
+++ b/user/contrib/elf-loader/platform/pleb2/main.cc
@@ -32,6 +32,7 @@
 
 #include <l4io.h>
 #include <elf-loader.h>
+#include <cstring>
 
 #define PHYS_OFFSET 0x00000000
 
@@ -49,20 +50,13 @@ extern "C" void putc(int c)
 
 extern "C" void memset (char * p, char c, int size)
 {
-    for (;size--;)
-        *(p++)=c;
+    std::memset(p, c, size);
 }
 
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)                    
-        *d++ = *s++;
-
-    return dst;                          
+    return std::memcpy(dst, src, len);
 }
 
 void start_kernel(L4_Word_t bootaddr)

--- a/user/contrib/elf-loader/platform/sb1/main.cc
+++ b/user/contrib/elf-loader/platform/sb1/main.cc
@@ -31,6 +31,7 @@
  ********************************************************************/
 
 #include "elf-loader.h"
+#include <cstring>
 
 #define PHYS_OFFSET 0xffffffff80000000
 
@@ -81,20 +82,13 @@ extern "C" void putc(char c)
 
 extern "C" void memset (char * p, char c, int size)
 {
-    for (;size--;)
-	*(p++)=c;
+    std::memset(p, c, size);
 }
 
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)
-	*d++ = *s++;
-
-    return dst;
+    return std::memcpy(dst, src, len);
 }
 
 

--- a/user/contrib/elf-loader/platform/srm/utils.cc
+++ b/user/contrib/elf-loader/platform/srm/utils.cc
@@ -32,6 +32,7 @@
 #include "alpha/hwrpb.h"
 
 #include <l4/types.h>
+#include <cstring>
 
 
 extern "C" int printf(const char *s, ...);
@@ -42,20 +43,13 @@ extern "C" void halt(void);
 
 extern "C" void memset (char * p, char c, int size)
 {
-    for (;size--;)
-	*(p++)=c;
+    std::memset(p, c, size);
 }
 
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)
-	*d++ = *s++;
-
-    return dst;
+    return std::memcpy(dst, src, len);
 }
 
 

--- a/user/contrib/elf-loader/platform/u4600/main.cc
+++ b/user/contrib/elf-loader/platform/u4600/main.cc
@@ -32,6 +32,7 @@
 
 #include "elf-loader.h"
 #include "z85230.h"
+#include <cstring>
 
 #define PHYS_OFFSET 0xffffffff80000000
 
@@ -111,20 +112,13 @@ extern "C" void putc(char c)
 
 extern "C" void memset (char * p, char c, int size)
 {
-    for (;size--;)
-	*(p++)=c;
+    std::memset(p, c, size);
 }
 
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)
-	*d++ = *s++;
-
-    return dst;
+    return std::memcpy(dst, src, len);
 }
 
 

--- a/user/contrib/elf-loader/platform/vr41xx/main.cc
+++ b/user/contrib/elf-loader/platform/vr41xx/main.cc
@@ -31,6 +31,7 @@
  ********************************************************************/
 
 #include "elf-loader.h"
+#include <cstring>
 
 #define PHYS_OFFSET 0xffffffff80000000
 
@@ -108,20 +109,13 @@ extern "C" int printf(const char * format, ...);
  
 extern "C" void memset (char * p, char c, int size)
 {
-    for (;size--;)
-	*(p++)=c;
+    std::memset(p, c, size);
 }
 
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)
-	*d++ = *s++;
-
-    return dst;
+    return std::memcpy(dst, src, len);
 }
 
 

--- a/user/serv/sigma0/sigma0.cc
+++ b/user/serv/sigma0/sigma0.cc
@@ -34,6 +34,7 @@
 #include <l4/misc.h>
 #include <l4/kdebug.h>
 #include <l4io.h>
+#include <cstring>
 
 #include "sigma0.h"
 #include "region.h"
@@ -63,13 +64,7 @@ L4_ThreadId_t rootserver_id;
 extern "C" __attribute__ ((weak)) void *
 memcpy (void * dst, const void * src, unsigned int len)
 {
-    unsigned char *d = (unsigned char *) dst;
-    unsigned char *s = (unsigned char *) src;
-
-    while (len-- > 0)
-	*d++ = *s++;
-
-    return dst;
+    return std::memcpy(dst, src, len);
 }
 
 

--- a/user/util/kickstart/lib.cc
+++ b/user/util/kickstart/lib.cc
@@ -30,6 +30,7 @@
  *                
  ********************************************************************/
 #include "lib.h"
+#include <cstring>
 
 extern "C" unsigned strlen( const char *src )
 {
@@ -66,11 +67,9 @@ extern "C" void strcpy( char *dst, const char *src )
  */
 extern "C" void memcopy(L4_Word_t dst, L4_Word_t src, L4_Word_t len)
 {
-    L4_Word8_t* s = (L4_Word8_t*) src;
-    L4_Word8_t* d = (L4_Word8_t*) dst;
-    
-    while (len--)
-        *d++ = *s++;
+    std::memcpy(reinterpret_cast<void*>(dst),
+                reinterpret_cast<void*>(src),
+                len);
 }
 
 
@@ -86,10 +85,7 @@ extern "C" void memcopy(L4_Word_t dst, L4_Word_t src, L4_Word_t len)
  */
 extern "C" void memset(L4_Word_t dst, L4_Word8_t val, L4_Word_t len)
 {
-    L4_Word8_t* d = (L4_Word8_t*) dst;
-
-    while (len--)
-        *d++ = val;
+    std::memset(reinterpret_cast<void*>(dst), val, len);
 }
 
 


### PR DESCRIPTION
## Summary
- enable `-Wall` and `-Werror` globally
- use `std::memcpy`/`std::memset` in kernel and user helpers
- replace pointer/integer casts with `std::uintptr_t`
- clean up memset/memcpy implementations in various userland platforms

## Testing
- `make check`