### PR TITLE
Add global scheduler spinlock

### DIFF
--- a/kernel/src/api/v4/schedule.cc
+++ b/kernel/src/api/v4/schedule.cc
@@ -43,6 +43,8 @@
 
 #include <kdb/tracepoints.h>
 
+DEFINE_SPINLOCK(sched_lock);
+
 /* global idle thread, we allocate a utcb to make accessing MRs etc easier */
 whole_tcb_t __whole_idle_tcb UNIT("cpulocal") __attribute__((aligned(sizeof(whole_tcb_t))));
 utcb_t	    __idle_utcb UNIT("cpulocal") __attribute__((aligned(sizeof(utcb_t))));

--- a/kernel/src/api/v4/schedule.h
+++ b/kernel/src/api/v4/schedule.h
@@ -36,6 +36,9 @@
 #include INC_API(tcb.h)
 #include INC_GLUE(schedule.h)
 #include <kdb/tracepoints.h>
+#include <sync.h>
+
+DECLARE_SPINLOCK(sched_lock);
 
 EXTERN_TRACEPOINT(SCHEDULE_DETAILS);
 

--- a/kernel/src/glue/v4-powerpc/init.cc
+++ b/kernel/src/glue/v4-powerpc/init.cc
@@ -698,6 +698,7 @@ extern "C" void SECTION(SEC_INIT) startup_system ( word_t r3, word_t r4, word_t 
 
     /* Initialize the idle tcb, and push notify frames for starting
      * the idle thread. */
+    sched_lock.init();
     get_current_scheduler()->init( true );
 
     /* Push a notify frame for the second stage of initialization, which

--- a/kernel/src/glue/v4-powerpc64/init.cc
+++ b/kernel/src/glue/v4-powerpc64/init.cc
@@ -352,6 +352,7 @@ extern "C" SECTION(".init") void virtmode_call(void)
 
     /* Initialize the idle tcb, and push notify frames for starting
      * the idle thread. */
+    sched_lock.init();
     get_current_scheduler()->init();
 
     /* Push a notify frame for the second stage of initialization, which

--- a/kernel/src/glue/v4-x86/init.cc
+++ b/kernel/src/glue/v4-x86/init.cc
@@ -564,6 +564,7 @@ extern "C" void SECTION(".init.init64") startup_system(u32_t is_ap)
 #endif /* defined(CONFIG_X86_COMPATIBILITY_MODE) */
 
     /* initialize the scheduler */
+    sched_lock.init();
     get_current_scheduler()->init(true);
     /* get the thing going - we should never return */
     get_current_scheduler()->start(cpuid);


### PR DESCRIPTION
## Summary
- add `sched_lock` declaration in scheduler header
- define and init lock during early boot
- protect run queue updates with `scoped_spinlock`

## Testing
- `pre-commit` *(fails: command not found)*