### PR TITLE
Refactor IPC modules

### DIFF
--- a/docs/server_interfaces.md
+++ b/docs/server_interfaces.md
@@ -12,14 +12,14 @@ structure:
 
 ```c
 struct mem_request {
-    mem_opcode op;    /* MEM_ALLOC or MEM_FREE */
+    mem_opcode op;    /* mem_opcode::Alloc or mem_opcode::Free */
     L4_Word_t  size;  /* bytes to allocate or free */
     L4_Word_t  addr;  /* address when freeing */
 };
 ```
 
-For a `MEM_ALLOC` request the server returns the allocated address in
-`MR1`.  `MEM_FREE` requests return `0`.
+For a `mem_opcode::Alloc` request the server returns the allocated address in
+`MR1`.  `mem_opcode::Free` requests return `0`.
 
 ## Scheduler Server
 

--- a/kernel/src/generic/user_mem.cc
+++ b/kernel/src/generic/user_mem.cc
@@ -24,7 +24,7 @@ extern "C" void *user_mem_alloc(word_t size)
     tcb_t *current = get_current_tcb();
 
     mem_request req;
-    req.op = MEM_ALLOC;
+    req.op = mem_opcode::Alloc;
     req.size = size;
     req.addr = 0;
 
@@ -47,7 +47,7 @@ extern "C" void user_mem_free(void *addr, word_t size)
     tcb_t *current = get_current_tcb();
 
     mem_request req;
-    req.op = MEM_FREE;
+    req.op = mem_opcode::Free;
     req.size = size;
     req.addr = (word_t)addr;
 

--- a/user/include/l4/memory.h
+++ b/user/include/l4/memory.h
@@ -6,9 +6,9 @@
 #include <l4/thread.h>
 #include <l4/compiler.h>
 
-enum mem_opcode {
-    MEM_ALLOC = 0,
-    MEM_FREE  = 1,
+enum class mem_opcode : L4_Word_t {
+    Alloc = 0,
+    Free  = 1,
 };
 
 struct mem_request {
@@ -17,9 +17,9 @@ struct mem_request {
     L4_Word_t  addr;
 };
 
-L4_Word_t L4_CDECL memory_alloc(L4_ThreadId_t server, L4_Word_t size);
+[[nodiscard]] L4_Word_t L4_CDECL memory_alloc(L4_ThreadId_t server, L4_Word_t size);
 void L4_CDECL memory_free(L4_ThreadId_t server, L4_Word_t addr, L4_Word_t size);
 /**
  * Return the default memory server thread ID as reported by the kernel.
  */
-L4_ThreadId_t L4_CDECL memory_server(void);
+[[nodiscard]] L4_ThreadId_t L4_CDECL memory_server(void);

--- a/user/lib/memory/memory.cc
+++ b/user/lib/memory/memory.cc
@@ -6,10 +6,10 @@
 #include <stddef.h>
 
 
-L4_Word_t memory_alloc(L4_ThreadId_t server, L4_Word_t size)
+[[nodiscard]] L4_Word_t memory_alloc(L4_ThreadId_t server, L4_Word_t size)
 {
     mem_request req;
-    req.op = MEM_ALLOC;
+    req.op = mem_opcode::Alloc;
     req.size = size;
     req.addr = 0;
 
@@ -29,7 +29,7 @@ L4_Word_t memory_alloc(L4_ThreadId_t server, L4_Word_t size)
 void memory_free(L4_ThreadId_t server, L4_Word_t addr, L4_Word_t size)
 {
     mem_request req;
-    req.op = MEM_FREE;
+    req.op = mem_opcode::Free;
     req.size = size;
     req.addr = addr;
 
@@ -43,7 +43,7 @@ void memory_free(L4_ThreadId_t server, L4_Word_t addr, L4_Word_t size)
     L4_Call(server);
 }
 
-L4_ThreadId_t memory_server(void)
+[[nodiscard]] L4_ThreadId_t memory_server(void)
 {
     void *kip = L4_KernelInterface(nullptr, nullptr, nullptr);
     L4_Word_t ubase = L4_ThreadIdUserBase(kip);

--- a/user/lib/sched/sched_client.cc
+++ b/user/lib/sched/sched_client.cc
@@ -1,36 +1,36 @@
 #include "sched_client.h"
-#include <cstddef>
+#include <array>
 
 static L4_ThreadId_t server_tid = {0};
-static const L4_Word_t SCHED_LABEL = 0x1234; /* arbitrary */
+enum class SchedLabel : L4_Word_t { Request = 0x1234 };
 
 void sched_set_server(L4_ThreadId_t tid)
 {
     server_tid = tid;
 }
 
-L4_ThreadId_t sched_get_server(void)
+[[nodiscard]] L4_ThreadId_t sched_get_server(void)
 {
     return server_tid;
 }
 
-L4_MsgTag_t sched_send_request(const SchedRequest *req)
+[[nodiscard]] L4_MsgTag_t sched_send_request(const SchedRequest *req)
 {
     L4_Msg_t msg;
-    L4_Word_t w[5] = { req->thread.raw, req->time_control,
-                       req->processor_control, req->prio_control,
-                       req->preemption_control };
-    L4_MsgPut(&msg, SCHED_LABEL, 5, w, 0, nullptr);
+    std::array<L4_Word_t, 5> w { req->thread.raw, req->time_control,
+                                 req->processor_control, req->prio_control,
+                                 req->preemption_control };
+    L4_MsgPut(&msg, static_cast<L4_Word_t>(SchedLabel::Request), w.size(), w.data(), 0, nullptr);
     L4_MsgLoad(&msg);
     return L4_Call(server_tid);
 }
 
-L4_MsgTag_t sched_wait_request(SchedRequest *req, L4_ThreadId_t *from)
+[[nodiscard]] L4_MsgTag_t sched_wait_request(SchedRequest *req, L4_ThreadId_t *from)
 {
     L4_Msg_t msg;
     L4_MsgTag_t tag = L4_Wait(from);
     L4_MsgStore(tag, &msg);
-    if (L4_Label(tag) == SCHED_LABEL && L4_UntypedWords(tag) == 5) {
+    if (L4_Label(tag) == static_cast<L4_Word_t>(SchedLabel::Request) && L4_UntypedWords(tag) == 5) {
         req->thread.raw = L4_MsgWord(&msg, 0);
         req->time_control = L4_MsgWord(&msg, 1);
         req->processor_control = L4_MsgWord(&msg, 2);

--- a/user/lib/sched/sched_client.h
+++ b/user/lib/sched/sched_client.h
@@ -18,10 +18,10 @@ typedef struct {
 } SchedRequest;
 
 void sched_set_server(L4_ThreadId_t tid);
-L4_ThreadId_t sched_get_server(void);
+[[nodiscard]] L4_ThreadId_t sched_get_server(void);
 
-L4_MsgTag_t sched_send_request(const SchedRequest *req);
-L4_MsgTag_t sched_wait_request(SchedRequest *req, L4_ThreadId_t *from);
+[[nodiscard]] L4_MsgTag_t sched_send_request(const SchedRequest *req);
+[[nodiscard]] L4_MsgTag_t sched_wait_request(SchedRequest *req, L4_ThreadId_t *from);
 void sched_switch(L4_ThreadId_t next);
 
 #ifdef __cplusplus

--- a/user/serv/scheduler/scheduler.cc
+++ b/user/serv/scheduler/scheduler.cc
@@ -4,7 +4,7 @@
 #include <deque>
 #include "../../lib/sched/sched_client.h"
 
-static const L4_Word_t SCHED_LABEL = 0x1234;
+enum class SchedLabel : L4_Word_t { Request = 0x1234 };
 
 int main()
 {
@@ -18,7 +18,7 @@ int main()
         SchedRequest req;
         L4_ThreadId_t from;
         L4_MsgTag_t tag = sched_wait_request(&req, &from);
-        if (L4_Label(tag) != SCHED_LABEL)
+        if (L4_Label(tag) != static_cast<L4_Word_t>(SchedLabel::Request))
             continue;
 
         /* enqueue requesting thread */


### PR DESCRIPTION
## Summary
- use `enum class` for mem server opcodes and scheduler labels
- return values marked `[[nodiscard]]`
- replace pointer casts with `std::span` and `std::array`
- update scheduler and memory services for the new types

## Testing
- `make check`