### PR TITLE
Document Codex boot workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Repository Codex Instructions
+
+This repository uses Codex CLI to maintain the development environment. When the agent opens the repository it should:
+
+1. Ensure `.codex/setup.sh` is executable and matches the latest template hosted by the project. If differences exist, patch the file in place and commit with message `auto-heal setup.sh`.
+2. Run `shellcheck` on `.codex/setup.sh` and `setup.sh` and fix any reported issues.
+3. Execute `./setup.sh` with available network access so dependencies are fetched before the environment goes offline.
+4. When modifying any file, run `pre-commit` before committing.
+5. Tests live under `tests/`; run `pytest -q` and `ctest --output-on-failure` after changes if applicable.

--- a/README
+++ b/README
@@ -129,3 +129,18 @@ A collection of TLA+ specifications lives in the `tla/` directory. The
 the TLA+ tools are installed::
 
     $ java -cp /path/to/tla/lib/* tlc2.TLC -deadlock tla/TicketLock.tla
+
+Automated setup at boot
+-----------------------
+To ensure the development environment is fully prepared while network access is
+still available, you can enable the included systemd service. Copy
+`docs/systemd/codex-setup.service` to `/etc/systemd/system/`, reload the daemon
+and enable it::
+
+    $ sudo cp docs/systemd/codex-setup.service /etc/systemd/system/
+    $ sudo systemctl daemon-reload
+    $ sudo systemctl enable codex-setup.service
+
+The unit runs `codex` in full-auto mode to heal `setup.sh` and then executes the
+script before the network is restricted.
+

--- a/docs/systemd/codex-setup.service
+++ b/docs/systemd/codex-setup.service
@@ -1,0 +1,15 @@
+# Example systemd unit to heal and run setup.sh before networking
+[Unit]
+Description=Heal and run setup.sh before networking
+DefaultDependencies=no
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/codex -q -a full-auto "doctor setup.sh" && /usr/local/bin/setup.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
## Summary
- add AGENTS instructions for Codex automation
- provide an example systemd service to run `setup.sh` at boot
- document the boot workflow in the README

## Testing
- `pytest -q`
- `ctest --output-on-failure`