### PR TITLE
Add nanosleep and timer tracking

### DIFF
--- a/docs/posix_compatibility.md
+++ b/docs/posix_compatibility.md
@@ -65,3 +65,16 @@ applications.
 
 Full copies of the POSIX specification are available under `docs/ben-books`. The `susv4-2018` HTML tree contains the Single UNIX Specification, version 4 (2018). Consult these documents when implementing system calls or verifying behaviour.
 
+## Timers and Sleeping
+
+The library implements a simple `nanosleep()` wrapper that records active
+timers within the process.  Each call registers a timer entry with the expected
+expiration time, invokes the host `nanosleep(2)` system call and removes the
+entry once the sleep completes.  The helper `posix_timer_count()` exposes the
+current number of active timers.
+
+```c
+struct timespec req = { .tv_sec = 0, .tv_nsec = 50000000 };
+posix_nanosleep(&req, NULL);
+```
+

--- a/user/lib/posix/posix.cc
+++ b/user/lib/posix/posix.cc
@@ -1,10 +1,33 @@
 #include "posix.h"
 #include <fcntl.h>
 #include <unistd.h>
+#include <errno.h>
+#include <time.h>
+#include <vector>
+#include <algorithm>
 
 // These stub implementations directly invoke the host system calls.
 // Future versions will forward requests to user-level servers using
 // the exokernel IPC helpers.
+
+using timer_vec = std::vector<posix_timer*>;
+static timer_vec timers;
+
+void _posix_timer_register(posix_timer *t)
+{
+    timers.push_back(t);
+}
+
+void _posix_timer_unregister(posix_timer *t)
+{
+    auto it = std::remove(timers.begin(), timers.end(), t);
+    timers.erase(it, timers.end());
+}
+
+size_t posix_timer_count(void)
+{
+    return timers.size();
+}
 
 int posix_open(const char *path, int flags, unsigned mode)
 {
@@ -24,5 +47,29 @@ ssize_t posix_write(int fd, const void *buf, size_t count)
 pid_t posix_fork(void)
 {
     return fork();
+}
+
+int posix_nanosleep(const struct timespec *req, struct timespec *rem)
+{
+    if (!req)
+        return -1;
+
+    posix_timer t;
+    clock_gettime(CLOCK_MONOTONIC, &t.expiry);
+    t.expiry.tv_sec += req->tv_sec;
+    t.expiry.tv_nsec += req->tv_nsec;
+    if (t.expiry.tv_nsec >= 1000000000L) {
+        t.expiry.tv_sec += 1;
+        t.expiry.tv_nsec -= 1000000000L;
+    }
+    _posix_timer_register(&t);
+
+    int ret;
+    do {
+        ret = nanosleep(req, rem);
+    } while (ret < 0 && errno == EINTR);
+
+    _posix_timer_unregister(&t);
+    return ret;
 }
 

--- a/user/lib/posix/posix.h
+++ b/user/lib/posix/posix.h
@@ -13,6 +13,18 @@ ssize_t posix_read(int fd, void *buf, size_t count);
 ssize_t posix_write(int fd, const void *buf, size_t count);
 pid_t posix_fork(void);
 
+struct timespec;
+
+typedef struct posix_timer {
+    struct timespec expiry;
+} posix_timer;
+
+void _posix_timer_register(posix_timer *t);
+void _posix_timer_unregister(posix_timer *t);
+size_t posix_timer_count(void);
+
+int posix_nanosleep(const struct timespec *req, struct timespec *rem);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- implement nanosleep wrapper
- add per-process timer bookkeeping helpers
- document timer usage

## Testing
- `pytest -q`
- `pre-commit run --files user/lib/posix/posix.cc user/lib/posix/posix.h docs/posix_compatibility.md` *(fails: command not found)*