### PR TITLE
Add capability-aware POSIX IPC stubs

### DIFF
--- a/user/lib/posix/Makefile.in
+++ b/user/lib/posix/Makefile.in
@@ -5,6 +5,6 @@ top_builddir=@top_builddir@
 include $(top_srcdir)/Mk/l4.base.mk
 
 LIBRARY=posix
-SRCS=posix.cc
+SRCS=posix.cc ipc.c
 
 include $(top_srcdir)/Mk/l4.lib.mk

--- a/user/lib/posix/ipc.c
+++ b/user/lib/posix/ipc.c
@@ -1,0 +1,25 @@
+#include "posix.h"
+#include <exo_ipc.h>
+
+/*
+ * These stubs simply forward to the exokernel IPC helpers.
+ * Real implementations will format requests and interpret replies
+ * according to the POSIX servers' protocols.
+ */
+
+int posix_mq_open_cap(L4_ThreadId_t cap)
+{
+    return exo_send(cap) == EXO_IPC_OK ? 0 : -1;
+}
+
+int posix_sem_open_cap(L4_ThreadId_t cap)
+{
+    return exo_send(cap) == EXO_IPC_OK ? 0 : -1;
+}
+
+int posix_shm_open_cap(L4_ThreadId_t cap)
+{
+    return exo_send(cap) == EXO_IPC_OK ? 0 : -1;
+}
+
+

--- a/user/lib/posix/posix.h
+++ b/user/lib/posix/posix.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <sys/types.h>
+#include <l4/thread.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +13,11 @@ int posix_open(const char *path, int flags, unsigned mode);
 ssize_t posix_read(int fd, void *buf, size_t count);
 ssize_t posix_write(int fd, const void *buf, size_t count);
 pid_t posix_fork(void);
+
+/* Capability aware IPC wrappers */
+int posix_mq_open_cap(L4_ThreadId_t cap);
+int posix_sem_open_cap(L4_ThreadId_t cap);
+int posix_shm_open_cap(L4_ThreadId_t cap);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- provide prototypes for capability aware wrappers in posix.h
- implement stub functions in `user/lib/posix/ipc.c`
- build new file in the posix library

## Testing
- `pre-commit run --files user/lib/posix/Makefile.in user/lib/posix/posix.h user/lib/posix/ipc.c` *(fails: `pre-commit: command not found`)*
- `make tests` *(fails: `missing separator`)*
