### PR TITLE
Implement simple directory helpers and test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(spinlock_fairness PRIVATE pthread)
 
 add_executable(posix_test_file tests/posix/test_file.c)
 add_executable(posix_test_process tests/posix/test_process.c)
+add_executable(posix_dirlist user/apps/dirlist.c)
 
-add_custom_target(tests DEPENDS spinlock_fairness posix_test_file posix_test_process)
+add_custom_target(tests DEPENDS spinlock_fairness posix_test_file posix_test_process posix_dirlist)
 

--- a/Makefile
+++ b/Makefile
@@ -16,28 +16,27 @@ all: build/string.o
 .PHONY: all clean check tests
 
 build/tests:
-        mkdir -p build/tests
+	mkdir -p build/tests
 
 build/tests/posix:
-        mkdir -p build/tests/posix
+	mkdir -p build/tests/posix
 
 build/tests/spinlock_fairness: tests/spinlock_fairness.c | build/tests
-        $(CC) $(CFLAGS) -pthread $< -o $@
-
+	$(CC) $(CFLAGS) -pthread $< -o $@
 build/tests/posix/test_file: tests/posix/test_file.c | build/tests/posix
-        $(CC) $(CFLAGS) $< -o $@
-
+	$(CC) $(CFLAGS) $< -o $@
 build/tests/posix/test_process: tests/posix/test_process.c | build/tests/posix
-        $(CC) $(CFLAGS) $< -o $@
-
-tests: build/tests/spinlock_fairness build/tests/posix/test_file build/tests/posix/test_process
-
+	$(CC) $(CFLAGS) $< -o $@
+build/tests/posix/dirlist: user/apps/dirlist.c | build/tests/posix
+	$(CC) $(CFLAGS) $< -o $@
+tests: build/tests/spinlock_fairness build/tests/posix/test_file build/tests/posix/test_process build/tests/posix/dirlist
 clean:
 	rm -rf build
 	find . -name '*.o' -delete
 
 check: all tests
-        python -m unittest discover -v tests
-        ./build/tests/spinlock_fairness
-        ./build/tests/posix/test_file
-        ./build/tests/posix/test_process
+	python -m unittest discover -v tests
+	./build/tests/spinlock_fairness
+	./build/tests/posix/test_file
+	./build/tests/posix/test_process
+	./build/tests/posix/dirlist

--- a/user/apps/dirlist.c
+++ b/user/apps/dirlist.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <dirent.h>
+
+int main(void) {
+    DIR *d = opendir("/");
+    if (!d) {
+        perror("opendir");
+        return 1;
+    }
+    struct dirent *de;
+    while ((de = readdir(d)) != NULL) {
+        printf("%s\n", de->d_name);
+    }
+    closedir(d);
+    return 0;
+}

--- a/user/include/dirent.h
+++ b/user/include/dirent.h
@@ -1,0 +1,23 @@
+#ifndef USER_DIRENT_H
+#define USER_DIRENT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct dirent {
+    char d_name[256];
+};
+
+typedef struct DIR DIR;
+
+DIR *opendir(const char *name);
+struct dirent *readdir(DIR *dirp);
+void rewinddir(DIR *dirp);
+int closedir(DIR *dirp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USER_DIRENT_H */

--- a/user/serv/vfs/vfs.cc
+++ b/user/serv/vfs/vfs.cc
@@ -1,5 +1,59 @@
 #include <l4/ipc.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dirent.h>
+
+struct DIR {
+    size_t pos;
+};
+
+static const char *root_entries[] = {
+    "README",
+    "docs",
+    "kernel",
+    nullptr
+};
+
+DIR *opendir(const char *name)
+{
+    if (!name || strcmp(name, "/") != 0)
+        return nullptr;
+
+    DIR *d = static_cast<DIR*>(malloc(sizeof(DIR)));
+    if (!d)
+        return nullptr;
+    d->pos = 0;
+    return d;
+}
+
+struct dirent *readdir(DIR *dirp)
+{
+    static struct dirent ent;
+    if (!dirp)
+        return nullptr;
+
+    const char *name = root_entries[dirp->pos];
+    if (!name)
+        return nullptr;
+
+    strncpy(ent.d_name, name, sizeof(ent.d_name) - 1);
+    ent.d_name[sizeof(ent.d_name) - 1] = '\0';
+    dirp->pos++;
+    return &ent;
+}
+
+void rewinddir(DIR *dirp)
+{
+    if (dirp)
+        dirp->pos = 0;
+}
+
+int closedir(DIR *dirp)
+{
+    free(dirp);
+    return 0;
+}
 
 int main()
 {


### PR DESCRIPTION
## Summary
- define `DIR` and directory routines in userland headers
- add a trivial in-memory directory implementation to the VFS server
- provide an example program that lists `/`
- build the new dirlist example as part of the POSIX tests

## Testing
- `python -m unittest discover -v tests`
- `make tests`
- `make check`
