### PR TITLE
Add nanosleep timer test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,5 @@ add_subdirectory(tools/memserver)
 
 add_custom_target(default_all ALL DEPENDS string_obj kernel_target userlib_target memserver_tool)
 
-add_executable(spinlock_fairness tests/spinlock_fairness.c)
-target_link_libraries(spinlock_fairness PRIVATE pthread)
-
-add_executable(posix_test_file tests/posix/test_file.c)
-add_executable(posix_test_process tests/posix/test_process.c)
-
-add_custom_target(tests DEPENDS spinlock_fairness posix_test_file posix_test_process)
+add_subdirectory(tests)
 

--- a/Makefile
+++ b/Makefile
@@ -16,28 +16,32 @@ all: build/string.o
 .PHONY: all clean check tests
 
 build/tests:
-        mkdir -p build/tests
+	        mkdir -p build/tests
 
 build/tests/posix:
-        mkdir -p build/tests/posix
+	        mkdir -p build/tests/posix
 
 build/tests/spinlock_fairness: tests/spinlock_fairness.c | build/tests
-        $(CC) $(CFLAGS) -pthread $< -o $@
+	        $(CC) $(CFLAGS) -pthread $< -o $@
 
 build/tests/posix/test_file: tests/posix/test_file.c | build/tests/posix
-        $(CC) $(CFLAGS) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
 build/tests/posix/test_process: tests/posix/test_process.c | build/tests/posix
-        $(CC) $(CFLAGS) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
-tests: build/tests/spinlock_fairness build/tests/posix/test_file build/tests/posix/test_process
+build/tests/posix/test_timer: tests/posix/test_timer.c | build/tests/posix
+	$(CC) $(CFLAGS) $< -o $@
+
+tests: build/tests/spinlock_fairness build/tests/posix/test_file build/tests/posix/test_process build/tests/posix/test_timer
 
 clean:
 	rm -rf build
 	find . -name '*.o' -delete
 
 check: all tests
-        python -m unittest discover -v tests
-        ./build/tests/spinlock_fairness
-        ./build/tests/posix/test_file
-        ./build/tests/posix/test_process
+	python -m unittest discover -v tests
+	./build/tests/spinlock_fairness
+	./build/tests/posix/test_file
+	./build/tests/posix/test_process
+	./build/tests/posix/test_timer

--- a/docs/building.md
+++ b/docs/building.md
@@ -229,6 +229,7 @@ $ cmake --build . --target tests
 ./spinlock_fairness
 ./posix_test_file
 ./posix_test_process
+./posix_test_timer
 ```
 
 The `spinlock_fairness` binary spawns multiple threads, measures how many times

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(spinlock_fairness spinlock_fairness.c)
+target_link_libraries(spinlock_fairness PRIVATE pthread)
+
+add_executable(posix_test_file posix/test_file.c)
+add_executable(posix_test_process posix/test_process.c)
+add_executable(posix_test_timer posix/test_timer.c)
+
+add_custom_target(tests DEPENDS spinlock_fairness posix_test_file posix_test_process posix_test_timer)

--- a/tests/posix/test_timer.c
+++ b/tests/posix/test_timer.c
@@ -1,0 +1,35 @@
+#define _POSIX_C_SOURCE 200809L
+#include <errno.h>
+#include <stdio.h>
+#include <time.h>
+
+int main(void) {
+    struct timespec req = {0};
+    req.tv_sec = 0;
+    req.tv_nsec = 100000000; // 100 ms
+    struct timespec start, end;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
+        perror("clock_gettime");
+        return 1;
+    }
+    if (nanosleep(&req, NULL) != 0) {
+        perror("nanosleep");
+        return 1;
+    }
+    if (clock_gettime(CLOCK_MONOTONIC, &end) != 0) {
+        perror("clock_gettime");
+        return 1;
+    }
+
+    long elapsed_ms = (end.tv_sec - start.tv_sec) * 1000;
+    elapsed_ms += (end.tv_nsec - start.tv_nsec) / 1000000;
+
+    if (elapsed_ms < 50 || elapsed_ms > 200) {
+        fprintf(stderr, "nanosleep duration out of range: %ldms\n", elapsed_ms);
+        return 1;
+    }
+
+    puts("timer test ok");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add new POSIX timer test exercising nanosleep
- build tests from dedicated `tests/CMakeLists.txt`
- integrate timer test into Makefile and docs

## Testing
- `cmake -S . -B build_cmake`
- `cmake --build build_cmake --target tests`
- `python -m unittest discover -v tests`
- `make tests`