### PR TITLE
Add memserver IPC parsing tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,9 @@ target_include_directories(string_obj PRIVATE
 
 add_subdirectory(kernel)
 add_subdirectory(src-userland/lib)
+add_subdirectory(tools/memserver)
 
-add_custom_target(default_all ALL DEPENDS string_obj kernel_target userlib_target)
+add_custom_target(default_all ALL DEPENDS string_obj kernel_target userlib_target memserver_tool)
 
 add_executable(spinlock_fairness tests/spinlock_fairness.c)
 target_link_libraries(spinlock_fairness PRIVATE pthread)

--- a/docs/server_interfaces.md
+++ b/docs/server_interfaces.md
@@ -21,6 +21,21 @@ struct mem_request {
 For a `mem_opcode::Alloc` request the server returns the allocated address in
 `MR1`.  `mem_opcode::Free` requests return `0`.
 
+### Debugging messages
+
+`tools/memserver/memparse` prints the decoded fields of a raw four word
+message.  Pass the values of `MR0`--`MR3` on the command line:
+
+```bash
+$ memparse 0 0 4096 0
+label: 0x0
+  op: Alloc
+  size: 4096
+  addr: 0x0
+```
+Compile the tool with `-DENABLE_CAPNP=ON` to link against `libcapnp` when
+available.
+
 ## Scheduler Server
 
 Scheduler messages use label `0x1234`.  Five untyped words encode the

--- a/tools/memserver/CMakeLists.txt
+++ b/tools/memserver/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(memparse memparse.cc)
+
+option(ENABLE_CAPNP "Link against libcapnp" OFF)
+if(ENABLE_CAPNP)
+    find_package(CapnProto REQUIRED)
+    target_link_libraries(memparse PRIVATE CapnProto::capnp)
+    target_compile_definitions(memparse PRIVATE WITH_CAPNP)
+endif()
+
+add_custom_target(memserver_tool ALL DEPENDS memparse)

--- a/tools/memserver/memparse.cc
+++ b/tools/memserver/memparse.cc
@@ -1,0 +1,44 @@
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+
+enum class mem_opcode : uint32_t {
+    Alloc = 0,
+    Free = 1
+};
+
+struct mem_request {
+    mem_opcode op;
+    uint64_t size;
+    uint64_t addr;
+};
+
+int main(int argc, char **argv)
+{
+    if (argc != 5) {
+        std::cerr << "Usage: " << argv[0] << " <mr0> <mr1> <mr2> <mr3>\n";
+        return 1;
+    }
+
+    uint64_t words[4];
+    for (int i = 0; i < 4; ++i) {
+        std::stringstream ss;
+        ss << std::hex << argv[i + 1];
+        ss >> words[i];
+    }
+
+    uint64_t label = words[0];
+    mem_request req{
+        static_cast<mem_opcode>(words[1]),
+        words[2],
+        words[3]
+    };
+
+    std::cout << "label: 0x" << std::hex << label << std::dec << "\n";
+    const char *opstr = req.op == mem_opcode::Alloc ? "Alloc" :
+                        (req.op == mem_opcode::Free ? "Free" : "Unknown");
+    std::cout << "  op: " << opstr << "\n";
+    std::cout << "  size: " << req.size << "\n";
+    std::cout << "  addr: 0x" << std::hex << req.addr << std::dec << "\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add memparse utility under `tools/memserver`
- link with libcapnp when enabled
- document usage of the new tool

## Testing
- `python3 -m unittest discover -v tests`
- `cmake -S . -B build`
- `cmake --build build`
- `./build/tools/memserver/memparse 0 0 10 0`