### PR TITLE
Update doc paths to engine/

### DIFF
--- a/README
+++ b/README
@@ -55,8 +55,8 @@ Once the exokernel and user land are built you can start resource
 managers using the `kickstart` utility.  For example, to build and
 launch the `sigma0` memory manager run::
 
-    $ make -C user/serv/sigma0
-    $ user/util/kickstart/kickstart -roottask=user/serv/sigma0/sigma0
+    $ make -C engine/serv/sigma0
+    $ engine/util/kickstart/kickstart -roottask=engine/serv/sigma0/sigma0
 
 `kickstart` loads the kernel and the specified user tasks and then
 transfers control to the resource manager.  Additional managers can be
@@ -65,22 +65,22 @@ specified on the command line in the order they should be started.
 To boot with the example memory and scheduler servers first build
 them::
 
-    $ make -C user/serv/memory
-    $ make -C user/serv/scheduler
+    $ make -C engine/serv/memory
+    $ make -C engine/serv/scheduler
 
 Then launch them together with the kernel using `kickstart`::
 
-    $ user/util/kickstart/kickstart \
-          -roottask=user/serv/memory/memory \
-          user/serv/scheduler/scheduler
+    $ engine/util/kickstart/kickstart \
+          -roottask=engine/serv/memory/memory \
+          engine/serv/scheduler/scheduler
 
 Additional servers can be started in the same manner.  For example,
 to also launch a device service pass its binary as another argument::
 
-    $ user/util/kickstart/kickstart \
-          -roottask=user/serv/memory/memory \
-          user/serv/scheduler/scheduler \
-          user/serv/device/device
+    $ engine/util/kickstart/kickstart \
+          -roottask=engine/serv/memory/memory \
+          engine/serv/scheduler/scheduler \
+          engine/serv/device/device
 
 
 Migration from the microkernel API
@@ -117,10 +117,10 @@ Running clang-tidy
 The tree includes a `.clang-tidy` configuration enabling the modernize
 and readability checks. The pre-commit hook runs the tool on modified
 C/C++ sources.  A `compile_commands.json` database is generated under
-`user/` to provide build flags.  Invoke the tool manually with the
+`engine/` to provide build flags.  Invoke the tool manually with the
 database path::
 
-    $ clang-tidy -p user path/to/file.cc
+    $ clang-tidy -p engine path/to/file.cc
 
 
 Model checking

--- a/docs/building.md
+++ b/docs/building.md
@@ -13,8 +13,8 @@ $ cmake --build .
 ```
 
 The default target compiles the example `string.o` object, builds the
- kernel using the Makefile under `kernel/` and builds the userland
- libraries from `user/lib`.
+ kernel using the Makefile under `engine/kernel` and builds the userland
+ libraries from `engine/lib`.
 
 To build individual pieces you can specify the targets explicitly:
 
@@ -31,7 +31,7 @@ $ cmake --build . --target userlib_clean
 ```
 
 These commands simply invoke the existing Makefiles so any custom
-settings in `kernel/Makeconf.local` or environment variables are still
+settings in `engine/kernel/Makeconf.local` or environment variables are still
 honoured.
 
 ### Cross compiling
@@ -138,7 +138,7 @@ TOOLPREFIX=/usr/bin/powerpc-linux-gnu-
 Build the kernel with `make`.  To run under QEMU:
 
 ```sh
-qemu-system-ppc -M g3beige -kernel kernel/powerpc-kernel
+qemu-system-ppc -M g3beige -kernel engine/kernel/powerpc-kernel
 ```
 
 For 64‑bit targets use `qemu-system-ppc64`.
@@ -166,7 +166,7 @@ The minimal real mode port builds with GCC's m16c cross compiler.  After
 installing `m16c-elf-gcc` the kernel can be compiled with:
 
 ```bash
-$ make -C kernel BUILDDIR=build-i16 TOOLPREFIX=m16c-elf- ARCH=i16 SUBARCH=x16
+$ make -C engine/kernel BUILDDIR=build-i16 TOOLPREFIX=m16c-elf- ARCH=i16 SUBARCH=x16
 ```
 
 ### CPU tuning flags

--- a/docs/exokernel_migration.md
+++ b/docs/exokernel_migration.md
@@ -39,34 +39,34 @@ By delegating these services the system gains flexibility: different application
 The memory server replaces the kernel's built‑in pager.  It receives
 allocation and deallocation requests from applications and returns raw
 memory frames.  All higher level allocators build on top of this
-service.  The implementation in `user/serv/memory` is intentionally
+service.  The implementation in `engine/serv/memory` is intentionally
 minimal to demonstrate how a user program can manage physical
 resources using only the kernel's IPC primitives.
 
 Build the server with::
 
-    $ make -C user/serv/memory
+    $ make -C engine/serv/memory
 
 Once compiled it can be started with `kickstart` together with the
 kernel image::
 
-    $ user/util/kickstart/kickstart -roottask=user/serv/memory/memory
+    $ engine/util/kickstart/kickstart -roottask=engine/serv/memory/memory
 
 ## Scheduler Server
 
 Scheduling policies are likewise moved out of the kernel.  The
-`user/serv/scheduler` example provides a rudimentary round‑robin
+`engine/serv/scheduler` example provides a rudimentary round‑robin
 scheduler that repeatedly calls `L4_ThreadSwitch` to hand the CPU to
 other threads.  More advanced policies can be implemented in the same
 way without enlarging the kernel.
 
 Compile the scheduler server via::
 
-    $ make -C user/serv/scheduler
+    $ make -C engine/serv/scheduler
 
 It may then be launched as an additional task using `kickstart`::
 
-    $ user/util/kickstart/kickstart \
-          -roottask=user/serv/memory/memory \
-          user/serv/scheduler/scheduler
+    $ engine/util/kickstart/kickstart \
+          -roottask=engine/serv/memory/memory \
+          engine/serv/scheduler/scheduler
 

--- a/docs/ipc_overview.md
+++ b/docs/ipc_overview.md
@@ -33,11 +33,11 @@ For an allocation request the server returns the allocated address in `MR1`.
 
 ### Scheduler server
 
-Scheduler messages use label `0x1234`. Five untyped words encode the `SchedRequest` structure from `user/lib/sched/sched_client.h`. Threads send a request with `L4_Call` and block until the server replies or performs a `L4_ThreadSwitch` to schedule the next thread.
+Scheduler messages use label `0x1234`. Five untyped words encode the `SchedRequest` structure from `engine/lib/sched/sched_client.h`. Threads send a request with `L4_Call` and block until the server replies or performs a `L4_ThreadSwitch` to schedule the next thread.
 
 ## Defining additional services
 
-New servers should pick a unique label and define packed request/reply structures. Client libraries can use `L4_MsgPut` or direct `L4_LoadMR` calls to copy these structures into `MR1` and beyond. Replies typically mirror the same layout. The examples under `user/serv/` provide small reference implementations.
+New servers should pick a unique label and define packed request/reply structures. Client libraries can use `L4_MsgPut` or direct `L4_LoadMR` calls to copy these structures into `MR1` and beyond. Replies typically mirror the same layout. The examples under `engine/serv/` provide small reference implementations.
 
 ## Cap'n Proto integration
 

--- a/docs/mlp_scheduler.md
+++ b/docs/mlp_scheduler.md
@@ -12,8 +12,8 @@ server:
 
 ```bash
 $ git clone https://gitlab.com/libeigen/eigen.git third_party/eigen
-$ make -C user/lib/mlp
-$ make -C user/serv/mlp_scheduler
+$ make -C engine/lib/mlp
+$ make -C engine/serv/mlp_scheduler
 ```
 
 ## Running
@@ -21,9 +21,9 @@ $ make -C user/serv/mlp_scheduler
 Launch the scheduler alongside the memory server with `kickstart`:
 
 ```bash
-$ user/util/kickstart/kickstart \
-      -roottask=user/serv/memory/memory \
-      user/serv/mlp_scheduler/mlp_scheduler
+$ engine/util/kickstart/kickstart \
+      -roottask=engine/serv/memory/memory \
+      engine/serv/mlp_scheduler/mlp_scheduler
 ```
 
 The scheduler loads a model file specified on the command line if

--- a/docs/posix_compatibility.md
+++ b/docs/posix_compatibility.md
@@ -43,7 +43,7 @@ the kernel only for low level IPC and context switching.
   [`docs/server_interfaces.md`](server_interfaces.md).
 - **POSIX syscall library** – a small C library that provides the standard
   functions (`open`, `read`, `write`, `fork`, etc.) and forwards them to the
-  above servers using the IPC helpers from `user/lib/exo`.
+  above servers using the IPC helpers from `engine/lib/exo`.
 
 Additional helpers such as a signal delivery library or a time server can be
 added to flesh out more of the specification.

--- a/docs/posix_roadmap.md
+++ b/docs/posix_roadmap.md
@@ -3,7 +3,7 @@
 This document synthesises the long term plan for implementing a full POSIX
 compatibility layer on top of Pistachio's exokernel.  The design draws from the
 existing exokernel migration notes and the partial servers found under
-`user/serv/`.  Each phase expands the current stubs into a feature complete
+`engine/serv/`.  Each phase expands the current stubs into a feature complete
 user-space subsystem while keeping the kernel minimal.
 
 ## Phase I – Build and Documentation Foundations
@@ -19,17 +19,17 @@ user-space subsystem while keeping the kernel minimal.
 ## Phase II – Memory Management Subsystem
 
 1. **Virtual memory manager** – extend the example `memory` server
-   (`user/serv/memory`) with page protection tracking and capability checks.
+   (`engine/serv/memory`) with page protection tracking and capability checks.
 2. **POSIX wrappers** – implement `px_mprotect`, `px_msync` and `px_mmap` in
-   `user/lib/posix` using IPC messages to the memory server.
+   `engine/lib/posix` using IPC messages to the memory server.
 3. **Testing** – create unit tests under `tests/` that exercise protection and
    mapping behaviour.
 
 ## Phase III – Process Management & Scheduling
 
-1. **Run queue structures** – flesh out `user/serv/scheduler` with a proper run
+1. **Run queue structures** – flesh out `engine/serv/scheduler` with a proper run
    queue and capability-aware state management.
-2. **Process server** – build on `user/serv/process` to provide `px_waitpid`,
+2. **Process server** – build on `engine/serv/process` to provide `px_waitpid`,
    `px_execve` and `px_spawn` interfaces.
 3. **Scheduling integration** – coordinate with the scheduler server to enforce
    preemptive multitasking and resource accounting.
@@ -88,7 +88,7 @@ user-space subsystem while keeping the kernel minimal.
 
 ## Phase X – Deployment and Examples
 
-1. **Example applications** – add small demo programs under `user/apps` showing
+1. **Example applications** – add small demo programs under `engine/apps` showing
    how to interact with the new APIs.
 2. **Deployment tooling** – script the launch of servers and demos with
    `kickstart` so that newcomers can reproduce a minimal POSIX environment.

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -34,7 +34,7 @@ class CompilerAttributeTest(unittest.TestCase):
                 '-std=c++23',
                 '-Werror',
                 '-Wno-attributes',
-                '-Iuser/include',
+                '-Iengine/include',
                 '-c',
                 name,
             ], check=True)

--- a/tests/test_i16_build.py
+++ b/tests/test_i16_build.py
@@ -22,7 +22,7 @@ class I16CompilationTest(unittest.TestCase):
                 "-std=c++23",
                 "-Werror",
                 "-I",
-                str(ROOT / "user/include"),
+                str(ROOT / "engine/include"),
                 "-c",
                 str(src),
             ]

--- a/tests/test_ipc_helpers.py
+++ b/tests/test_ipc_helpers.py
@@ -25,7 +25,7 @@ class IpcHelpersBuildTest(unittest.TestCase):
                 compiler,
                 "-std=c++23",
                 "-I",
-                str(ROOT / "user/include"),
+                str(ROOT / "engine/include"),
                 "-c",
                 str(src),
             ]

--- a/tests/test_mlp_scheduler_build.py
+++ b/tests/test_mlp_scheduler_build.py
@@ -6,7 +6,7 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 CODE = r"""
-#include "../../user/lib/mlp/mlp.h"
+#include "../../engine/lib/mlp/mlp.h"
 int main() {
     float f[1] = {0};
     mlp_init(nullptr);
@@ -27,7 +27,7 @@ class MlpSchedulerBuildTest(unittest.TestCase):
                 compiler,
                 "-std=c++23",
                 "-I",
-                str(ROOT / "user/include"),
+                str(ROOT / "engine/include"),
                 "-I",
                 str(ROOT / "third_party/eigen"),
                 "-c",

--- a/tests/test_types_size.py
+++ b/tests/test_types_size.py
@@ -25,7 +25,7 @@ class TypeSizeCompilationTest(unittest.TestCase):
                 "-std=c++23",
                 "-Werror",
                 "-I",
-                str(ROOT / "user/include"),
+                str(ROOT / "engine/include"),
                 "-c",
                 str(src),
             ]


### PR DESCRIPTION
## Summary
- update documentation to reference `engine/` paths instead of `user/`
- adjust build instructions for new layout
- update tests to point to `engine/include`

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q`
- `ctest --output-on-failure`