### PR TITLE
Fix tests to use engine include paths

### DIFF
--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -34,7 +34,7 @@ class CompilerAttributeTest(unittest.TestCase):
                 '-std=c++23',
                 '-Werror',
                 '-Wno-attributes',
-                '-Iuser/include',
+                '-Iengine/include',
                 '-c',
                 name,
             ], check=True)

--- a/tests/test_i16_build.py
+++ b/tests/test_i16_build.py
@@ -22,7 +22,7 @@ class I16CompilationTest(unittest.TestCase):
                 "-std=c++23",
                 "-Werror",
                 "-I",
-                str(ROOT / "user/include"),
+                str(ROOT / "engine/include"),
                 "-c",
                 str(src),
             ]

--- a/tests/test_ipc_helpers.py
+++ b/tests/test_ipc_helpers.py
@@ -25,7 +25,7 @@ class IpcHelpersBuildTest(unittest.TestCase):
                 compiler,
                 "-std=c++23",
                 "-I",
-                str(ROOT / "user/include"),
+                str(ROOT / "engine/include"),
                 "-c",
                 str(src),
             ]

--- a/tests/test_mlp_scheduler_build.py
+++ b/tests/test_mlp_scheduler_build.py
@@ -6,7 +6,7 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 CODE = r"""
-#include "../../user/lib/mlp/mlp.h"
+#include "../../engine/lib/mlp/mlp.h"
 int main() {
     float f[1] = {0};
     mlp_init(nullptr);
@@ -27,7 +27,7 @@ class MlpSchedulerBuildTest(unittest.TestCase):
                 compiler,
                 "-std=c++23",
                 "-I",
-                str(ROOT / "user/include"),
+                str(ROOT / "engine/include"),
                 "-I",
                 str(ROOT / "third_party/eigen"),
                 "-c",

--- a/tests/test_types_size.py
+++ b/tests/test_types_size.py
@@ -25,7 +25,7 @@ class TypeSizeCompilationTest(unittest.TestCase):
                 "-std=c++23",
                 "-Werror",
                 "-I",
-                str(ROOT / "user/include"),
+                str(ROOT / "engine/include"),
                 "-c",
                 str(src),
             ]


### PR DESCRIPTION
## Summary
- reference engine headers in build tests

## Testing
- `pytest -q`