### PR TITLE
Add minimal pthread stub library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,24 +11,30 @@ build/string.o: user/contrib/elf-loader/platform/amd64-pc99/string.cc
 	mkdir -p build
 	g++ $(CXXFLAGS) -Iuser/include -Iuser/contrib/elf-loader/include -c $< -o $@
 
-all: build/string.o
+all: build/string.o build/libpthread.a
 
 .PHONY: all clean check tests
 
 build/tests:
-        mkdir -p build/tests
+	mkdir -p build/tests
 
 build/tests/posix:
-        mkdir -p build/tests/posix
+	mkdir -p build/tests/posix
 
 build/tests/spinlock_fairness: tests/spinlock_fairness.c | build/tests
-        $(CC) $(CFLAGS) -pthread $< -o $@
+	$(CC) $(CFLAGS) -pthread $< -o $@
 
 build/tests/posix/test_file: tests/posix/test_file.c | build/tests/posix
-        $(CC) $(CFLAGS) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
 build/tests/posix/test_process: tests/posix/test_process.c | build/tests/posix
-        $(CC) $(CFLAGS) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
+build/pthread.o: user/lib/pthread/pthread.cc
+	mkdir -p build
+	g++ $(CXXFLAGS) -Iuser/include -c $< -o $@
+		
+build/libpthread.a: build/pthread.o
+	ar rcs $@ $^
 
 tests: build/tests/spinlock_fairness build/tests/posix/test_file build/tests/posix/test_process
 
@@ -37,7 +43,7 @@ clean:
 	find . -name '*.o' -delete
 
 check: all tests
-        python -m unittest discover -v tests
-        ./build/tests/spinlock_fairness
-        ./build/tests/posix/test_file
-        ./build/tests/posix/test_process
+	python -m unittest discover -v tests
+	./build/tests/spinlock_fairness
+	./build/tests/posix/test_file
+	./build/tests/posix/test_process

--- a/docs/posix_compatibility.md
+++ b/docs/posix_compatibility.md
@@ -61,6 +61,11 @@ By layering the POSIX subsystem on top of the exokernel's primitives, the kernel
 remains small while user-level servers provide the rich API expected by
 applications.
 
+## Threading Support
+
+`libpthread` offers a very small subset of the POSIX threads interface.  Only
+`pthread_create()` and `pthread_join()` merely execute the start routine synchronously in the calling thread. Mutex functions exist only as stubs and provide no mutual exclusion. Condition variables and the rest of the API are unimplemented.
+
 ## Reference Specification
 
 Full copies of the POSIX specification are available under `docs/ben-books`. The `susv4-2018` HTML tree contains the Single UNIX Specification, version 4 (2018). Consult these documents when implementing system calls or verifying behaviour.

--- a/user/include/pthread.h
+++ b/user/include/pthread.h
@@ -1,0 +1,30 @@
+#ifndef PISTACHIO_PTHREAD_H
+#define PISTACHIO_PTHREAD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    void *impl;
+} pthread_t;
+
+typedef int pthread_attr_t;
+typedef struct { int unused; } pthread_mutex_t;
+typedef int pthread_mutexattr_t;
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *arg);
+int pthread_join(pthread_t thread, void **retval);
+
+int pthread_mutex_init(pthread_mutex_t *mutex,
+                       const pthread_mutexattr_t *attr);
+int pthread_mutex_lock(pthread_mutex_t *mutex);
+int pthread_mutex_unlock(pthread_mutex_t *mutex);
+int pthread_mutex_destroy(pthread_mutex_t *mutex);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PISTACHIO_PTHREAD_H

--- a/user/lib/Makefile.in
+++ b/user/lib/Makefile.in
@@ -36,7 +36,7 @@ top_builddir=	@top_builddir@
 include $(top_srcdir)/Mk/l4.base.mk
 
 
-SUBDIRS=      l4 io memory ipc sched mlp posix
+SUBDIRS=      l4 io memory ipc sched mlp posix pthread
 
 post-clean:
 	rm -f *.a

--- a/user/lib/pthread/Makefile.in
+++ b/user/lib/pthread/Makefile.in
@@ -1,0 +1,10 @@
+srcdir=@srcdir@
+top_srcdir=@top_srcdir@
+top_builddir=@top_builddir@
+
+include $(top_srcdir)/Mk/l4.base.mk
+
+LIBRARY=pthread
+SRCS=pthread.cc
+
+include $(top_srcdir)/Mk/l4.lib.mk

--- a/user/lib/pthread/pthread.cc
+++ b/user/lib/pthread/pthread.cc
@@ -1,0 +1,39 @@
+#include <pthread.h>
+
+extern "C" {
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *,
+                   void *(*start_routine)(void *), void *arg)
+{
+    thread->impl = start_routine(arg);
+    return 0;
+}
+
+int pthread_join(pthread_t thread, void **retval)
+{
+    if (retval)
+        *retval = thread.impl;
+    return 0;
+}
+
+int pthread_mutex_init(pthread_mutex_t *, const pthread_mutexattr_t *)
+{
+    return 0;
+}
+
+int pthread_mutex_lock(pthread_mutex_t *)
+{
+    return 0;
+}
+
+int pthread_mutex_unlock(pthread_mutex_t *)
+{
+    return 0;
+}
+
+int pthread_mutex_destroy(pthread_mutex_t *)
+{
+    return 0;
+}
+
+} // extern "C"


### PR DESCRIPTION
## Summary
- implement a tiny pthread library in `user/lib/pthread`
- expose `<pthread.h>` in `user/include`
- document limited pthread support
- compile the library from the top-level Makefile

## Testing
- `make all`
- `make check`