### PR TITLE
Add POSIX spawn helper and test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,21 @@ add_executable(spinlock_fairness tests/spinlock_fairness.c)
 target_link_libraries(spinlock_fairness PRIVATE pthread)
 
 add_executable(posix_test_file tests/posix/test_file.c)
-add_executable(posix_test_process tests/posix/test_process.c)
+add_executable(posix_test_process
+    tests/posix/test_process.c
+    user/lib/posix/posix.cc
+)
+target_include_directories(posix_test_process PRIVATE ${CMAKE_SOURCE_DIR}/user/lib/posix)
+add_executable(posix_spawn_child
+    tests/posix/spawn_child.c
+    user/lib/posix/posix.cc
+)
+target_include_directories(posix_spawn_child PRIVATE ${CMAKE_SOURCE_DIR}/user/lib/posix)
+add_executable(posix_test_spawn_wait
+    tests/posix/test_spawn_wait.c
+    user/lib/posix/posix.cc
+)
+target_include_directories(posix_test_spawn_wait PRIVATE ${CMAKE_SOURCE_DIR}/user/lib/posix)
 
-add_custom_target(tests DEPENDS spinlock_fairness posix_test_file posix_test_process)
+add_custom_target(tests DEPENDS spinlock_fairness posix_test_file posix_test_process posix_spawn_child posix_test_spawn_wait)
 

--- a/Makefile
+++ b/Makefile
@@ -16,28 +16,35 @@ all: build/string.o
 .PHONY: all clean check tests
 
 build/tests:
-        mkdir -p build/tests
+	mkdir -p build/tests
 
 build/tests/posix:
-        mkdir -p build/tests/posix
+	mkdir -p build/tests/posix
 
 build/tests/spinlock_fairness: tests/spinlock_fairness.c | build/tests
-        $(CC) $(CFLAGS) -pthread $< -o $@
+	$(CC) $(CFLAGS) -pthread $< -o $@
 
 build/tests/posix/test_file: tests/posix/test_file.c | build/tests/posix
-        $(CC) $(CFLAGS) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
-build/tests/posix/test_process: tests/posix/test_process.c | build/tests/posix
-        $(CC) $(CFLAGS) $< -o $@
+build/tests/posix/test_process: tests/posix/test_process.c user/lib/posix/posix.cc | build/tests/posix
+	$(CXX) $(CXXFLAGS) -Iuser/lib/posix $^ -o $@
 
-tests: build/tests/spinlock_fairness build/tests/posix/test_file build/tests/posix/test_process
+build/tests/posix/spawn_child: tests/posix/spawn_child.c user/lib/posix/posix.cc | build/tests/posix
+	$(CXX) $(CXXFLAGS) -Iuser/lib/posix $^ -o $@
+
+build/tests/posix/test_spawn_wait: tests/posix/test_spawn_wait.c user/lib/posix/posix.cc | build/tests/posix build/tests/posix/spawn_child
+	$(CXX) $(CXXFLAGS) -Iuser/lib/posix $^ -o $@
+
+tests: build/tests/spinlock_fairness build/tests/posix/test_file build/tests/posix/test_process build/tests/posix/test_spawn_wait
 
 clean:
 	rm -rf build
 	find . -name '*.o' -delete
 
 check: all tests
-        python -m unittest discover -v tests
-        ./build/tests/spinlock_fairness
-        ./build/tests/posix/test_file
-        ./build/tests/posix/test_process
+	python -m unittest discover -v tests
+	./build/tests/spinlock_fairness
+	./build/tests/posix/test_file
+	./build/tests/posix/test_process
+	./build/tests/posix/test_spawn_wait

--- a/docs/building.md
+++ b/docs/building.md
@@ -214,7 +214,7 @@ See the top-level LICENSE file for the project's terms.
 ## Running tests
 
 The repository provides a small test suite consisting of Python unit tests,
-a C stress test for the ticket-lock implementation and a pair of simple
+a C stress test for the ticket-lock implementation and a trio of simple
 POSIX programs under `tests/posix`.  The Makefile exposes a `check` target
 which builds these programs and runs all tests:
 
@@ -229,6 +229,7 @@ $ cmake --build . --target tests
 ./spinlock_fairness
 ./posix_test_file
 ./posix_test_process
+./posix_test_spawn_wait
 ```
 
 The `spinlock_fairness` binary spawns multiple threads, measures how many times

--- a/tests/posix/spawn_child.c
+++ b/tests/posix/spawn_child.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+    puts("spawn child running");
+    return 7;
+}

--- a/tests/posix/test_spawn_wait.c
+++ b/tests/posix/test_spawn_wait.c
@@ -1,31 +1,27 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/wait.h>
 #include "posix.h"
+#include <stdio.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 int main(void) {
-    pid_t pid = posix_fork();
+    char *const args[] = {(char *)"./build/tests/posix/spawn_child", NULL};
+    pid_t pid = posix_spawn(args[0], args);
     if (pid < 0) {
-        perror("fork");
+        perror("posix_spawn");
         return 1;
-    }
-    if (pid == 0) {
-        puts("child running");
-        _exit(42);
     }
 
     int status = 0;
     if (posix_waitpid(pid, &status, 0) < 0) {
-        perror("waitpid");
+        perror("posix_waitpid");
         return 1;
     }
 
-    if (!WIFEXITED(status) || WEXITSTATUS(status) != 42) {
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 7) {
         fprintf(stderr, "unexpected status %d\n", status);
         return 1;
     }
 
-    puts("process test ok");
+    puts("spawn wait test ok");
     return 0;
 }

--- a/user/lib/posix/posix.cc
+++ b/user/lib/posix/posix.cc
@@ -1,5 +1,7 @@
 #include "posix.h"
 #include <fcntl.h>
+#include <stdlib.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 // These stub implementations directly invoke the host system calls.
@@ -24,5 +26,25 @@ ssize_t posix_write(int fd, const void *buf, size_t count)
 pid_t posix_fork(void)
 {
     return fork();
+}
+
+int posix_execv(const char *path, char *const argv[])
+{
+    return execv(path, argv);
+}
+
+pid_t posix_spawn(const char *path, char *const argv[])
+{
+    pid_t pid = fork();
+    if (pid == 0) {
+        execv(path, argv);
+        _exit(127);
+    }
+    return pid;
+}
+
+pid_t posix_waitpid(pid_t pid, int *status, int options)
+{
+    return waitpid(pid, status, options);
 }
 

--- a/user/lib/posix/posix.h
+++ b/user/lib/posix/posix.h
@@ -12,6 +12,9 @@ int posix_open(const char *path, int flags, unsigned mode);
 ssize_t posix_read(int fd, void *buf, size_t count);
 ssize_t posix_write(int fd, const void *buf, size_t count);
 pid_t posix_fork(void);
+int posix_execv(const char *path, char *const argv[]);
+pid_t posix_spawn(const char *path, char *const argv[]);
+pid_t posix_waitpid(pid_t pid, int *status, int options);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- expand `posix.h` with exec/spawn helpers and waitpid options
- implement helpers in `user/lib/posix`
- build new spawn child and spawn/wait tests
- update process test to use POSIX wrappers
- document the additional test

## Testing
- `make check`
- `cmake --build build_cmake --target tests`