### PR TITLE
Fix include paths in tests

### DIFF
--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -3,6 +3,9 @@ import subprocess
 import tempfile
 import textwrap
 import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
 
 class CompilerAttributeTest(unittest.TestCase):
     def test_function_pointer_attributes(self) -> None:
@@ -34,7 +37,8 @@ class CompilerAttributeTest(unittest.TestCase):
                 '-std=c++23',
                 '-Werror',
                 '-Wno-attributes',
-                '-Iengine/include',
+                '-I',
+                str(ROOT / 'user/include'),
                 '-c',
                 name,
             ], check=True)

--- a/tests/test_i16_build.py
+++ b/tests/test_i16_build.py
@@ -22,7 +22,7 @@ class I16CompilationTest(unittest.TestCase):
                 "-std=c++23",
                 "-Werror",
                 "-I",
-                str(ROOT / "engine/include"),
+                str(ROOT / "user/include"),
                 "-c",
                 str(src),
             ]

--- a/tests/test_ipc_helpers.py
+++ b/tests/test_ipc_helpers.py
@@ -25,7 +25,7 @@ class IpcHelpersBuildTest(unittest.TestCase):
                 compiler,
                 "-std=c++23",
                 "-I",
-                str(ROOT / "engine/include"),
+                str(ROOT / "user/include"),
                 "-c",
                 str(src),
             ]

--- a/tests/test_mlp_scheduler_build.py
+++ b/tests/test_mlp_scheduler_build.py
@@ -27,7 +27,7 @@ class MlpSchedulerBuildTest(unittest.TestCase):
                 compiler,
                 "-std=c++23",
                 "-I",
-                str(ROOT / "engine/include"),
+                str(ROOT / "user/include"),
                 "-I",
                 str(ROOT / "third_party/eigen"),
                 "-c",

--- a/tests/test_types_size.py
+++ b/tests/test_types_size.py
@@ -25,7 +25,7 @@ class TypeSizeCompilationTest(unittest.TestCase):
                 "-std=c++23",
                 "-Werror",
                 "-I",
-                str(ROOT / "engine/include"),
+                str(ROOT / "user/include"),
                 "-c",
                 str(src),
             ]


### PR DESCRIPTION
## Summary
- use `user/include` when compiling tests
- fix attributes test to compute repository root

## Testing
- `pytest -q`
- `ctest --output-on-failure`