### PR TITLE
Add exo_ipc status enum and wrappers

### DIFF
--- a/include/door.h
+++ b/include/door.h
@@ -1,0 +1,19 @@
+#ifndef DOOR_H
+#define DOOR_H
+
+#include <exo_ipc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline exo_ipc_status door_call(L4_ThreadId_t door)
+{
+    return exo_send(door);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DOOR_H */

--- a/include/exo_ipc.h
+++ b/include/exo_ipc.h
@@ -1,0 +1,32 @@
+#ifndef EXO_IPC_H
+#define EXO_IPC_H
+
+#include <l4/ipc.h>
+#include <l4/thread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Status codes returned by the exokernel IPC helpers. The values
+ * roughly mirror L4 error codes but are independent from the
+ * architecture specific constants.
+ */
+
+typedef enum {
+    EXO_IPC_OK = 0,
+    EXO_IPC_TIMEOUT,
+    EXO_IPC_INVALID_PARTNER,
+    EXO_IPC_OVERFLOW,
+    EXO_IPC_ERROR,
+} exo_ipc_status;
+
+exo_ipc_status exo_send(L4_ThreadId_t to);
+exo_ipc_status exo_recv(L4_ThreadId_t from, L4_ThreadId_t *sender);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EXO_IPC_H */

--- a/include/typed_channel.h
+++ b/include/typed_channel.h
@@ -1,0 +1,35 @@
+#ifndef TYPED_CHANNEL_H
+#define TYPED_CHANNEL_H
+
+#include <exo_ipc.h>
+#include <l4/message.h>
+#include <span>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    L4_ThreadId_t partner;
+} typed_channel_t;
+
+static inline void typed_channel_init(typed_channel_t *ch, L4_ThreadId_t partner)
+{
+    ch->partner = partner;
+}
+
+static inline exo_ipc_status typed_channel_send(typed_channel_t *ch,
+                                                const L4_Word_t *words,
+                                                size_t count)
+{
+    L4_Msg_t msg;
+    L4_MsgPut(&msg, 0, count, words, 0, nullptr);
+    L4_MsgLoad(&msg);
+    return exo_send(ch->partner);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TYPED_CHANNEL_H */

--- a/src-userland/lib/CMakeLists.txt
+++ b/src-userland/lib/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 add_library(useripc STATIC
     ${CMAKE_SOURCE_DIR}/user/lib/ipc/user_ipc.cc
+    ${CMAKE_SOURCE_DIR}/user/lib/exo/exo_ipc.cc
 )
 
 add_library(sched STATIC
@@ -13,6 +14,7 @@ add_library(sched STATIC
 
 target_include_directories(useripc PRIVATE
     ${CMAKE_SOURCE_DIR}/user/include
+    ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/user/contrib/elf-loader/include
 )
 

--- a/user/lib/exo/exo_ipc.cc
+++ b/user/lib/exo/exo_ipc.cc
@@ -1,0 +1,35 @@
+#include <exo_ipc.h>
+#include <l4/message.h>
+
+// Simple wrappers around the L4 IPC primitives that translate
+// the kernel error codes into the exo_ipc_status enumeration.
+
+static exo_ipc_status translate_error(L4_MsgTag_t tag)
+{
+    if (L4_IpcSucceeded(tag))
+        return EXO_IPC_OK;
+
+    L4_Word_t err = L4_ErrorCode();
+    // L4 error codes are architecture specific. We map the most
+    // common ones used by the examples into portable values.
+    switch (err) {
+    case L4_ERROR_INVALID_THREAD:
+        return EXO_IPC_INVALID_PARTNER;
+    default:
+        return EXO_IPC_ERROR;
+    }
+}
+
+exo_ipc_status exo_send(L4_ThreadId_t to)
+{
+    return translate_error(L4_Send(to));
+}
+
+exo_ipc_status exo_recv(L4_ThreadId_t from, L4_ThreadId_t *sender)
+{
+    L4_ThreadId_t src;
+    L4_MsgTag_t tag = L4_Receive(from, &src);
+    if (sender)
+        *sender = src;
+    return translate_error(tag);
+}


### PR DESCRIPTION
## Summary
- introduce `exo_ipc_status` enumeration
- add basic `exo_send`/`exo_recv` helpers
- expose typed channel and door wrappers using the new status codes
- build new sources in userland library

## Testing
- `make check`