### PR TITLE
Add recursion-chimeric architecture notes

### DIFF
--- a/docs/exokernel_migration.md
+++ b/docs/exokernel_migration.md
@@ -2,6 +2,9 @@
 
 This document sketches the high level plan for transforming Pistachio's existing microkernel into a more minimal exokernel. The intent is to keep the kernel as small as possible while still supplying enough hooks to implement system functionality in user space.
 
+For ideas on blending microkernel message passing with recursively composed user-space services see
+[recursion_chimeric_design.md](recursion_chimeric_design.md).
+
 The source tree uses modern language features.  All C++ code now targets the
 C++23 standard.
 

--- a/docs/recursion_chimeric_design.md
+++ b/docs/recursion_chimeric_design.md
@@ -1,0 +1,17 @@
+# Recursion-Chimeric Kernel Architecture
+
+This note explores how Pistachio's ongoing exokernel migration can blend recursion-based abstractions with microkernel-style message passing. The intent is to achieve a "chimeric" design: keeping the kernel minimal while allowing user code to construct higher level facilities by recursively composing small services.
+
+## Overview
+
+1. **Minimal core** – The kernel exposes just enough primitives for scheduling, memory protection and IPC.
+2. **Recursive servers** – User-space components can themselves spawn lightweight servers that further delegate responsibilities, forming chains of decreasing trust.
+3. **Chimeric layering** – Where performance is critical, services may link directly to one another, effectively fusing layers. Less demanding components communicate over the standard message interfaces.
+
+## Goals
+
+- Allow services to be composed and optimised recursively without expanding the kernel.
+- Support experimentation with unconventional policies by mixing microkernel and exokernel techniques.
+- Maintain POSIX compatibility through user-space libraries layered atop this design.
+
+For a more complete description of the exokernel transition see [exokernel_migration.md](exokernel_migration.md).


### PR DESCRIPTION
## Summary
- document recursion-chimeric architecture blending microkernel and exokernel ideas
- reference the new document from exokernel migration notes

## Testing
- `pytest -q`
- `ctest --output-on-failure`
