### PR TITLE
Add networking helpers to libposix

### DIFF
--- a/docs/posix_compatibility.md
+++ b/docs/posix_compatibility.md
@@ -65,3 +65,11 @@ applications.
 
 Full copies of the POSIX specification are available under `docs/ben-books`. The `susv4-2018` HTML tree contains the Single UNIX Specification, version 4 (2018). Consult these documents when implementing system calls or verifying behaviour.
 
+## Networking Helpers
+
+`libposix` currently exposes a few networking wrappers for convenience.
+`posix_setsockopt()` and `posix_getsockopt()` merely delegate to the host
+implementation.  Helper functions `posix_inet_pton()` and
+`posix_inet_ntop()` convert between text addresses and their binary forms.
+In the future these calls will forward requests to a user-level network stack.
+

--- a/user/lib/posix/Makefile.in
+++ b/user/lib/posix/Makefile.in
@@ -5,6 +5,6 @@ top_builddir=@top_builddir@
 include $(top_srcdir)/Mk/l4.base.mk
 
 LIBRARY=posix
-SRCS=posix.cc
+SRCS=posix.cc network.c
 
 include $(top_srcdir)/Mk/l4.lib.mk

--- a/user/lib/posix/network.c
+++ b/user/lib/posix/network.c
@@ -1,0 +1,25 @@
+#include "posix.h"
+#include <sys/socket.h>
+#include <arpa/inet.h>
+
+int posix_setsockopt(int sockfd, int level, int optname,
+                     const void *optval, socklen_t optlen)
+{
+    return setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+int posix_getsockopt(int sockfd, int level, int optname,
+                     void *optval, socklen_t *optlen)
+{
+    return getsockopt(sockfd, level, optname, optval, optlen);
+}
+
+int posix_inet_pton(int af, const char *src, void *dst)
+{
+    return inet_pton(af, src, dst);
+}
+
+const char *posix_inet_ntop(int af, const void *src, char *dst, socklen_t size)
+{
+    return inet_ntop(af, src, dst, size);
+}

--- a/user/lib/posix/posix.h
+++ b/user/lib/posix/posix.h
@@ -13,6 +13,17 @@ ssize_t posix_read(int fd, void *buf, size_t count);
 ssize_t posix_write(int fd, const void *buf, size_t count);
 pid_t posix_fork(void);
 
+/* Socket option helpers */
+int posix_setsockopt(int fd, int level, int optname,
+                     const void *optval, socklen_t optlen);
+int posix_getsockopt(int fd, int level, int optname,
+                     void *optval, socklen_t *optlen);
+
+/* Internet address conversion helpers */
+int posix_inet_pton(int af, const char *src, void *dst);
+const char *posix_inet_ntop(int af, const void *src,
+                             char *dst, socklen_t size);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- expose socket option functions and address conversions in libposix
- build new `network.c` into the posix library
- document networking helpers in the POSIX compatibility notes

## Testing
- `make` *(fails: missing separator - environment lacks build setup)*