### PR TITLE
Add debug flag for setup script

### DIFF
--- a/README
+++ b/README
@@ -102,6 +102,7 @@ formatters and linters such as **black**, **ruff**, **shellcheck** and
 script runs while network access is available so required packages can
 be downloaded.  After cloning the repository you can re-install the
 You can also run the script offline by placing the required `.deb` files in `offline_packages/` and invoking `./setup.sh --offline`.
+Use `DEBUG=1` or pass the `--debug` flag to see each command executed during setup.
 hooks manually if desired::
 
     $ pre-commit install --install-hooks

--- a/setup.sh
+++ b/setup.sh
@@ -1,14 +1,30 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2155
+#
+# Pistachio environment setup script. Options:
+#   --offline    Install packages from offline_packages/ only
+#   --debug or DEBUG=1  Enable verbose command tracing
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 # Optional offline mode installs packages from offline_packages/*.deb
 OFFLINE=0
+# Enable verbose tracing with DEBUG=1 or --debug
+DEBUG="${DEBUG:-0}"
 for arg in "$@"; do
-  if [ "$arg" = "--offline" ]; then
-    OFFLINE=1
-  fi
+  case "$arg" in
+    --offline)
+      OFFLINE=1
+      ;;
+    --debug)
+      DEBUG=1
+      ;;
+  esac
 done
+
+if [ "$DEBUG" = "1" ]; then
+  set -x
+fi
 
 # Log file for any failures during setup
 FAIL_LOG="/tmp/setup_failures.log"


### PR DESCRIPTION
## Summary
- add --debug/DEBUG=1 option to setup.sh
- document debug tracing in README

## Testing
- `shellcheck setup.sh` *(fails: command not found)*
- `shellcheck .codex/setup.sh` *(fails: command not found)*
- `DEBUG=1 ./setup.sh --offline`
- `pre-commit run --files README setup.sh` *(fails: command not found)*
- `pytest -q`
- `ctest --output-on-failure`