### PR TITLE
Add FIFO capability objects and test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ target_link_libraries(spinlock_fairness PRIVATE pthread)
 
 add_executable(posix_test_file tests/posix/test_file.c)
 add_executable(posix_test_process tests/posix/test_process.c)
+add_executable(fifo_test user/apps/fifo_test/fifo_test.c)
+target_link_libraries(fifo_test PRIVATE posix)
 
-add_custom_target(tests DEPENDS spinlock_fairness posix_test_file posix_test_process)
+add_custom_target(tests DEPENDS spinlock_fairness posix_test_file posix_test_process fifo_test)
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -229,6 +229,7 @@ $ cmake --build . --target tests
 ./spinlock_fairness
 ./posix_test_file
 ./posix_test_process
+./fifo_test
 ```
 
 The `spinlock_fairness` binary spawns multiple threads, measures how many times

--- a/src-userland/lib/CMakeLists.txt
+++ b/src-userland/lib/CMakeLists.txt
@@ -13,6 +13,10 @@ add_library(mlp STATIC
     ${CMAKE_SOURCE_DIR}/user/lib/mlp/mlp.cc
 )
 
+add_library(posix STATIC
+    ${CMAKE_SOURCE_DIR}/user/lib/posix/posix.cc
+)
+
 # Include directories match the Makefile
 # using absolute paths from the repository root
 
@@ -33,8 +37,13 @@ target_include_directories(mlp PRIVATE
     ${CMAKE_SOURCE_DIR}/third_party/eigen
 )
 
+target_include_directories(posix PRIVATE
+    ${CMAKE_SOURCE_DIR}/user/include
+    ${CMAKE_SOURCE_DIR}/user/contrib/elf-loader/include
+)
+
 add_custom_target(userlib_target ALL
-    DEPENDS useripc sched mlp
+    DEPENDS useripc sched mlp posix
 )
 
 add_custom_target(userlib_clean

--- a/user/apps/fifo_test/fifo_test.c
+++ b/user/apps/fifo_test/fifo_test.c
@@ -1,0 +1,42 @@
+#include "posix.h"
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+    const char *name = "testfifo";
+    if (posix_mkfifo(name, 0600) < 0) {
+        perror("mkfifo");
+        return 1;
+    }
+    int w = posix_open(name, O_WRONLY, 0);
+    int r = posix_open(name, O_RDONLY, 0);
+    if (w < 0 || r < 0) {
+        perror("open");
+        return 1;
+    }
+
+    const char *msg = "fifo\n";
+    if (posix_write(w, msg, strlen(msg)) != (ssize_t)strlen(msg)) {
+        perror("write");
+        return 1;
+    }
+
+    char buf[16] = {0};
+    if (posix_read(r, buf, sizeof(buf)) <= 0) {
+        perror("read");
+        return 1;
+    }
+
+    posix_close(w);
+    posix_close(r);
+
+    if (strncmp(buf, msg, strlen(msg)) != 0) {
+        fprintf(stderr, "mismatch\n");
+        return 1;
+    }
+
+    puts("fifo test ok");
+    return 0;
+}

--- a/user/lib/posix/posix.cc
+++ b/user/lib/posix/posix.cc
@@ -1,24 +1,116 @@
 #include "posix.h"
 #include <fcntl.h>
 #include <unistd.h>
+#include <map>
+#include <string>
+#include <vector>
 
 // These stub implementations directly invoke the host system calls.
 // Future versions will forward requests to user-level servers using
 // the exokernel IPC helpers.
 
+/*
+ * Simple in-process FIFO support. mkfifo() creates a pipe and stores it
+ * in an internal table keyed by pathname.  open/read/write/dup/close
+ * recognise file descriptors that refer to these FIFOs and operate on
+ * the underlying pipe endpoints.
+ */
+
+struct FifoEntry {
+    int fds[2];      // 0: read end, 1: write end
+    int refcnt;
+    std::string name;
+};
+
+static std::map<std::string, int> fifo_by_name;
+static std::vector<FifoEntry> fifo_table;
+static std::map<int, std::pair<int,int>> fifo_handles; // fd -> {index,end}
+static int next_fifo_fd = 10000; // distinguish from host descriptors
+
+static int alloc_fifo_handle(int idx, int end)
+{
+    int fd = next_fifo_fd++;
+    fifo_handles[fd] = {idx, end};
+    fifo_table[idx].refcnt++;
+    return fd;
+}
+
+int posix_mkfifo(const char *path, unsigned mode)
+{
+    if (fifo_by_name.count(path))
+        return -1;
+    int fds[2];
+    if (pipe(fds) < 0)
+        return -1;
+    FifoEntry e;
+    e.fds[0] = fds[0];
+    e.fds[1] = fds[1];
+    e.refcnt = 0;
+    e.name = path;
+    fifo_table.push_back(e);
+    fifo_by_name[path] = fifo_table.size() - 1;
+    (void)mode;
+    return 0;
+}
+
 int posix_open(const char *path, int flags, unsigned mode)
 {
+    auto it = fifo_by_name.find(path);
+    if (it != fifo_by_name.end()) {
+        int idx = it->second;
+        int end = ((flags & O_ACCMODE) == O_WRONLY) ? 1 : 0;
+        return alloc_fifo_handle(idx, end);
+    }
     return open(path, flags, mode);
 }
 
 ssize_t posix_read(int fd, void *buf, size_t count)
 {
+    auto it = fifo_handles.find(fd);
+    if (it != fifo_handles.end()) {
+        int idx = it->second.first;
+        int end = it->second.second;
+        return read(fifo_table[idx].fds[end], buf, count);
+    }
     return read(fd, buf, count);
 }
 
 ssize_t posix_write(int fd, const void *buf, size_t count)
 {
+    auto it = fifo_handles.find(fd);
+    if (it != fifo_handles.end()) {
+        int idx = it->second.first;
+        int end = it->second.second;
+        return write(fifo_table[idx].fds[end], buf, count);
+    }
     return write(fd, buf, count);
+}
+
+int posix_dup(int fd)
+{
+    auto it = fifo_handles.find(fd);
+    if (it != fifo_handles.end())
+        return alloc_fifo_handle(it->second.first, it->second.second);
+    return dup(fd);
+}
+
+int posix_close(int fd)
+{
+    auto it = fifo_handles.find(fd);
+    if (it != fifo_handles.end()) {
+        int idx = it->second.first;
+        fifo_handles.erase(it);
+        if (--fifo_table[idx].refcnt == 0) {
+            close(fifo_table[idx].fds[0]);
+            close(fifo_table[idx].fds[1]);
+            fifo_by_name.erase(fifo_table[idx].name);
+            fifo_table[idx].fds[0] = -1;
+            fifo_table[idx].fds[1] = -1;
+            fifo_table[idx].name.clear();
+        }
+        return 0;
+    }
+    return close(fd);
 }
 
 pid_t posix_fork(void)

--- a/user/lib/posix/posix.h
+++ b/user/lib/posix/posix.h
@@ -11,6 +11,9 @@ extern "C" {
 int posix_open(const char *path, int flags, unsigned mode);
 ssize_t posix_read(int fd, void *buf, size_t count);
 ssize_t posix_write(int fd, const void *buf, size_t count);
+int posix_dup(int fd);
+int posix_close(int fd);
+int posix_mkfifo(const char *path, unsigned mode);
 pid_t posix_fork(void);
 
 #ifdef __cplusplus

--- a/user/serv/vfs/vfs.cc
+++ b/user/serv/vfs/vfs.cc
@@ -1,12 +1,42 @@
 #include <l4/ipc.h>
 #include <stdio.h>
+#include <unistd.h>
+#include <vector>
+
+enum class VfsLabel : L4_Word_t { Mkfifo = 1 };
+
+struct FifoObj {
+    int fds[2];
+};
+
+static std::vector<FifoObj> fifo_list;
+
+static L4_Word_t handle_mkfifo(void)
+{
+    int fds[2];
+    if (pipe(fds) < 0)
+        return static_cast<L4_Word_t>(-1);
+    fifo_list.push_back({{fds[0], fds[1]}});
+    return fifo_list.size() - 1; /* capability */
+}
 
 int main()
 {
     printf("VFS server started\n");
     while (1) {
-        L4_ThreadId_t from = L4_nilthread;
-        L4_Receive(from, &from);
+        L4_ThreadId_t from;
+        L4_MsgTag_t tag = L4_Wait(&from);
+        L4_Word_t label = L4_Label(tag);
+        L4_Word_t res = 0;
+
+        if (label == static_cast<L4_Word_t>(VfsLabel::Mkfifo))
+            res = handle_mkfifo();
+
+        L4_Msg_t reply;
+        L4_MsgClear(&reply);
+        L4_MsgAppendWord(&reply, res);
+        L4_Set_MsgLabel(&reply, label);
+        L4_MsgLoad(&reply);
         L4_Reply(from);
     }
     return 0;


### PR DESCRIPTION
## Summary
- extend `libposix` with fifo-capable mkfifo/open/read/write/dup/close
- implement a small fifo store in the VFS server
- build new `fifo_test` app and run it as part of the POSIX tests
- mention the new test binary in docs

## Testing
- `pytest -q`