### PR TITLE
Add memory API demos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,19 +16,19 @@ all: build/string.o
 .PHONY: all clean check tests
 
 build/tests:
-        mkdir -p build/tests
+	mkdir -p build/tests
 
 build/tests/posix:
-        mkdir -p build/tests/posix
+	mkdir -p build/tests/posix
 
 build/tests/spinlock_fairness: tests/spinlock_fairness.c | build/tests
-        $(CC) $(CFLAGS) -pthread $< -o $@
+	$(CC) $(CFLAGS) -pthread $< -o $@
 
 build/tests/posix/test_file: tests/posix/test_file.c | build/tests/posix
-        $(CC) $(CFLAGS) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
 build/tests/posix/test_process: tests/posix/test_process.c | build/tests/posix
-        $(CC) $(CFLAGS) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
 tests: build/tests/spinlock_fairness build/tests/posix/test_file build/tests/posix/test_process
 
@@ -37,7 +37,7 @@ clean:
 	find . -name '*.o' -delete
 
 check: all tests
-        python -m unittest discover -v tests
-        ./build/tests/spinlock_fairness
-        ./build/tests/posix/test_file
-        ./build/tests/posix/test_process
+	python -m unittest discover -v tests
+	./build/tests/spinlock_fairness
+	./build/tests/posix/test_file
+	./build/tests/posix/test_process

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -9,6 +9,7 @@ class CompilerAttributeTest(unittest.TestCase):
         code = textwrap.dedent(
             """
             #include <l4/compiler.h>
+            #include <l4/memory.h>
 
             void L4_CDECL cdecl_fn(int) {}
             void L4_FASTCALL fast_fn(int, int) {}
@@ -20,6 +21,8 @@ class CompilerAttributeTest(unittest.TestCase):
                 p1 a = cdecl_fn;
                 p2 b = fast_fn;
                 (void)a; (void)b;
+                L4_ThreadId_t ms = memory_server();
+                (void)memory_alloc(ms, 256);
                 return 0;
             }
             """

--- a/tests/test_i16_build.py
+++ b/tests/test_i16_build.py
@@ -6,7 +6,13 @@ import unittest
 ROOT = Path(__file__).resolve().parents[1]
 CODE = r"""
 #include <l4/types.h>
+#include <l4/memory.h>
 static_assert(sizeof(L4_Word_t) > 0);
+int main() {
+    L4_ThreadId_t ms = memory_server();
+    (void)memory_alloc(ms, 64);
+    return 0;
+}
 """
 
 class I16CompilationTest(unittest.TestCase):

--- a/tests/test_ipc_helpers.py
+++ b/tests/test_ipc_helpers.py
@@ -7,9 +7,13 @@ ROOT = Path(__file__).resolve().parents[1]
 CODE = r"""
 #include <l4/exo_ipc.h>
 #include <l4/ipc.h>
+#include <l4/memory.h>
+
 int main() {
     exo_ipc_status st = exo_call(L4_nilthread);
     (void)st;
+    L4_ThreadId_t ms = memory_server();
+    (void)memory_alloc(ms, 4096);
     return 0;
 }
 """

--- a/tests/test_mlp_scheduler_build.py
+++ b/tests/test_mlp_scheduler_build.py
@@ -6,9 +6,12 @@ import unittest
 ROOT = Path(__file__).resolve().parents[1]
 CODE = r"""
 #include "../../user/lib/mlp/mlp.h"
+#include <l4/memory.h>
 int main() {
     float f[1] = {0};
     mlp_init(nullptr);
+    L4_ThreadId_t ms = memory_server();
+    (void)memory_alloc(ms, 1024);
     return mlp_predict(f);
 }
 """

--- a/tests/test_types_size.py
+++ b/tests/test_types_size.py
@@ -6,10 +6,16 @@ import unittest
 ROOT = Path(__file__).resolve().parents[1]
 CODE = r"""
 #include <l4/types.h>
+#include <l4/memory.h>
 static_assert(sizeof(L4_Fpage_t) == sizeof(L4_Word_t));
 static_assert(sizeof(L4_ThreadId_t) == sizeof(L4_Word_t));
 static_assert(sizeof(L4_Clock_t) == sizeof(L4_Word64_t));
 static_assert(sizeof(L4_Time_t) == sizeof(L4_Word_t));
+int main() {
+    L4_ThreadId_t ms = memory_server();
+    (void)memory_alloc(ms, 128);
+    return 0;
+}
 """
 
 class TypeSizeCompilationTest(unittest.TestCase):

--- a/user/apps/Makefile.in
+++ b/user/apps/Makefile.in
@@ -36,7 +36,7 @@ top_builddir=	@top_builddir@
 include $(top_srcdir)/Mk/l4.base.mk
 
 
-SUBDIRS=	bench grabmem l4test
+SUBDIRS=	bench grabmem l4test memdemo
 
 
 include $(top_srcdir)/Mk/l4.subdir.mk

--- a/user/apps/memdemo/Makefile.in
+++ b/user/apps/memdemo/Makefile.in
@@ -1,0 +1,25 @@
+######################################################################
+##
+## Simple memory demo program
+##
+######################################################################
+
+srcdir=         @srcdir@
+top_srcdir=     @top_srcdir@
+top_builddir=   @top_builddir@
+
+include $(top_srcdir)/Mk/l4.base.mk
+
+PROGRAM=        memdemo
+PROGRAM_DEPS=   $(top_builddir)/lib/l4/libl4.a \
+                $(top_builddir)/lib/io/libio.a
+
+SRCS=           crt0-$(ARCH).S memdemo.cc
+
+LIBS+=          -ll4 -lio
+LDFLAGS+=       -Ttext=$(ROOTTASK_LINKBASE)
+
+CFLAGS_powerpc+=        -fno-builtin -msoft-float
+CXXFLAGS_powerpc+=      -fno-rtti
+
+include $(top_srcdir)/Mk/l4.prog.mk

--- a/user/apps/memdemo/crt0-amd64.S
+++ b/user/apps/memdemo/crt0-amd64.S
@@ -1,0 +1,72 @@
+/*********************************************************************
+ *                
+ * Copyright (C) 1999-2010,  Karlsruhe University
+ *                
+ * File path:     grabmem/crt0-amd64.S
+ * Description:   
+ *                
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *                
+ * $Id$
+ *                
+ ********************************************************************/
+	.text
+	.global _start
+	.global _stext
+_stext:	
+_start:
+	/* Set sp */
+	leaq	__stack, %rsp
+	/* Push mbi values */
+	pushq	%rbx	/* mbi ptr	*/
+	pushq	%rax	/* mb magic	*/
+
+	/* Initialize Syscalls */
+	callq	__L4_Init
+	
+	/* Return address */
+	pushq	$___return_from_main
+	jmp	main
+
+#if 1
+	.align 16, 0x90
+__mb_header:
+	.long   0x1BADB002;
+	.long   0x00010000;
+	.long   - 0x00010000 - 0x1BADB002;
+	.long   __mb_header;
+	.long   _start;
+	.long   _edata;
+	.long   _end;
+	.long   _start;
+#endif
+	
+___return_from_main:
+	int $3
+	jmp 1f
+	.ascii "System stopped."
+1:	jmp ___return_from_main
+		
+	.bss
+
+	.space	1024
+__stack:

--- a/user/apps/memdemo/crt0-ia32.S
+++ b/user/apps/memdemo/crt0-ia32.S
@@ -1,0 +1,53 @@
+/*********************************************************************
+ *                
+ * Copyright (C) 2003,  Karlsruhe University
+ *                
+ * File path:     roottask/crt0-ia32.S
+ * Description:   Startup code for x86 family processors.
+ *                
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *                
+ * $Id: crt0-ia32.S,v 1.1 2003/10/01 16:45:39 skoglund Exp $
+ *                
+ ********************************************************************/
+#include <config.h>
+
+	.text
+	.global _start
+	.global _stext
+_stext:	
+_start:
+0:	leal	stack, %esp
+	pushl	$___return_from_main
+	jmp	main
+	
+___return_from_main:
+	int $3
+	jmp 1f
+	.ascii "System stopped."
+1:	jmp ___return_from_main
+		
+	.bss
+
+	.align	16
+	.space	4096 * 2
+stack:

--- a/user/apps/memdemo/crt0-powerpc.S
+++ b/user/apps/memdemo/crt0-powerpc.S
@@ -1,0 +1,73 @@
+/****************************************************************************
+ *
+ * Copyright (C) 2002-2003, Karlsruhe University
+ *
+ * File path:	apps/l4test/powerpc/crt0.S
+ * Description:	PowerPC startup code for l4test.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $Id: crt0-powerpc.S,v 1.1 2003/10/21 04:54:08 benno Exp $
+ *
+ ***************************************************************************/
+
+	.section ".data"
+	.align	2
+	.globl	_l4_utcb
+_l4_utcb:
+	.long	0
+
+	.section ".text"
+	.align	2
+	.globl	_start
+_start:
+	/* Install our stack. */
+	lis	%r1, _sigma0_stack_top@ha
+	la	%r1, _sigma0_stack_top@l(%r1)
+	addi	%r1, %r1, -16
+
+	/* Point to 0 for the small data area. */
+	li	%r13, 0
+
+	/* Save the utcb pointer handed us by the kernel in r2. */
+	lis	%r10, _l4_utcb@ha
+	la	%r10, _l4_utcb@l(%r10)
+	stw	%r2, 0(%r10)
+
+	bl	__L4_Init
+
+	/* Jump into C code. */
+	bl	main
+
+1:	b	1b	/* Spin. */
+
+/****************************************************************************/
+
+	.section ".bss"
+	.globl _sigma0_stack_bottom
+	.globl _sigma0_stack_top
+
+#define SIGMA0_STACK_SIZE	(4096*2)
+_sigma0_stack_bottom:
+.lcomm	_sigma0_stack, SIGMA0_STACK_SIZE, 16
+_sigma0_stack_top:
+

--- a/user/apps/memdemo/crt0-powerpc64.S
+++ b/user/apps/memdemo/crt0-powerpc64.S
@@ -1,0 +1,79 @@
+/****************************************************************************
+ *
+ * Copyright (C) 2002-2003, University of New South Wales
+ *
+ * File path:	user/serv/sigma0/crt0-powerpc64.S
+ * Description:	PowerPC64 startup code for Sigma 0.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $Id: crt0-powerpc64.S,v 1.3 2005/01/21 06:02:21 cvansch Exp $
+ *
+ ***************************************************************************/
+
+#include <l4/powerpc64/asm.h>
+
+
+	.section ".text"
+	.align	2
+	.globl	_start
+_start:
+	/* Install our stack. */
+	LD_ADDR(%r1, _sigma0_stack_top)
+	addi	%r1, %r1, -64
+
+	/* Load the TOC. */
+	LD_ADDR(%r10, __L4_Init)
+	ld	%r2, 8(%r10)
+
+	/* Zero bss */
+	LD_ADDR(%r10, __bss_start)
+	LD_ADDR(%r11, _end)
+	subi	%r10, %r10, 4
+	subi	%r11, %r11, 4
+
+	li	%r12, 0
+1:	cmp	0, %r10, %r11
+	beq	2f
+	stwu	%r12, 4(%r10)
+	b	1b
+2:
+
+	bl	.__L4_Init
+
+	/* Jump into C code. */
+	bl	.main
+
+	.long	0x00000000
+1:	b	1b	/* Spin. */
+
+/****************************************************************************/
+
+	.section ".bss"
+	.globl _sigma0_stack_bottom
+	.globl _sigma0_stack_top
+
+#define SIGMA0_STACK_SIZE	(4096*4)
+_sigma0_stack_bottom:
+.lcomm	_sigma0_stack, SIGMA0_STACK_SIZE, 16
+_sigma0_stack_top:
+

--- a/user/apps/memdemo/memdemo.cc
+++ b/user/apps/memdemo/memdemo.cc
@@ -1,0 +1,42 @@
+#include <l4io.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <string.h>
+#include <stdio.h>
+
+int main(void)
+{
+    const char *fname = "memdemo.tmp";
+    int fd = open(fname, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        perror("open");
+        return 1;
+    }
+
+    size_t ps = (size_t)getpagesize();
+    if (ftruncate(fd, ps) < 0) {
+        perror("ftruncate");
+        close(fd);
+        return 1;
+    }
+
+    char *p = (char *)mmap(NULL, ps, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (p == MAP_FAILED) {
+        perror("mmap");
+        close(fd);
+        return 1;
+    }
+
+    strcpy(p, "hello world\n");
+    if (msync(p, ps, MS_SYNC) < 0)
+        perror("msync");
+    if (mprotect(p, ps, PROT_READ) < 0)
+        perror("mprotect");
+
+    munmap(p, ps);
+    close(fd);
+    unlink(fname);
+    printf("memory demo done\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- update compatibility build tests to exercise new memory APIs
- add a simple memdemo program showing mprotect/msync usage

## Testing
- `pre-commit` *(fails: No module named pre_commit)*
- `make check`