### PR TITLE
Add mprotect/msync wrappers to POSIX lib

### DIFF
--- a/docs/posix_compatibility.md
+++ b/docs/posix_compatibility.md
@@ -1,4 +1,4 @@
-# POSIX Compatibility Layer
+#POSIX Compatibility Layer
 
 Pistachio's exokernel exposes only primitive operations such as threads, IPC and
 address spaces.  Traditional UNIX functionality therefore lives entirely in
@@ -65,3 +65,11 @@ applications.
 
 Full copies of the POSIX specification are available under `docs/ben-books`. The `susv4-2018` HTML tree contains the Single UNIX Specification, version 4 (2018). Consult these documents when implementing system calls or verifying behaviour.
 
+### Memory helpers
+
+`libposix` provides lightweight wrappers for a few memory management calls. The
+`posix_mprotect()` function forwards to the host `mprotect(2)` implementation and
+updates an internal table that records the protection flags of every page it
+operates on. `posix_msync()` simply invokes the host `msync(2)` to flush any
+modified pages. This bookkeeping allows future components to query the current
+permissions without scanning page tables.

--- a/user/lib/posix/posix.cc
+++ b/user/lib/posix/posix.cc
@@ -1,28 +1,84 @@
 #include "posix.h"
+#include <cstdint>
 #include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/types.h>
 #include <unistd.h>
+#include <unordered_map>
+
+// Keep track of the protection flags for every page that has been mapped
+// through the POSIX helpers. The key is the page aligned address.
+static std::unordered_map<void *, int> page_prot;
+static long page_size = 0;
+
+static long get_page_size() {
+  if (!page_size)
+    page_size = sysconf(_SC_PAGESIZE);
+  return page_size;
+}
+
+static void remember_prot(void *addr, size_t len, int prot) {
+  long ps = get_page_size();
+  uintptr_t start =
+      (reinterpret_cast<uintptr_t>(addr) & ~(static_cast<uintptr_t>(ps) - 1));
+  uintptr_t end = (reinterpret_cast<uintptr_t>(addr) + len + ps - 1) &
+                  ~(static_cast<uintptr_t>(ps) - 1);
+  for (uintptr_t p = start; p < end; p += ps)
+    page_prot[reinterpret_cast<void *>(p)] = prot;
+}
+
+static void forget_prot(void *addr, size_t len) {
+  long ps = get_page_size();
+  uintptr_t start =
+      (reinterpret_cast<uintptr_t>(addr) & ~(static_cast<uintptr_t>(ps) - 1));
+  uintptr_t end = (reinterpret_cast<uintptr_t>(addr) + len + ps - 1) &
+                  ~(static_cast<uintptr_t>(ps) - 1);
+  for (uintptr_t p = start; p < end; p += ps)
+    page_prot.erase(reinterpret_cast<void *>(p));
+}
+
+// Map memory and record its initial protection flags. Currently this simply
+// forwards to the host mmap implementation.
+static void *tracked_mmap(void *addr, size_t length, int prot, int flags,
+                          int fd, off_t offset) {
+  void *ret = mmap(addr, length, prot, flags, fd, offset);
+  if (ret != MAP_FAILED)
+    remember_prot(ret, length, prot);
+  return ret;
+}
+
+static int tracked_munmap(void *addr, size_t length) {
+  int r = munmap(addr, length);
+  if (r == 0)
+    forget_prot(addr, length);
+  return r;
+}
 
 // These stub implementations directly invoke the host system calls.
 // Future versions will forward requests to user-level servers using
 // the exokernel IPC helpers.
 
-int posix_open(const char *path, int flags, unsigned mode)
-{
-    return open(path, flags, mode);
+int posix_open(const char *path, int flags, unsigned mode) {
+  return open(path, flags, mode);
 }
 
-ssize_t posix_read(int fd, void *buf, size_t count)
-{
-    return read(fd, buf, count);
+ssize_t posix_read(int fd, void *buf, size_t count) {
+  return read(fd, buf, count);
 }
 
-ssize_t posix_write(int fd, const void *buf, size_t count)
-{
-    return write(fd, buf, count);
+ssize_t posix_write(int fd, const void *buf, size_t count) {
+  return write(fd, buf, count);
 }
 
-pid_t posix_fork(void)
-{
-    return fork();
+pid_t posix_fork(void) { return fork(); }
+
+int posix_mprotect(void *addr, size_t len, int prot) {
+  int ret = mprotect(addr, len, prot);
+  if (ret == 0)
+    remember_prot(addr, len, prot);
+  return ret;
 }
 
+int posix_msync(void *addr, size_t len, int flags) {
+  return msync(addr, len, flags);
+}

--- a/user/lib/posix/posix.h
+++ b/user/lib/posix/posix.h
@@ -12,6 +12,8 @@ int posix_open(const char *path, int flags, unsigned mode);
 ssize_t posix_read(int fd, void *buf, size_t count);
 ssize_t posix_write(int fd, const void *buf, size_t count);
 pid_t posix_fork(void);
+int posix_mprotect(void *addr, size_t len, int prot);
+int posix_msync(void *addr, size_t len, int flags);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- store protection flags for POSIX memory pages
- provide mprotect/msync wrappers in the POSIX library
- document new helpers in the POSIX compatibility guide

## Testing
- `pre-commit run --files user/lib/posix/posix.cc user/lib/posix/posix.h docs/posix_compatibility.md` *(fails: command not found)*
- `cmake -S . -B build`
- `cmake --build build` *(fails: missing Eigen for mlp)*
- `clang-tidy user/lib/posix/posix.cc -- -Iuser/include`