### PR TITLE
Add offline option to setup script

### DIFF
--- a/README
+++ b/README
@@ -98,6 +98,7 @@ formatters and linters such as **black**, **ruff**, **shellcheck** and
 `pip` and fetches the hook environments automatically.  Ensure the
 script runs while network access is available so required packages can
 be downloaded.  After cloning the repository you can re-install the
+You can also run the script offline by placing the required `.deb` files in `offline_packages/` and invoking `./setup.sh --offline`.
 hooks manually if desired::
 
     $ pre-commit install --install-hooks

--- a/offline_packages/README.md
+++ b/offline_packages/README.md
@@ -1,0 +1,14 @@
+# Offline Package Cache
+
+This directory can hold `.deb` packages for environments without
+network access.  When running `setup.sh --offline` the script installs
+all packages located here using `dpkg -i`.
+
+To gather the packages on a machine with network access you can use
+`apt-get download`::
+
+    $ apt-get download <package-name>
+
+Copy the resulting files into this folder along with any dependency
+packages.  The setup script does not resolve dependencies in offline
+mode so ensure all required `.deb` files are present.


### PR DESCRIPTION
## Summary
- support an `--offline` option in `setup.sh`
- install local `.deb` files from `offline_packages` when offline
- document how to populate the offline package cache
- describe offline mode usage in the main `README`

## Testing
- `bash -n setup.sh`
- `pip install pre-commit` *(fails: no network access)*