### PR TITLE
Add calling convention macros and test

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -164,6 +164,15 @@ header that translates the historic SVR4 machine dependencies into a
 typed C++23 interface.  A short usage sample lives in
 `docs/svr4_machdep_cpp23.cpp`.
 
+### Calling conventions
+
+Both the kernel and user land use explicit calling convention attributes.
+The header `l4/compiler.h` defines macros such as `L4_CDECL` and
+`L4_FASTCALL` which expand to the GNU style attributes `[[gnu::cdecl]]` and
+`[[gnu::fastcall]]`.  All exported kernel entry points and public API
+functions are annotated with these macros to make the required ABI
+visible in the source code.
+
 See the top-level LICENSE file for the project's terms.
 
 ## Running tests

--- a/kernel/src/glue/v4-x86/x64/user.cc
+++ b/kernel/src/glue/v4-x86/x64/user.cc
@@ -33,8 +33,9 @@
 #include INC_API(user.h)
 #include INC_API(tcb.h)
 #include INC_API(ipc.h)
+#include <l4/compiler.h>
 
-extern "C" void user_nop()
+extern "C" L4_CDECL void user_nop()
 {
     __asm__ (
 	"	syscall			\n"
@@ -45,8 +46,8 @@ extern "C" void user_nop()
 
 #define OFS_USER_UTCB_MYGLOBAL  (OFS_UTCB_MY_GLOBAL_ID - OFS_UTCB_MR)
 #define OFS_USER_UTCB_PROC      (OFS_UTCB_PROCESSOR_NO - OFS_UTCB_MR)
-extern "C" void SECTION(".user.syscall.ipc") user_ipc_wrapper();
-void user_ipc_wrapper() 
+extern "C" L4_CDECL void SECTION(".user.syscall.ipc") user_ipc_wrapper();
+void L4_CDECL user_ipc_wrapper()
 {
     __asm__ (
 	"	.global user_ipc, user_lipc	\n"
@@ -79,7 +80,7 @@ void user_ipc_wrapper()
 	);
 }
 
-extern "C" void user_exchange_registers()
+extern "C" L4_CDECL void user_exchange_registers()
 {
     __asm__ __volatile__ (
 	"	test	$0x3f, %al		\n"
@@ -91,7 +92,7 @@ extern "C" void user_exchange_registers()
 }
 
 
-extern "C" void user_system_clock()
+extern "C" L4_CDECL void user_system_clock()
 {
     __asm__ __volatile__ ("syscall\n");
 #if 0
@@ -116,7 +117,7 @@ extern "C" void user_system_clock()
 #endif
 }
 
-extern "C" void user_thread_switch()
+extern "C" L4_CDECL void user_thread_switch()
 {
     __asm__ __volatile__ (
 	"	test	%rdi, %rdi		\n"
@@ -129,7 +130,7 @@ extern "C" void user_thread_switch()
 	);
 }
 
-extern "C" void user_schedule()
+extern "C" L4_CDECL void user_schedule()
 {
     __asm__ __volatile__ (
 	"	test	%rdi, %rdi		\n"
@@ -142,7 +143,7 @@ extern "C" void user_schedule()
 	);
 }
 
-extern "C" void user_unmap()
+extern "C" L4_CDECL void user_unmap()
 {
     __asm__ __volatile__ (
 	"movq	 %r9,  (%rdi)			\n"	// save mr0
@@ -166,7 +167,7 @@ extern "C" void user_unmap()
 	);
 }
 
-extern "C" void user_thread_control()
+extern "C" L4_CDECL void user_thread_control()
 {
     __asm__ __volatile__ (
 	"	test	%rsi, %rsi		\n"
@@ -189,7 +190,7 @@ extern "C" void user_thread_control()
 	);
 }
 
-extern "C" void user_space_control()
+extern "C" L4_CDECL void user_space_control()
 {
     __asm__ __volatile__ (
 	"	test	%r9, %r9		\n"
@@ -202,12 +203,12 @@ extern "C" void user_space_control()
 	);
 }
 
-extern "C" void user_processor_control()
+extern "C" L4_CDECL void user_processor_control()
 {
     __asm__ __volatile__ ("syscall\n");
 }
 
-extern "C" void user_memory_control()
+extern "C" L4_CDECL void user_memory_control()
 {
     __asm__ __volatile__ ("syscall\n");
 }

--- a/kernel/src/glue/v4-x86/x64/x32comp/user.cc
+++ b/kernel/src/glue/v4-x86/x64/x32comp/user.cc
@@ -63,9 +63,10 @@
 
 #endif /* !defined(CONFIG_X86_EM64T) */
 
+#include <l4/compiler.h>
 
 extern "C" void SECTION(".user.syscall_32.ipc") user_ipc_32_wrapper();
-void user_ipc_32_wrapper()
+void L4_CDECL user_ipc_32_wrapper()
 {
     __asm__ __volatile__ (
 	"	.global user_lipc_32		\n"
@@ -114,7 +115,7 @@ void user_ipc_32_wrapper()
         );
 }
 extern "C" void SECTION(".user.syscall_32.exregs") user_exchange_registers_32_wrapper();
-void user_exchange_registers_32_wrapper()
+void L4_CDECL user_exchange_registers_32_wrapper()
 {
     __asm__ __volatile__ (
 	BEGIN(user_exchange_registers_32, ".user.syscall_32.exregs")
@@ -136,7 +137,7 @@ void user_exchange_registers_32_wrapper()
 }
 
 extern "C" void SECTION(".user.syscall_32.sysclock") user_system_clock_32_wrapper();
-void user_system_clock_32_wrapper()
+void L4_CDECL user_system_clock_32_wrapper()
 {
     __asm__ __volatile__ (
         BEGIN(user_system_clock_32,	  ".user.syscall_32.sysclock")
@@ -150,7 +151,7 @@ void user_system_clock_32_wrapper()
 }
 
 extern "C" void SECTION(".user.syscall_32.threadswtch") user_thread_switch_32_wrapper();
-void user_thread_switch_32_wrapper()
+void L4_CDECL user_thread_switch_32_wrapper()
 {
     __asm__ __volatile__ (
         BEGIN(user_thread_switch_32,	  ".user.syscall_32.threadswtch")
@@ -180,7 +181,7 @@ void user_thread_switch_32_wrapper()
 }
 
 extern "C" void SECTION(".user.syscall_32.schedule") user_schedule_32_wrapper();
-void user_schedule_32_wrapper()
+void L4_CDECL user_schedule_32_wrapper()
 {
     __asm__ __volatile__ (
         BEGIN(user_schedule_32,		  ".user.syscall_32.schedule")
@@ -195,7 +196,7 @@ void user_schedule_32_wrapper()
 }
 
 extern "C" void SECTION(".user.syscall_32.unmap") user_unmap_32_wrapper();
-void user_unmap_32_wrapper()
+void L4_CDECL user_unmap_32_wrapper()
 {
     __asm__ __volatile__ (
         BEGIN(user_unmap_32,		  ".user.syscall_32.unmap")
@@ -207,7 +208,7 @@ void user_unmap_32_wrapper()
 }
 
 extern "C" void SECTION(".user.syscall_32.threadctrl") user_thread_control_32_wrapper();
-void user_thread_control_32_wrapper()
+void L4_CDECL user_thread_control_32_wrapper()
 {
     __asm__ __volatile__ (
         BEGIN(user_thread_control_32,	  ".user.syscall_32.threadctrl")
@@ -234,7 +235,7 @@ void user_thread_control_32_wrapper()
 }
 
 extern "C" void SECTION(".user.syscall_32.spacectrl") user_space_control_32_wrapper();
-void user_space_control_32_wrapper()
+void L4_CDECL user_space_control_32_wrapper()
 {
     __asm__ __volatile__ (
         BEGIN(user_space_control_32,	  ".user.syscall_32.spacectrl")
@@ -252,7 +253,7 @@ void user_space_control_32_wrapper()
 }
 
 extern "C" void SECTION(".user.syscall_32.procctrl") user_processor_control_32_wrapper();
-void user_processor_control_32_wrapper()
+void L4_CDECL user_processor_control_32_wrapper()
 {
     __asm__ __volatile__ (
         BEGIN(user_processor_control_32,  ".user.syscall_32.procctrl")
@@ -263,7 +264,7 @@ void user_processor_control_32_wrapper()
 }
 
 extern "C" void SECTION(".user.syscall_32.memctrl") user_memory_control_32_wrapper();
-void user_memory_control_32_wrapper()
+void L4_CDECL user_memory_control_32_wrapper()
 {
     __asm__ __volatile__ (
         BEGIN(user_memory_control_32,	  ".user.syscall_32.memctrl")

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+class CompilerAttributeTest(unittest.TestCase):
+    def test_function_pointer_attributes(self) -> None:
+        code = textwrap.dedent(
+            """
+            #include <l4/compiler.h>
+
+            void L4_CDECL cdecl_fn(int) {}
+            void L4_FASTCALL fast_fn(int, int) {}
+
+            using p1 = L4_CDECL void (*)(int);
+            using p2 = L4_FASTCALL void (*)(int, int);
+
+            int main() {
+                p1 a = cdecl_fn;
+                p2 b = fast_fn;
+                (void)a; (void)b;
+                return 0;
+            }
+            """
+        )
+        with tempfile.NamedTemporaryFile('w', suffix='.cc', delete=False) as f:
+            f.write(code)
+            name = f.name
+        try:
+            subprocess.run([
+                os.getenv('CXX', 'g++'),
+                '-std=c++23',
+                '-Iuser/include',
+                '-c',
+                name,
+            ], check=True)
+        finally:
+            os.unlink(name)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/user/include/l4/compiler.h
+++ b/user/include/l4/compiler.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef __GNUC__
+# define L4_CDECL [[gnu::cdecl]]
+# define L4_FASTCALL [[gnu::fastcall]]
+# define L4_STDCALL [[gnu::stdcall]]
+# define L4_REGPARM(n) [[gnu::regparm(n)]]
+#else
+# define L4_CDECL
+# define L4_FASTCALL
+# define L4_STDCALL
+# define L4_REGPARM(n)
+#endif
+

--- a/user/include/l4/memory.h
+++ b/user/include/l4/memory.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <l4/types.h>
 #include <l4/thread.h>
+#include <l4/compiler.h>
 
 enum mem_opcode {
     MEM_ALLOC = 0,
@@ -16,9 +17,9 @@ struct mem_request {
     L4_Word_t  addr;
 };
 
-L4_Word_t memory_alloc(L4_ThreadId_t server, L4_Word_t size);
-void memory_free(L4_ThreadId_t server, L4_Word_t addr, L4_Word_t size);
+L4_Word_t L4_CDECL memory_alloc(L4_ThreadId_t server, L4_Word_t size);
+void L4_CDECL memory_free(L4_ThreadId_t server, L4_Word_t addr, L4_Word_t size);
 /**
  * Return the default memory server thread ID as reported by the kernel.
  */
-L4_ThreadId_t memory_server(void);
+L4_ThreadId_t L4_CDECL memory_server(void);


### PR DESCRIPTION
## Summary
- add `l4/compiler.h` with L4_CDECL and L4_FASTCALL attribute macros
- annotate kernel wrappers and memory API with these macros
- document the new macros in the build guide
- add test to ensure function pointers with attributes compile

## Testing
- `python -m unittest discover -v tests`