### PR TITLE
Add POSIX reference and skeleton components

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Documentation Overview
+
+This directory contains design notes, build instructions and references
+for Pistachio's exokernel and userland components.
+
+The `ben-books` folder bundles PDF and HTML copies of the POSIX
+specification, including the Single UNIX Specification, version 4
+(2018 edition).  These documents are provided as a convenient reference
+when implementing or verifying POSIX interfaces.
+
+

--- a/docs/posix_compatibility.md
+++ b/docs/posix_compatibility.md
@@ -60,3 +60,8 @@ control until a reply is received.
 By layering the POSIX subsystem on top of the exokernel's primitives, the kernel
 remains small while user-level servers provide the rich API expected by
 applications.
+
+## Reference Specification
+
+Full copies of the POSIX specification are available under `docs/ben-books`. The `susv4-2018` HTML tree contains the Single UNIX Specification, version 4 (2018). Consult these documents when implementing system calls or verifying behaviour.
+

--- a/user/lib/Makefile.in
+++ b/user/lib/Makefile.in
@@ -36,7 +36,7 @@ top_builddir=	@top_builddir@
 include $(top_srcdir)/Mk/l4.base.mk
 
 
-SUBDIRS=	 l4 io memory ipc sched mlp
+SUBDIRS=      l4 io memory ipc sched mlp posix
 
 post-clean:
 	rm -f *.a

--- a/user/lib/posix/Makefile.in
+++ b/user/lib/posix/Makefile.in
@@ -1,0 +1,10 @@
+srcdir=@srcdir@
+top_srcdir=@top_srcdir@
+top_builddir=@top_builddir@
+
+include $(top_srcdir)/Mk/l4.base.mk
+
+LIBRARY=posix
+SRCS=posix.cc
+
+include $(top_srcdir)/Mk/l4.lib.mk

--- a/user/lib/posix/posix.cc
+++ b/user/lib/posix/posix.cc
@@ -1,0 +1,28 @@
+#include "posix.h"
+#include <fcntl.h>
+#include <unistd.h>
+
+// These stub implementations directly invoke the host system calls.
+// Future versions will forward requests to user-level servers using
+// the exokernel IPC helpers.
+
+int posix_open(const char *path, int flags, unsigned mode)
+{
+    return open(path, flags, mode);
+}
+
+ssize_t posix_read(int fd, void *buf, size_t count)
+{
+    return read(fd, buf, count);
+}
+
+ssize_t posix_write(int fd, const void *buf, size_t count)
+{
+    return write(fd, buf, count);
+}
+
+pid_t posix_fork(void)
+{
+    return fork();
+}
+

--- a/user/lib/posix/posix.h
+++ b/user/lib/posix/posix.h
@@ -1,0 +1,20 @@
+#ifndef POSIX_LIB_H
+#define POSIX_LIB_H
+
+#include <stddef.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int posix_open(const char *path, int flags, unsigned mode);
+ssize_t posix_read(int fd, void *buf, size_t count);
+ssize_t posix_write(int fd, const void *buf, size_t count);
+pid_t posix_fork(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* POSIX_LIB_H */

--- a/user/serv/Makefile.in
+++ b/user/serv/Makefile.in
@@ -36,7 +36,7 @@ top_builddir=	@top_builddir@
 include $(top_srcdir)/Mk/l4.base.mk
 
 
-SUBDIRS=	sigma0 memory
+SUBDIRS=     sigma0 memory scheduler vfs process
 
 
 include $(top_srcdir)/Mk/l4.subdir.mk

--- a/user/serv/process/Makefile.in
+++ b/user/serv/process/Makefile.in
@@ -1,0 +1,6 @@
+SRCS = process.cc
+LIBS += -ll4 -lio
+LDFLAGS += -Ttext=$(ROOTTASK_LINKBASE)
+
+include \
+    $(top_srcdir)/Mk/l4.prog.mk

--- a/user/serv/process/process.cc
+++ b/user/serv/process/process.cc
@@ -1,0 +1,13 @@
+#include <l4/ipc.h>
+#include <stdio.h>
+
+int main()
+{
+    printf("Process server started\n");
+    while (1) {
+        L4_ThreadId_t from = L4_nilthread;
+        L4_Receive(from, &from);
+        L4_Reply(from);
+    }
+    return 0;
+}

--- a/user/serv/vfs/Makefile.in
+++ b/user/serv/vfs/Makefile.in
@@ -1,0 +1,6 @@
+SRCS = vfs.cc
+LIBS += -ll4 -lio
+LDFLAGS += -Ttext=$(ROOTTASK_LINKBASE)
+
+include \
+    $(top_srcdir)/Mk/l4.prog.mk

--- a/user/serv/vfs/vfs.cc
+++ b/user/serv/vfs/vfs.cc
@@ -1,0 +1,13 @@
+#include <l4/ipc.h>
+#include <stdio.h>
+
+int main()
+{
+    printf("VFS server started\n");
+    while (1) {
+        L4_ThreadId_t from = L4_nilthread;
+        L4_Receive(from, &from);
+        L4_Reply(from);
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- document location of bundled POSIX specification
- reference docs/ben-books from the POSIX compatibility guide
- add skeleton `libposix` library
- stub out `vfs` and `process` user-level servers
- hook new components into the build system

## Testing
- `pytest -q`