### PR TITLE
Add basic POSIX test programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,5 +43,9 @@ add_custom_target(default_all ALL DEPENDS string_obj kernel_target userlib_targe
 
 add_executable(spinlock_fairness tests/spinlock_fairness.c)
 target_link_libraries(spinlock_fairness PRIVATE pthread)
-add_custom_target(tests DEPENDS spinlock_fairness)
+
+add_executable(posix_test_file tests/posix/test_file.c)
+add_executable(posix_test_process tests/posix/test_process.c)
+
+add_custom_target(tests DEPENDS spinlock_fairness posix_test_file posix_test_process)
 

--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,28 @@ all: build/string.o
 .PHONY: all clean check tests
 
 build/tests:
-	mkdir -p build/tests
+        mkdir -p build/tests
+
+build/tests/posix:
+        mkdir -p build/tests/posix
 
 build/tests/spinlock_fairness: tests/spinlock_fairness.c | build/tests
-	$(CC) $(CFLAGS) -pthread $< -o $@
+        $(CC) $(CFLAGS) -pthread $< -o $@
 
-tests: build/tests/spinlock_fairness
+build/tests/posix/test_file: tests/posix/test_file.c | build/tests/posix
+        $(CC) $(CFLAGS) $< -o $@
+
+build/tests/posix/test_process: tests/posix/test_process.c | build/tests/posix
+        $(CC) $(CFLAGS) $< -o $@
+
+tests: build/tests/spinlock_fairness build/tests/posix/test_file build/tests/posix/test_process
 
 clean:
 	rm -rf build
 	find . -name '*.o' -delete
 
 check: all tests
-	python -m unittest discover -v tests
-	./build/tests/spinlock_fairness
+        python -m unittest discover -v tests
+        ./build/tests/spinlock_fairness
+        ./build/tests/posix/test_file
+        ./build/tests/posix/test_process

--- a/docs/building.md
+++ b/docs/building.md
@@ -213,9 +213,10 @@ See the top-level LICENSE file for the project's terms.
 
 ## Running tests
 
-The repository provides a small test suite consisting of Python unit tests and
-a C stress test for the ticket-lock implementation.  The Makefile exposes a
-`check` target which builds the `spinlock_fairness` program and runs all tests:
+The repository provides a small test suite consisting of Python unit tests,
+a C stress test for the ticket-lock implementation and a pair of simple
+POSIX programs under `tests/posix`.  The Makefile exposes a `check` target
+which builds these programs and runs all tests:
 
 ```bash
 $ make check
@@ -226,6 +227,8 @@ When using CMake, invoke the `tests` target:
 ```bash
 $ cmake --build . --target tests
 ./spinlock_fairness
+./posix_test_file
+./posix_test_process
 ```
 
 The `spinlock_fairness` binary spawns multiple threads, measures how many times

--- a/tests/posix/test_file.c
+++ b/tests/posix/test_file.c
@@ -1,0 +1,48 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void) {
+    const char *fname = "posix_test.tmp";
+    const char *msg = "hello\n";
+    int fd = open(fname, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        perror("open");
+        return 1;
+    }
+    ssize_t written = write(fd, msg, strlen(msg));
+    if (written != (ssize_t)strlen(msg)) {
+        perror("write");
+        close(fd);
+        unlink(fname);
+        return 1;
+    }
+    close(fd);
+
+    char buf[16] = {0};
+    fd = open(fname, O_RDONLY);
+    if (fd < 0) {
+        perror("open");
+        unlink(fname);
+        return 1;
+    }
+    ssize_t n = read(fd, buf, sizeof(buf) - 1);
+    if (n < 0) {
+        perror("read");
+        close(fd);
+        unlink(fname);
+        return 1;
+    }
+    close(fd);
+    unlink(fname);
+
+    if (strncmp(buf, msg, strlen(msg)) != 0) {
+        fprintf(stderr, "content mismatch\n");
+        return 1;
+    }
+
+    puts("file test ok");
+    return 0;
+}

--- a/tests/posix/test_process.c
+++ b/tests/posix/test_process.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(void) {
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return 1;
+    }
+    if (pid == 0) {
+        puts("child running");
+        _exit(42);
+    }
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0) {
+        perror("waitpid");
+        return 1;
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 42) {
+        fprintf(stderr, "unexpected status %d\n", status);
+        return 1;
+    }
+
+    puts("process test ok");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add simple file and process tests under `tests/posix`
- build new tests in Makefile and CMake
- document running the new tests

## Testing
- `pre-commit run --files Makefile CMakeLists.txt docs/building.md tests/posix/test_file.c tests/posix/test_process.c` *(fails: pre-commit not installed)*