### PR TITLE
Add IPC demo apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,9 @@ target_include_directories(string_obj PRIVATE
 add_subdirectory(kernel)
 add_subdirectory(src-userland/lib)
 add_subdirectory(tools/memserver)
+add_subdirectory(user/apps/ipc_demo)
 
-add_custom_target(default_all ALL DEPENDS string_obj kernel_target userlib_target memserver_tool)
+add_custom_target(default_all ALL DEPENDS string_obj kernel_target userlib_target memserver_tool ipc_demo_apps)
 
 add_executable(spinlock_fairness tests/spinlock_fairness.c)
 target_link_libraries(spinlock_fairness PRIVATE pthread)

--- a/user/apps/Makefile.in
+++ b/user/apps/Makefile.in
@@ -36,7 +36,7 @@ top_builddir=	@top_builddir@
 include $(top_srcdir)/Mk/l4.base.mk
 
 
-SUBDIRS=	bench grabmem l4test
+SUBDIRS=	bench grabmem l4test ipc_demo
 
 
 include $(top_srcdir)/Mk/l4.subdir.mk

--- a/user/apps/ipc_demo/CMakeLists.txt
+++ b/user/apps/ipc_demo/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(self_ipc self_ipc/main.cc)
+add_executable(typed_channel_demo typed_channel/main.cc)
+
+target_include_directories(self_ipc PRIVATE
+    ${CMAKE_SOURCE_DIR}/user/include
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+target_include_directories(typed_channel_demo PRIVATE
+    ${CMAKE_SOURCE_DIR}/user/include
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+add_custom_target(ipc_demo_apps ALL DEPENDS self_ipc typed_channel_demo)

--- a/user/apps/ipc_demo/Makefile.in
+++ b/user/apps/ipc_demo/Makefile.in
@@ -1,0 +1,9 @@
+srcdir=@srcdir@
+top_srcdir=@top_srcdir@
+top_builddir=@top_builddir@
+
+include $(top_srcdir)/Mk/l4.base.mk
+
+SUBDIRS=self_ipc typed_channel
+
+include $(top_srcdir)/Mk/l4.subdir.mk

--- a/user/apps/ipc_demo/self_ipc/Makefile.in
+++ b/user/apps/ipc_demo/self_ipc/Makefile.in
@@ -1,0 +1,12 @@
+srcdir=@srcdir@
+top_srcdir=@top_srcdir@
+top_builddir=@top_builddir@
+
+include $(top_srcdir)/Mk/l4.base.mk
+
+PROGRAM=self_ipc
+PROGRAM_DEPS=$(top_builddir)/lib/l4/libl4.a $(top_builddir)/lib/io/libio.a
+SRCS=main.cc
+LIBS+=-ll4 -lio
+
+include $(top_srcdir)/Mk/l4.prog.mk

--- a/user/apps/ipc_demo/self_ipc/main.cc
+++ b/user/apps/ipc_demo/self_ipc/main.cc
@@ -1,0 +1,12 @@
+#include <l4/ipc.h>
+#include <stdio.h>
+
+int main() {
+    L4_MsgTag_t tag = L4_UserIpc(L4_Myself(), L4_nilthread,
+                                 L4_Timeouts(L4_Never, L4_Never), nullptr);
+    if (L4_IpcSucceeded(tag))
+        printf("self IPC succeeded\n");
+    else
+        printf("self IPC failed: %lu\n", L4_ErrorCode());
+    return 0;
+}

--- a/user/apps/ipc_demo/typed_channel/Makefile.in
+++ b/user/apps/ipc_demo/typed_channel/Makefile.in
@@ -1,0 +1,12 @@
+srcdir=@srcdir@
+top_srcdir=@top_srcdir@
+top_builddir=@top_builddir@
+
+include $(top_srcdir)/Mk/l4.base.mk
+
+PROGRAM=typed_channel_demo
+PROGRAM_DEPS=$(top_builddir)/lib/l4/libl4.a $(top_builddir)/lib/io/libio.a
+SRCS=main.cc
+LIBS+=-ll4 -lio
+
+include $(top_srcdir)/Mk/l4.prog.mk

--- a/user/apps/ipc_demo/typed_channel/main.cc
+++ b/user/apps/ipc_demo/typed_channel/main.cc
@@ -1,0 +1,11 @@
+#include <typed_channel.h>
+#include <stdio.h>
+
+int main() {
+    typed_channel_t ch;
+    typed_channel_init(&ch, L4_Myself());
+    L4_Word_t words[1] = {42};
+    exo_ipc_status st = typed_channel_send(&ch, words, 1);
+    printf("typed_channel_send returned %d\n", (int)st);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add simple IPC demo programs
- build demo apps via new CMake rules and hook into main build

## Testing
- `pytest -q`