### PR TITLE
Add timed mailbox receive helper

### DIFF
--- a/docs/ipc_overview.md
+++ b/docs/ipc_overview.md
@@ -7,6 +7,11 @@ This document summarises how L4 IPC is used by the example servers and where add
 `L4_Ipc` is the kernel syscall that sends a message to one thread while optionally receiving from another. The operation uses the message registers (`MR0`..`MR63`) for payload. `MR0` stores the `L4_MsgTag_t` which encodes the message label, counts of untyped and typed words and several flags. `L4_UserIpc` wraps the syscall and performs a user mode fast path when the destination is the current thread and no receive phase is required.
 
 Most high level calls such as `L4_Call`, `L4_Send` and `L4_Receive` are implemented on top of `L4_UserIpc` in `l4/ipc.h`.
+`Recv_T` from `mailbox_t.h` builds on these helpers and waits for an incoming
+message with a timeout. It repeatedly performs a non-blocking wait and sleeps
+for short periods using `nanosleep` until either a message is delivered or the
+timeout expires. The function returns the sender's thread ID and stores the
+received tag in the supplied pointer.
 
 ## Message formats
 

--- a/user/include/mailbox_t.h
+++ b/user/include/mailbox_t.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <l4/types.h>
+#include <l4/thread.h>
+#include <l4/message.h>
+#include <l4/compiler.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+[[nodiscard]] L4_ThreadId_t L4_CDECL mailbox_recv_t(L4_MsgTag_t *tag, L4_Time_t timeout);
+
+static inline L4_ThreadId_t Recv_T(L4_MsgTag_t *tag, L4_Time_t timeout)
+{
+    return mailbox_recv_t(tag, timeout);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/user/lib/ipc/Makefile.in
+++ b/user/lib/ipc/Makefile.in
@@ -5,6 +5,6 @@ top_builddir=@top_builddir@
 include $(top_srcdir)/Mk/l4.base.mk
 
 LIBRARY=useripc
-SRCS=user_ipc.cc
+SRCS=user_ipc.cc mailbox.c
 
 include $(top_srcdir)/Mk/l4.lib.mk

--- a/user/lib/ipc/mailbox.c
+++ b/user/lib/ipc/mailbox.c
@@ -1,0 +1,42 @@
+#include <l4/ipc.h>
+#include <l4/message.h>
+#include <l4/thread.h>
+#include <time.h>
+
+static inline unsigned long long timeout_to_us(L4_Time_t t)
+{
+    if (t.raw == 0)
+        return ~(unsigned long long)0;
+    unsigned long long man = t.raw & 0x3ffU;
+    unsigned long long exp = (t.raw >> 10) & 0x1fU;
+    return man << exp;
+}
+
+L4_ThreadId_t mailbox_recv_t(L4_MsgTag_t *tag, L4_Time_t timeout)
+{
+    const struct timespec nap = {0, 1000000}; /* 1ms */
+    unsigned long long us = timeout_to_us(timeout);
+    L4_Clock_t end;
+    if (timeout.raw == 0)
+        end.raw = ~0ULL;
+    else
+        end = L4_ClockAddUsec(L4_SystemClock(), us);
+
+    L4_MsgTag_t t;
+    L4_ThreadId_t from;
+
+    for (;;) {
+        t = L4_Wait_Timeout(L4_ZeroTime, &from);
+        if (!L4_IpcFailed(t)) {
+            if (tag)
+                *tag = t;
+            return from;
+        }
+        if (timeout.raw != 0 && L4_IsClockLater(L4_SystemClock(), end)) {
+            if (tag)
+                *tag = t;
+            return L4_nilthread;
+        }
+        nanosleep(&nap, NULL);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `mailbox_recv_t` with polling via `nanosleep`
- expose the helper through new `mailbox_t.h`
- build mailbox code into `useripc` library
- document `Recv_T` usage and semantics

## Testing
- `pytest -q`