### PR TITLE
Clean up memory helper functions

### DIFF
--- a/user/contrib/elf-loader/platform/amd64-pc99/elf.cc
+++ b/user/contrib/elf-loader/platform/amd64-pc99/elf.cc
@@ -31,6 +31,7 @@
  ********************************************************************/
 
 #include "globals.h"
+#include <cstring>
 
 Elf64_Shdr *elf64_next_shdr(Elf64_Ehdr *ehdr, int *index)						
 {														
@@ -110,10 +111,11 @@ void elf64_install_image(Elf64_Ehdr *ehdr,  L4_Word64_t *image_start,  L4_Word64
 	//(L4_Word_t) phdr->p_filesz,
 	//(void *) ((L4_Word_t) phdr->p_paddr));
 
-	if (copy)
-	    memcpy((void *) ( (L4_Word_t) phdr->p_paddr),\
-		   (void *) ( (L4_Word_t) ehdr + (L4_Word_t) phdr->p_offset),\
-		   (L4_Word_t) phdr->p_filesz);
+        if (copy)
+            std::memcpy(reinterpret_cast<void *>(phdr->p_paddr),
+                        reinterpret_cast<void *>(
+                            (L4_Word_t)ehdr + (L4_Word_t)phdr->p_offset),
+                        (L4_Word_t)phdr->p_filesz);
 	
        
 	start <?= ((L4_Word_t) phdr->p_paddr);

--- a/user/contrib/elf-loader/platform/amd64-pc99/globals.h
+++ b/user/contrib/elf-loader/platform/amd64-pc99/globals.h
@@ -45,7 +45,6 @@ void elf64_install_image(Elf64_Ehdr *ehdr,  L4_Word64_t *image_start,  L4_Word64
 /* From string.cc */
 int strcmp(const char * cs,const char * ct);
 int strncmp(const char * cs,const char * ct, unsigned int count);
-void memcpy(void * dst, void * src, unsigned long size);
     
 /* From screen.c */
 void putc(int c);

--- a/user/contrib/elf-loader/platform/amd64-pc99/string.cc
+++ b/user/contrib/elf-loader/platform/amd64-pc99/string.cc
@@ -178,95 +178,20 @@ char * strpbrk(const char * cs,const char * ct)
 
 char * strtok(char * s,const char * ct)
 {
-	char *sbegin, *send;
+        char *sbegin, *send;
 
-	sbegin  = s ? s : ___strtok;
-	if (!sbegin) {
-		return nullptr;
-	}
-	sbegin += strspn(sbegin,ct);
-	if (*sbegin == '\0') {
-		___strtok = nullptr;
-		return( nullptr );
-	}
-	send = strpbrk( sbegin, ct);
-	if (send && *send != '\0')
-		*send++ = '\0';
-	___strtok = send;
-	return (sbegin);
-}
-
-void * memset(void * s, int c, unsigned int count)
-{
-	char *xs = (char *) s;
-
-	while (count--)
-		*xs++ = c;
-
-	return s;
-}
-
-char * bcopy(const char * src, char * dest, int count)
-{
-	char *tmp = dest;
-
-	while (count--)
-		*tmp++ = *src++;
-
-	return dest;
-}
-
-void * memmove(void * dest,const void *src,unsigned int count)
-{
-	char *tmp, *s;
-
-	if (dest <= src) {
-		tmp = (char *) dest;
-		s = (char *) src;
-		while (count--)
-			*tmp++ = *s++;
-		}
-	else {
-		tmp = (char *) dest + count;
-		s = (char *) src + count;
-		while (count--)
-			*--tmp = *--s;
-		}
-
-	return dest;
-}
-
-int memcmp(const void *cs, const void *ct, unsigned int count)
-{
-    char *su1, *su2;
-    signed char res = 0;
-    
-    for(su1 = (char *)cs, su2 = (char *) ct; 0 < count; ++su1, ++su2, count--)
-	if ((res = *su1 - *su2) != 0)
-	    break;
-    return res;
-}
-
-/*
- * find the first occurrence of byte 'c', or 1 past the area if none
- */
-void * memscan(void * addr, unsigned char c, unsigned int size)
-{
-	unsigned char * p = (unsigned char *) addr;
-
-	while (size) {
-		if (*p == c)
-			return (void *) p;
-		p++;
-		size--;
-	}
-  	return (void *) p;
-}
-
-void memcpy(void * dst, void * src, unsigned long size)
-{
-    L4_Word_t * _src = (L4_Word_t*)src;
-    L4_Word_t * _dst = (L4_Word_t*)dst;
-    for (unsigned int i = 0; i < size; i += sizeof(L4_Word_t))
-	*_dst++ = *_src++;
+        sbegin  = s ? s : ___strtok;
+        if (!sbegin) {
+                return nullptr;
+        }
+        sbegin += strspn(sbegin,ct);
+        if (*sbegin == '\0') {
+                ___strtok = nullptr;
+                return( nullptr );
+        }
+        send = strpbrk( sbegin, ct);
+        if (send && *send != '\0')
+                *send++ = '\0';
+        ___strtok = send;
+        return (sbegin);
 }

--- a/user/util/kickstart/elf.cc
+++ b/user/util/kickstart/elf.cc
@@ -35,6 +35,7 @@
 #include "kickstart.h"
 #include "elf.h"
 #include "lib.h"
+#include <cstring>
 
 #if defined(L4_32BIT)
 #define BI_NS BI32
@@ -130,7 +131,8 @@ bool __elf_func(elf_load) (L4_Word_t file_start,
             // Copy bytes from "file" to memory - load address
             memcopy(dst_start, src_start, ph->fsize);
             // Zero "non-file" bytes
-            memset(dst_start + ph->fsize, 0, ph->msize - ph->fsize);
+            std::memset(reinterpret_cast<void *>(dst_start + ph->fsize), 0,
+                        ph->msize - ph->fsize);
             // Update min and max
             min_addr = min(min_addr, dst_start);
             max_addr = max(max_addr, dst_end);
@@ -161,7 +163,7 @@ bool __elf_func(elf_find_sections) (L4_Word_t addr,
         return false;
 
     // Initialize a local bootinfo record
-    memset ((L4_Word_t) exec, 0, sizeof (*exec));
+    std::memset(exec, 0, sizeof(*exec));
     exec->type = L4_BootInfo_SimpleExec;
     exec->version = 1;
     exec->initial_ip = eh->entry;

--- a/user/util/kickstart/lib.cc
+++ b/user/util/kickstart/lib.cc
@@ -74,23 +74,7 @@ extern "C" void memcopy(L4_Word_t dst, L4_Word_t src, L4_Word_t len)
 }
 
 
-/**
- * Fill memory with a constant byte
- *
- * @param dst   destination address
- * @param val   byte to write to memory block
- * @param len   length of memory block in bytes
- *
- * The memset() function fills the first len bytes of the memory
- * block pointed to by dst with the constant byte val.
- */
-extern "C" void memset(L4_Word_t dst, L4_Word8_t val, L4_Word_t len)
-{
-    L4_Word8_t* d = (L4_Word8_t*) dst;
 
-    while (len--)
-        *d++ = val;
-}
 
 
 

--- a/user/util/kickstart/lib.h
+++ b/user/util/kickstart/lib.h
@@ -61,7 +61,6 @@ extern "C" char *strstr(const char *s, const char *find) __attribute__((weak));
 extern "C" unsigned long strtoul(const char *cp, char **endp, int base) __attribute__((weak));
 extern "C" char *strchr(const char *p, int ch) __attribute__((weak));
 extern "C" void memcopy(L4_Word_t dst, L4_Word_t src, L4_Word_t len) __attribute__((weak));
-extern "C" void memset(L4_Word_t dst, L4_Word8_t val, L4_Word_t len) __attribute__((weak));
 
 extern inline void memcopy(void *dst, void *src, L4_Word_t len)
 {


### PR DESCRIPTION
## Summary
- rely on standard memory helpers
- drop unused memset/bcopy/memmove implementations
- use `std::memcpy` and `std::memset` in loader and kickstart

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*