### PR TITLE
Add generic runqueue helpers

### DIFF
--- a/kernel/Mk/Makeconf
+++ b/kernel/Mk/Makeconf
@@ -138,7 +138,7 @@ endif
 UNDEFS	 += $(ARCH) $(CPU) $(PLATFORM) $(API) $(SCHED)
 DEFINES	 += __ARCH__=$(ARCH) __CPU__=$(CPU) __PLATFORM__=$(PLATFORM) \
 	    __API__=$(API) $(DEFINES_$(ARCH)) __SCHED__=$(SCHED)
-INCLUDES += $(BUILDDIR)/include $(SRCDIR)/src $(SRCDIR)/src/generic $(LIBGCCINC)
+INCLUDES += $(BUILDDIR)/include $(SRCDIR)/include $(SRCDIR)/src $(SRCDIR)/src/generic $(LIBGCCINC)
 
 
 ######################################################################

--- a/kernel/include/runqueue.h
+++ b/kernel/include/runqueue.h
@@ -1,0 +1,9 @@
+#ifndef __RUNQUEUE_H__
+#define __RUNQUEUE_H__
+
+#include INC_API(tcb.h)
+
+extern "C" void setrunqueue(tcb_t **head, tcb_t *tcb);
+extern "C" void remrq(tcb_t **head, tcb_t *tcb);
+
+#endif /* __RUNQUEUE_H__ */

--- a/kernel/src/api/v4/Makeconf
+++ b/kernel/src/api/v4/Makeconf
@@ -31,6 +31,7 @@
 ##                
 ######################################################################
 SOURCES += $(addprefix src/api/v4/, exregs.cc ipc.cc ipcx.cc kernelinterface.cc thread.cc schedule.cc space.cc interrupt.cc smp.cc processor.cc)
+SOURCES += src/runqueue.cc
 
 SOURCES += $(addprefix src/api/v4/sched-$(SCHED)/, schedule.cc)
 

--- a/kernel/src/api/v4/sched-hs/schedule.cc
+++ b/kernel/src/api/v4/sched-hs/schedule.cc
@@ -15,6 +15,7 @@
 #include INC_API(schedule.h)
 #include INC_API(interrupt.h)
 #include INC_API(queueing.h)
+#include <runqueue.h>
 #include INC_API(syscalls.h)
 #include INC_API(smp.h)
 #include INC_API(cpu.h)

--- a/kernel/src/api/v4/sched-rr/schedule.cc
+++ b/kernel/src/api/v4/sched-rr/schedule.cc
@@ -15,6 +15,7 @@
 #include INC_API(schedule.h)
 #include INC_API(interrupt.h)
 #include INC_API(queueing.h)
+#include <runqueue.h>
 #include INC_API(syscalls.h)
 #include INC_API(smp.h)
 #include INC_API(cpu.h)

--- a/kernel/src/api/v4/schedule.cc
+++ b/kernel/src/api/v4/schedule.cc
@@ -34,6 +34,7 @@
 #include INC_API(schedule.h)
 #include INC_API(interrupt.h)
 #include INC_API(queueing.h)
+#include <runqueue.h>
 #include INC_API(syscalls.h)
 #include INC_API(smp.h)
 #include INC_API(cpu.h)

--- a/kernel/src/runqueue.cc
+++ b/kernel/src/runqueue.cc
@@ -1,0 +1,16 @@
+#include <runqueue.h>
+#include INC_API(queueing.h)
+
+extern "C" void setrunqueue(tcb_t **head, tcb_t *tcb)
+{
+    if (!tcb)
+        return;
+    ENQUEUE_LIST_TAIL((*head), tcb, sched_state.ready_list);
+}
+
+extern "C" void remrq(tcb_t **head, tcb_t *tcb)
+{
+    if (!tcb)
+        return;
+    DEQUEUE_LIST((*head), tcb, sched_state.ready_list);
+}


### PR DESCRIPTION
## Summary
- add new runqueue helper implementations
- expose runqueue interface in new header
- build runqueue code with kernel
- include runqueue interface in schedulers

## Testing
- `make -C kernel` *(fails: Aieeee, this is the SOURCE directory!)*