### PR TITLE
Add language restriction pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,9 @@ repos:
         entry: clang-tidy -p user
         language: system
         files: \.(c|cc|cpp|cxx|h|hpp)$
+      - id: check-sources
+        name: check-allowed-sources
+        entry: tools/check_allowed_sources.py
+        language: python
+        pass_filenames: false
 

--- a/README
+++ b/README
@@ -32,6 +32,9 @@ later is needed only when regenerating the legacy `configure` script.
 Detailed instructions, including cross‑compilation tips, are available in the
 [`docs/building.md`](docs/building.md#cross-compilation) guide.
 
+Only C++23 and platform‑agnostic assembly sources are permitted in the tree.
+Other languages must be transpiled or otherwise converted before inclusion.
+
 
 Requirements
 ------------
@@ -105,6 +108,8 @@ hooks manually if desired::
 With the hooks installed, each commit will automatically format and
 lint changed files.  Run `pre-commit` manually to check all files or
 `pre-commit autoupdate` to refresh hook versions.
+An additional hook rejects any staged files that are not C++23 or
+assembly sources, ensuring the repository remains language limited.
 
 Running clang-tidy
 ------------------

--- a/tools/check_allowed_sources.py
+++ b/tools/check_allowed_sources.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Pre-commit hook to ensure only permitted source languages are used."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Allowed file extensions for C and assembly sources
+ALLOWED_EXTS = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hpp",
+    ".hxx",
+    ".hh",
+    ".s",
+    ".S",
+    ".asm",
+}
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or []
+    if argv:
+        files = argv
+    else:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        files = result.stdout.splitlines()
+
+    disallowed = [f for f in files if Path(f).suffix not in ALLOWED_EXTS]
+    if disallowed:
+        print("Disallowed file types detected. Only C/C++23 and assembly sources "
+              "are permitted:")
+        for f in disallowed:
+            print(f"  {f}")
+        return 1
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- limit repository languages to C++23 and platform-agnostic assembly
- check staged files with a new pre-commit hook
- document language policy in README

## Testing
- `pytest -q`