### PR TITLE
Add -Werror support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ set(ARCH "" CACHE STRING "Kernel architecture")
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_CXX_STANDARD 23)
 
+add_compile_options(-Werror)
+
 # CPU tuning flags. Default to -march=native but allow overrides via
 # -DTUNE_CPU=<cpu> or explicit -DCMAKE_C_FLAGS_RELEASE.
 set(TUNE_CPU "native" CACHE STRING "CPU microarchitecture for -march")

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ CXXFLAGS ?= -std=c++23
 CPU_CFLAGS ?= -march=native
 CFLAGS += $(CPU_CFLAGS)
 CXXFLAGS += $(CPU_CFLAGS)
+CFLAGS += -Werror
+CXXFLAGS += -Werror
 
 build/string.o: user/contrib/elf-loader/platform/amd64-pc99/string.cc
 	echo Building string.o

--- a/kernel/Mk/Makeconf
+++ b/kernel/Mk/Makeconf
@@ -171,7 +171,7 @@ VFLAGS =
 
 # use optimization level of at least 1 - otherwise inlining will fail
 CCFLAGS += -fno-rtti -fno-builtin  -fomit-frame-pointer -fno-exceptions \
-          -Wall -Wno-non-virtual-dtor -Wno-format   \
+          -Wall -Wno-non-virtual-dtor -Wno-format -Werror  \
           $(CFLAGS_$(ARCH)) $(CFLAGS_$(CPU)) $(CFLAGS_$(PLATFORM))
 
 # C++ compiler flags build on C compiler flags and set the C++ standard

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -31,6 +31,8 @@ class CompilerAttributeTest(unittest.TestCase):
             subprocess.run([
                 os.getenv('CXX', 'g++'),
                 '-std=c++23',
+                '-Werror',
+                '-Wno-attributes',
                 '-Iuser/include',
                 '-c',
                 name,

--- a/tests/test_i16_build.py
+++ b/tests/test_i16_build.py
@@ -18,6 +18,7 @@ class I16CompilationTest(unittest.TestCase):
                 "g++",
                 "-m16",
                 "-std=c++23",
+                "-Werror",
                 "-I",
                 str(ROOT / "user/include"),
                 "-c",

--- a/tests/test_types_size.py
+++ b/tests/test_types_size.py
@@ -21,7 +21,7 @@ class TypeSizeCompilationTest(unittest.TestCase):
                 "g++",
                 flag,
                 "-std=c++23",
-                "-fpermissive",
+                "-Werror",
                 "-I",
                 str(ROOT / "user/include"),
                 "-c",

--- a/user/Mk/l4.base.mk
+++ b/user/Mk/l4.base.mk
@@ -40,7 +40,7 @@ ECHO_MSG=	$(ECHO) ===\>
 MKDIRHIER=	$(top_srcdir)/../tools/mkdirhier
 
 CPPFLAGS+=	$(CPPFLAGS_$(ARCH))
-CFLAGS+=	-O2 -g -Wall -Wshadow \
+CFLAGS+=	-O2 -g -Wall -Wshadow -Werror \
 		$(CFLAGS_$(ARCH))
 LDFLAGS+=	$(LDFLAGS_$(ARCH))
 

--- a/user/include/l4/compiler.h
+++ b/user/include/l4/compiler.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
 # define L4_CDECL [[gnu::cdecl]]
 # define L4_FASTCALL [[gnu::fastcall]]
 # define L4_STDCALL [[gnu::stdcall]]


### PR DESCRIPTION
## Summary
- compile with `-Werror`
- make compiler attributes conditional on x86
- remove obsolete `-fpermissive`
- fix tests to work with strict warnings

## Testing
- `make check`
