### PR TITLE
Improve LLVM-based CMake build

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure essential Python tooling is present before running the full setup.
+python3 -m pip install --user --upgrade pre-commit compiledb configuredb
+pre-commit --version >/dev/null
+compiledb --version >/dev/null
+configuredb --help >/dev/null
+
 # Invoke repository root setup script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,35 @@ permissions:
   contents: read
 
 jobs:
+  cmake-clang:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install LLVM toolchain
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y clang lld llvm cmake ninja-build
+      - name: Install Python tools
+        run: |
+          python3 -m pip install --user pre-commit compiledb configuredb
+          pre-commit --version
+          compiledb --version
+          configuredb --help
+      - name: Configure
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_LINKER=lld \
+            -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build -j$(nproc)
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color always --all-files
+      - name: Run tests
+        run: |
+          cd build
+          ctest --output-on-failure
   build-userland:
     runs-on: ubuntu-latest
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,25 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
+
+# Require clang/LLVM toolchain
+if(NOT CMAKE_C_COMPILER MATCHES "clang$" AND NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR "Clang is required to build Pistachio")
+endif()
+if(NOT CMAKE_CXX_COMPILER MATCHES "clang\+\+$" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR "Clang++ is required to build Pistachio")
+endif()
+
 project(pistachio C CXX)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+foreach(lang C CXX)
+    set(CMAKE_${lang}_STANDARD 23)
+    set(CMAKE_${lang}_STANDARD_REQUIRED ON)
+endforeach()
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
 
 # Add Eigen headers if present
 include_directories(${CMAKE_SOURCE_DIR}/third_party/eigen)
@@ -9,8 +29,6 @@ set(TOOLPREFIX "" CACHE STRING "Prefix for cross compilation tools")
 set(SUBARCH "" CACHE STRING "Kernel sub-architecture")
 set(ARCH "" CACHE STRING "Kernel architecture")
 
-set(CMAKE_C_STANDARD 23)
-set(CMAKE_CXX_STANDARD 23)
 
 add_compile_options(-Werror)
 

--- a/README
+++ b/README
@@ -26,18 +26,17 @@ operation and super-fast IPC.
 Building with modern compilers
 ==============================
 
-The build system expects C23 and C++23 capable compilers. GCC 14 and
-Clang 17 are known to work. Autoconf 2.69 or later is required to
-regenerate the configure script. Detailed instructions, including
-cross‑compilation tips, are available in the
+The build system expects C23 and C++23 capable compilers. The
+LLVM toolchain with Clang 17 or newer is required. Autoconf 2.69 or
+later is needed only when regenerating the legacy `configure` script.
+Detailed instructions, including cross‑compilation tips, are available in the
 [`docs/building.md`](docs/building.md#cross-compilation) guide.
 
 
 Requirements
 ------------
-Pistachio requires a C compiler with C23 support and a C++ compiler
-that implements at least the C++23 standard. The minimum versions
-known to work are GCC 14 and Clang 17.
+Pistachio requires the LLVM toolchain with Clang and LLD providing
+C23 and C++23 support.  Clang 17 or newer is mandatory.
 
 Building on i686 and x86_64 hosts
 --------------------------------

--- a/docs/building.md
+++ b/docs/building.md
@@ -50,10 +50,11 @@ Adjust the values for your toolchain and desired target.
 =======
 # Building Pistachio
 
-This guide summarises how to build the kernel and user land with modern
-C23 and C++23 compilers.  GCC 14 and Clang 17 are known to work.  When
-building from a repository checkout run `pre-commit install --install-hooks`
-so that formatting and linting tools run automatically.
+This guide summarises how to build the kernel and user land using the
+LLVM toolchain.  A recent Clang (version 17 or newer) is required and
+`ld.lld` is used for linking.  When building from a repository checkout
+run `pre-commit install --install-hooks` so that formatting and linting
+tools run automatically.
 
 ## Kernel
 


### PR DESCRIPTION
## Summary
- enforce Clang/LLD in the root CMakeLists
- install required Python tooling in `.codex/setup.sh`
- document LLVM requirement in README and build guide
- add a CMake+Clang CI job

## Testing
- `pytest tests/test_subdomain.py tests/test_waitqueue.py`
- `pre-commit` *(failed: command not found)*