### PR TITLE
Add Cap'n Proto stub and optional memory server support

### DIFF
--- a/user/lib/Makefile.in
+++ b/user/lib/Makefile.in
@@ -36,7 +36,7 @@ top_builddir=	@top_builddir@
 include $(top_srcdir)/Mk/l4.base.mk
 
 
-SUBDIRS=	 l4 io memory ipc sched
+SUBDIRS=	 l4 io memory ipc sched capnp
 
 post-clean:
 	rm -f *.a

--- a/user/lib/capnp/Makefile.in
+++ b/user/lib/capnp/Makefile.in
@@ -1,0 +1,10 @@
+srcdir=@srcdir@
+top_srcdir=@top_srcdir@
+top_builddir=@top_builddir@
+
+include $(top_srcdir)/Mk/l4.base.mk
+
+LIBRARY=capnp
+SRCS=capnp.cc
+
+include $(top_srcdir)/Mk/l4.lib.mk

--- a/user/lib/capnp/capnp.cc
+++ b/user/lib/capnp/capnp.cc
@@ -1,0 +1,3 @@
+#include "capnp.h"
+
+/* Header only - no additional implementation needed. */

--- a/user/lib/capnp/capnp.h
+++ b/user/lib/capnp/capnp.h
@@ -1,0 +1,32 @@
+#ifndef CAPNP_HELPERS_H
+#define CAPNP_HELPERS_H
+
+#include <cstddef>
+#include <cstdint>
+#include <l4/memory.h>
+
+namespace capnp {
+
+static const size_t MEM_REQ_WORDS = 3;
+
+inline void encode_mem_request(const mem_request &req, uint32_t *buf)
+{
+    buf[0] = static_cast<uint32_t>(req.op);
+    buf[1] = static_cast<uint32_t>(req.size);
+    buf[2] = static_cast<uint32_t>(req.addr);
+}
+
+inline bool decode_mem_request(const uint32_t *buf, size_t words,
+                               mem_request &req)
+{
+    if (words < MEM_REQ_WORDS)
+        return false;
+    req.op = static_cast<mem_opcode>(buf[0]);
+    req.size = buf[1];
+    req.addr = buf[2];
+    return true;
+}
+
+} // namespace capnp
+
+#endif // CAPNP_HELPERS_H

--- a/user/serv/memory/Makefile.in
+++ b/user/serv/memory/Makefile.in
@@ -14,5 +14,10 @@ PROGRAM=        memory
 PROGRAM_DEPS=   $(top_builddir)/lib/l4/libl4.a $(top_builddir)/lib/io/libio.a
 SRCS=           memory.cc
 LIBS+=          -ll4 -lio
+ifdef WITH_CAPNP
+PROGRAM_DEPS+=  $(top_builddir)/lib/capnp/libcapnp.a
+LIBS+=          -lcapnp
+CPPFLAGS+=      -DWITH_CAPNP
+endif
 
 include $(top_srcdir)/Mk/l4.prog.mk

--- a/user/serv/memory/memory.cc
+++ b/user/serv/memory/memory.cc
@@ -4,6 +4,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <l4/memory.h>
+#ifdef WITH_CAPNP
+#include "../../lib/capnp/capnp.h"
+#endif
 
 static const L4_Word_t MEM_LABEL = 0;
 
@@ -34,7 +37,16 @@ int main()
         }
 
         mem_request req;
+#ifdef WITH_CAPNP
+        L4_Word_t raw[capnp::MEM_REQ_WORDS];
+        L4_StoreMRs(1, capnp::MEM_REQ_WORDS, raw);
+        if (!capnp::decode_mem_request(raw, capnp::MEM_REQ_WORDS, req)) {
+            L4_Reply(partner);
+            continue;
+        }
+#else
         L4_StoreMRs(1, sizeof(req)/sizeof(L4_Word_t), (L4_Word_t*)&req);
+#endif
         L4_Word_t res = handle_request(req);
 
         L4_MsgClear(&msg);


### PR DESCRIPTION
## Summary
- add capnp wrapper library with simple helpers
- integrate capnp into user lib build
- add optional capnp parsing to memory server

## Testing
- `make -f user/lib/capnp/Makefile.in` *(fails: '@top_srcdir@/Mk/l4.lib.mk: No such file or directory')*