### PR TITLE
Enable -Werror in build scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ if("${CMAKE_CXX_FLAGS_RELEASE}" STREQUAL "")
     set(CMAKE_CXX_FLAGS_RELEASE "${CPU_CFLAGS}")
 endif()
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+
 # Build the string.o example from the legacy Makefile
 add_library(string_obj OBJECT
     user/contrib/elf-loader/platform/amd64-pc99/string.cc

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ CXXFLAGS ?= -std=c++23
 CPU_CFLAGS ?= -march=native
 CFLAGS += $(CPU_CFLAGS)
 CXXFLAGS += $(CPU_CFLAGS)
+CFLAGS += -Werror
+CXXFLAGS += -Werror
 
 build/string.o: user/contrib/elf-loader/platform/amd64-pc99/string.cc
 	echo Building string.o

--- a/kernel/Mk/Makeconf
+++ b/kernel/Mk/Makeconf
@@ -176,6 +176,7 @@ CCFLAGS += -fno-rtti -fno-builtin  -fomit-frame-pointer -fno-exceptions \
 
 # C++ compiler flags build on C compiler flags and set the C++ standard
 CXXFLAGS += $(CCFLAGS) -std=c++23
+CXXFLAGS += -Werror
 
 ifeq ("$(CC_VERSION)", "4")
 CCFLAGS += -Wno-conversion
@@ -191,6 +192,7 @@ CCFLAGS  += -g
 endif
 
 CFLAGS = -ffreestanding $(CCFLAGS) -std=c2x
+CFLAGS += -Werror
 
 # these for assembly files only
 ASMFLAGS += $(ASMFLAGS_$(PLATFORM)) $(ASMFLAGS_$(ARCH)) $(ASMFLAGS_$(CPU))

--- a/user/Mk/l4.base.mk
+++ b/user/Mk/l4.base.mk
@@ -50,6 +50,8 @@ else
 CFLAGS += -Wconversion
 endif
 
+CFLAGS += -Werror
+CXXFLAGS += -Werror
 
 # Create early targets so that a make without args (implicit all) does
 # not take the first target in worker makefile (e.g., a clean target).


### PR DESCRIPTION
## Summary
- enable `-Werror` on the main Makefile
- enable `-Werror` for kernel makefiles
- enable `-Werror` for userland makefiles
- add `-Werror` to the CMake configuration

## Testing
- `make all`
- `cmake ..`
- `cmake --build . --verbose`