### PR TITLE
Add Meson build files for demo programs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,16 @@
+project('pistachio_demos', ['cpp', 'c'],
+    default_options: ['cpp_std=c++23', 'c_std=c23'])
+
+add_project_arguments('-Werror', language: ['c', 'cpp'])
+
+# Global include directories used by demos and libraries
+pistachio_inc = include_directories(
+    'include',
+    'user/include',
+    'user/contrib/elf-loader/include',
+    'third_party/eigen'
+)
+
+subdir('user/lib')
+subdir('user/serv')
+subdir('user/apps')

--- a/user/apps/bench/meson.build
+++ b/user/apps/bench/meson.build
@@ -1,0 +1,1 @@
+subdir('pingpong')

--- a/user/apps/bench/pingpong/meson.build
+++ b/user/apps/bench/pingpong/meson.build
@@ -1,0 +1,5 @@
+executable('pingpong',
+    'pingpong.cc',
+    'crt0-amd64.S',
+    include_directories: pistachio_inc,
+    dependencies: [l4_dep, io_dep])

--- a/user/apps/grabmem/meson.build
+++ b/user/apps/grabmem/meson.build
@@ -1,0 +1,5 @@
+executable('grabmem',
+    'grabmem.cc',
+    'crt0-amd64.S',
+    include_directories: pistachio_inc,
+    dependencies: [l4_dep, io_dep])

--- a/user/apps/l4test/meson.build
+++ b/user/apps/l4test/meson.build
@@ -1,0 +1,17 @@
+arch = 'amd64'
+arch_dir = join_paths(meson.current_source_dir(), arch)
+
+sources = files(
+    'main.cc', 'assert.cc', 'menu.cc', 'threads.cc', 'string.cc',
+    'ipc.cc', 'ipc-string.cc', 'ipc-pf.cc', 'ipc-smp.cc',
+    'kip.cc', 'mem.cc', 'sig0.cc', 'exreg.cc', 'tcontrol.cc',
+    'schedule.cc',
+    join_paths(arch, 'crt0.S'),
+    join_paths(arch, 'help.cc'),
+    join_paths(arch, 'tests.cc')
+)
+
+executable('l4test',
+    sources,
+    include_directories: [pistachio_inc, include_directories(arch)],
+    dependencies: [l4_dep, io_dep])

--- a/user/apps/meson.build
+++ b/user/apps/meson.build
@@ -1,0 +1,3 @@
+subdir('bench')
+subdir('grabmem')
+subdir('l4test')

--- a/user/lib/meson.build
+++ b/user/lib/meson.build
@@ -1,0 +1,42 @@
+userlib_inc = include_directories('.', '..', '../contrib/elf-loader/include')
+eigen_inc = include_directories('../../third_party/eigen')
+
+l4_lib = static_library('l4',
+    'l4/debug.cc',
+    'l4/amd64.cc',
+    include_directories: [userlib_inc, pistachio_inc]
+)
+l4_dep = declare_dependency(link_with: l4_lib, include_directories: [userlib_inc, pistachio_inc])
+
+io_lib = static_library('io',
+    'io/get_hex.cc',
+    'io/print.cc',
+    'io/amd64.cc',
+    include_directories: [userlib_inc, pistachio_inc]
+)
+io_dep = declare_dependency(link_with: io_lib, include_directories: [userlib_inc, pistachio_inc])
+
+ipc_lib = static_library('ipc',
+    'ipc/user_ipc.cc',
+    'exo/exo_ipc.cc',
+    include_directories: [userlib_inc, pistachio_inc]
+)
+ipc_dep = declare_dependency(link_with: ipc_lib, include_directories: [userlib_inc, pistachio_inc])
+
+memory_lib = static_library('memory',
+    'memory/memory.cc',
+    include_directories: [userlib_inc, pistachio_inc]
+)
+memory_dep = declare_dependency(link_with: memory_lib, include_directories: [userlib_inc, pistachio_inc])
+
+sched_lib = static_library('sched',
+    'sched/sched_client.cc',
+    include_directories: [userlib_inc, pistachio_inc]
+)
+sched_dep = declare_dependency(link_with: sched_lib, include_directories: [userlib_inc, pistachio_inc])
+
+mlp_lib = static_library('mlp',
+    'mlp/mlp.cc',
+    include_directories: [userlib_inc, pistachio_inc, eigen_inc]
+)
+mlp_dep = declare_dependency(link_with: mlp_lib, include_directories: [userlib_inc, pistachio_inc, eigen_inc])

--- a/user/serv/memory/meson.build
+++ b/user/serv/memory/meson.build
@@ -1,0 +1,4 @@
+executable('memory_server',
+    'memory.cc',
+    include_directories: pistachio_inc,
+    dependencies: [l4_dep, io_dep, memory_dep])

--- a/user/serv/meson.build
+++ b/user/serv/meson.build
@@ -1,0 +1,5 @@
+subdir('memory')
+subdir('process')
+subdir('scheduler')
+subdir('mlp_scheduler')
+subdir('vfs')

--- a/user/serv/mlp_scheduler/meson.build
+++ b/user/serv/mlp_scheduler/meson.build
@@ -1,0 +1,4 @@
+executable('mlp_scheduler_server',
+    'mlp_scheduler.cc',
+    include_directories: pistachio_inc,
+    dependencies: [l4_dep, io_dep, sched_dep, mlp_dep])

--- a/user/serv/process/meson.build
+++ b/user/serv/process/meson.build
@@ -1,0 +1,4 @@
+executable('process_server',
+    'process.cc',
+    include_directories: pistachio_inc,
+    dependencies: [l4_dep, io_dep])

--- a/user/serv/scheduler/meson.build
+++ b/user/serv/scheduler/meson.build
@@ -1,0 +1,4 @@
+executable('scheduler_server',
+    'scheduler.cc',
+    include_directories: pistachio_inc,
+    dependencies: [l4_dep, io_dep, sched_dep])

--- a/user/serv/vfs/meson.build
+++ b/user/serv/vfs/meson.build
@@ -1,0 +1,4 @@
+executable('vfs_server',
+    'vfs.cc',
+    include_directories: pistachio_inc,
+    dependencies: [l4_dep, io_dep])


### PR DESCRIPTION
## Summary
- add top-level `meson.build`
- provide Meson rules for user libraries
- add Meson build definitions for demo servers and apps

## Testing
- `pre-commit` *(fails: command not found)*
- `meson setup builddir` *(fails: command not found)*