### PR TITLE
Add MLP scheduler example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
 project(pistachio C CXX)
 
+# Add Eigen headers if present
+include_directories(${CMAKE_SOURCE_DIR}/third_party/eigen)
+
 # Allow passing cross build settings through CMake
 set(TOOLPREFIX "" CACHE STRING "Prefix for cross compilation tools")
 set(SUBARCH "" CACHE STRING "Kernel sub-architecture")

--- a/docs/mlp_scheduler.md
+++ b/docs/mlp_scheduler.md
@@ -1,0 +1,30 @@
+# MLP Scheduler
+
+The `mlp_scheduler` server demonstrates using a small multi-layer
+perceptron to choose the next runnable thread.  The implementation uses
+the [Eigen](https://eigen.tuxfamily.org/) library for matrix operations.
+Provide Eigen under `third_party/eigen` before building.
+
+## Building
+
+Clone Eigen into the `third_party` directory and build the library and
+server:
+
+```bash
+$ git clone https://gitlab.com/libeigen/eigen.git third_party/eigen
+$ make -C user/lib/mlp
+$ make -C user/serv/mlp_scheduler
+```
+
+## Running
+
+Launch the scheduler alongside the memory server with `kickstart`:
+
+```bash
+$ user/util/kickstart/kickstart \
+      -roottask=user/serv/memory/memory \
+      user/serv/mlp_scheduler/mlp_scheduler
+```
+
+The scheduler loads a model file specified on the command line if
+provided.

--- a/src-userland/lib/CMakeLists.txt
+++ b/src-userland/lib/CMakeLists.txt
@@ -9,6 +9,10 @@ add_library(sched STATIC
     ${CMAKE_SOURCE_DIR}/user/lib/sched/sched_client.cc
 )
 
+add_library(mlp STATIC
+    ${CMAKE_SOURCE_DIR}/user/lib/mlp/mlp.cc
+)
+
 # Include directories match the Makefile
 # using absolute paths from the repository root
 
@@ -23,8 +27,14 @@ target_include_directories(sched PRIVATE
     ${CMAKE_SOURCE_DIR}/user/contrib/elf-loader/include
 )
 
+target_include_directories(mlp PRIVATE
+    ${CMAKE_SOURCE_DIR}/user/include
+    ${CMAKE_SOURCE_DIR}/user/contrib/elf-loader/include
+    ${CMAKE_SOURCE_DIR}/third_party/eigen
+)
+
 add_custom_target(userlib_target ALL
-    DEPENDS useripc sched
+    DEPENDS useripc sched mlp
 )
 
 add_custom_target(userlib_clean

--- a/tests/test_mlp_scheduler_build.py
+++ b/tests/test_mlp_scheduler_build.py
@@ -1,0 +1,37 @@
+import subprocess
+import tempfile
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+CODE = r"""
+#include "../../user/lib/mlp/mlp.h"
+int main() {
+    float f[1] = {0};
+    mlp_init(nullptr);
+    return mlp_predict(f);
+}
+"""
+
+class MlpSchedulerBuildTest(unittest.TestCase):
+    def test_compile(self) -> None:
+        eigen_dir = ROOT / "third_party" / "eigen" / "Eigen"
+        if not eigen_dir.exists():
+            self.skipTest("Eigen not available")
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / "test.cpp"
+            src.write_text(CODE)
+            cmd = [
+                "g++",
+                "-std=c++23",
+                "-I",
+                str(ROOT / "user/include"),
+                "-I",
+                str(ROOT / "third_party/eigen"),
+                "-c",
+                str(src),
+            ]
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/third_party/eigen/README.md
+++ b/third_party/eigen/README.md
@@ -1,0 +1,3 @@
+Eigen is not bundled with this repository.
+Download it from https://gitlab.com/libeigen/eigen.git
+and place the contents here so that `third_party/eigen/Eigen` exists.

--- a/user/config.mk
+++ b/user/config.mk
@@ -52,7 +52,7 @@ CFLAGS=		-std=c2x
 CXXFLAGS=       $(CXXSTD) -fno-exceptions
 CXXSTD=	-std=c++23
 LDFLAGS=	
-CPPFLAGS=	
+CPPFLAGS= -I$(top_srcdir)/../third_party/eigen
 LGCC=		-lgcc
 
 TOOLPREFIX=	

--- a/user/config.mk.in
+++ b/user/config.mk.in
@@ -52,7 +52,7 @@ CFLAGS=		@CFLAGS@
 CXXFLAGS=       $(CXXSTD) -fno-exceptions
 CXXSTD=	@CXXSTD@
 LDFLAGS=	@LDFLAGS@
-CPPFLAGS=	@CPPFLAGS@
+CPPFLAGS=       @CPPFLAGS@ -I$(top_srcdir)/../third_party/eigen
 LGCC=		-lgcc
 
 TOOLPREFIX=	@TOOLPREFIX@

--- a/user/lib/Makefile.in
+++ b/user/lib/Makefile.in
@@ -36,7 +36,7 @@ top_builddir=	@top_builddir@
 include $(top_srcdir)/Mk/l4.base.mk
 
 
-SUBDIRS=	 l4 io memory ipc sched
+SUBDIRS=	 l4 io memory ipc sched mlp
 
 post-clean:
 	rm -f *.a

--- a/user/lib/mlp/Makefile.in
+++ b/user/lib/mlp/Makefile.in
@@ -1,0 +1,10 @@
+srcdir=@srcdir@
+top_srcdir=@top_srcdir@
+top_builddir=@top_builddir@
+
+include $(top_srcdir)/Mk/l4.base.mk
+
+LIBRARY=mlp
+SRCS=mlp.cc
+
+include $(top_srcdir)/Mk/l4.lib.mk

--- a/user/lib/mlp/mlp.cc
+++ b/user/lib/mlp/mlp.cc
@@ -1,0 +1,68 @@
+#include "mlp.h"
+#include <Eigen/Dense>
+#include <fstream>
+#include <vector>
+
+using Eigen::MatrixXf;
+using Eigen::VectorXf;
+
+static MatrixXf W1;
+static VectorXf b1;
+static MatrixXf W2;
+static VectorXf b2;
+
+void mlp_init(const char *model_path)
+{
+    if (!model_path) return;
+    std::ifstream f(model_path);
+    if (!f)
+        return;
+    int in, hidden, out;
+    if (!(f >> in >> hidden >> out))
+        return;
+    W1.resize(hidden, in);
+    b1.resize(hidden);
+    for (int i = 0; i < hidden; ++i)
+        for (int j = 0; j < in; ++j)
+            f >> W1(i, j);
+    for (int i = 0; i < hidden; ++i)
+        f >> b1(i);
+    W2.resize(out, hidden);
+    b2.resize(out);
+    for (int i = 0; i < out; ++i)
+        for (int j = 0; j < hidden; ++j)
+            f >> W2(i, j);
+    for (int i = 0; i < out; ++i)
+        f >> b2(i);
+}
+
+static int input_dim()
+{
+    return W1.cols() ? W1.cols() : 1;
+}
+
+int mlp_predict(const float *features)
+{
+    Eigen::Map<const VectorXf> x(features, input_dim());
+    VectorXf h;
+    if (W1.size() == 0)
+    {
+        h = x;
+    }
+    else
+    {
+        h = (W1 * x + b1).array().tanh();
+    }
+    VectorXf o;
+    if (W2.size() == 0)
+    {
+        o = h;
+    }
+    else
+    {
+        o = W2 * h + b2;
+    }
+    Eigen::Index idx;
+    o.maxCoeff(&idx);
+    return static_cast<int>(idx);
+}

--- a/user/lib/mlp/mlp.h
+++ b/user/lib/mlp/mlp.h
@@ -1,0 +1,13 @@
+#ifndef LIB_MLP_H
+#define LIB_MLP_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void mlp_init(const char *model_path);
+int mlp_predict(const float *features);
+
+#ifdef __cplusplus
+}
+#endif
+#endif // LIB_MLP_H

--- a/user/serv/mlp_scheduler/Makefile.in
+++ b/user/serv/mlp_scheduler/Makefile.in
@@ -1,0 +1,6 @@
+SRCS = mlp_scheduler.cc
+LIBS += -ll4 -lio -lsched -lmlp
+LDFLAGS += -Ttext=$(ROOTTASK_LINKBASE)
+
+include \
+    $(top_srcdir)/Mk/l4.prog.mk

--- a/user/serv/mlp_scheduler/mlp_scheduler.cc
+++ b/user/serv/mlp_scheduler/mlp_scheduler.cc
@@ -1,0 +1,50 @@
+#include <l4/thread.h>
+#include <l4/ipc.h>
+#include <stdio.h>
+#include <deque>
+#include "../../lib/sched/sched_client.h"
+#include "../../lib/mlp/mlp.h"
+
+enum class SchedLabel : L4_Word_t { Request = 0x1234 };
+
+int main(int argc, char **argv)
+{
+    const char *model = argc > 1 ? argv[1] : nullptr;
+    mlp_init(model);
+
+    printf("MLP scheduler server started\n");
+
+    sched_set_server(L4_Myself());
+    std::deque<L4_ThreadId_t> queue;
+
+    while (1)
+    {
+        SchedRequest req;
+        L4_ThreadId_t from;
+        L4_MsgTag_t tag = sched_wait_request(&req, &from);
+        if (L4_Label(tag) != static_cast<L4_Word_t>(SchedLabel::Request))
+            continue;
+
+        queue.push_back(from);
+
+        if (!queue.empty())
+        {
+            float feat[1] = { static_cast<float>(queue.size()) };
+            int front = mlp_predict(feat);
+            L4_ThreadId_t next;
+            if (front || queue.size() == 1)
+            {
+                next = queue.front();
+                queue.pop_front();
+            }
+            else
+            {
+                next = queue.back();
+                queue.pop_back();
+            }
+            sched_switch(next);
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- vendor Eigen headers directory with usage instructions
- include Eigen in Makefiles and CMake builds
- implement `libmlp` with a small MLP using Eigen
- add `mlp_scheduler` server using the new library
- document how to build and run the scheduler
- add a compile test for the new header

## Testing
- `pytest -q`
- ❌ `pre-commit run --files CMakeLists.txt src-userland/lib/CMakeLists.txt user/config.mk user/config.mk.in user/lib/Makefile.in docs/mlp_scheduler.md tests/test_mlp_scheduler_build.py user/lib/mlp/mlp.h user/lib/mlp/mlp.cc user/lib/mlp/Makefile.in user/serv/mlp_scheduler/mlp_scheduler.cc user/serv/mlp_scheduler/Makefile.in third_party/eigen/README.md` *(fails: `pre-commit: command not found`)*