### PR TITLE
Add functional tooling and tests

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,51 @@
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(cmd, input=None):
+    res = subprocess.run(cmd, input=input, text=True, capture_output=True, check=True)
+    return res.stdout.strip()
+
+
+def test_bitfield_gen(tmp_path):
+    spec = tmp_path / "spec.yml"
+    spec.write_text("FIELD_A: [0, 1]\nFIELD_B: [2, 3]\n")
+    out = run([str(ROOT / "tools/bitfield_gen.py"), str(spec)])
+    assert "FIELD_A_SHIFT" in out
+    assert "FIELD_B_MASK" in out
+
+
+def test_condition_to_cpp(tmp_path):
+    xml = tmp_path / "cond.xml"
+    xml.write_text("<and><config var='A'/><not><config var='B'/></not></and>")
+    out = run([str(ROOT / "tools/condition.py"), str(xml)])
+    assert out == "(defined(A) && !defined(B))"
+
+
+def test_syscall_header_gen(tmp_path):
+    out_file = tmp_path / "sys.h"
+    run([str(ROOT / "tools/syscall_header_gen.py"), str(out_file)])
+    data = out_file.read_text()
+    assert "SYSCALL_CALL" in data
+
+
+def test_invocation_header_gen(tmp_path):
+    out_file = tmp_path / "inv.h"
+    run([str(ROOT / "tools/invocation_header_gen.py"), str(out_file)])
+    data = out_file.read_text()
+    assert "seL4_Call" in data
+
+
+def test_changed_sh():
+    out = run(["bash", str(ROOT / "tools/changed.sh"), "HEAD" ])
+    assert isinstance(out, str)
+
+
+def test_xmllint_sh(tmp_path):
+    xml = tmp_path / "a.xml"
+    xml.write_text("<root/>")
+    out = run(["bash", str(ROOT / "tools/xmllint.sh"), str(xml)])
+    assert out == ""
+

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,55 @@
+# Pistachio Helper Tools
+
+This directory provides small utilities used when building or validating the
+kernel sources.
+
+## bitfield_gen.py
+
+```
+$ tools/bitfield_gen.py spec.yml > bitfields.h
+```
+
+Reads a YAML description of bitfields and prints C macros containing shift and
+mask definitions.
+
+## invocation_header_gen.py
+
+```
+$ tools/invocation_header_gen.py out.h
+```
+
+Parses `engine/api/syscall.xml` and writes a header declaring simple `static`
+syscall stubs.
+
+## syscall_header_gen.py
+
+```
+$ tools/syscall_header_gen.py out.h
+```
+
+Generates numeric syscall constants from the same XML specification.
+
+## condition.py
+
+```
+$ tools/condition.py condition.xml
+```
+
+Converts an XML condition to a C preprocessor expression on stdout.
+
+## changed.sh
+
+```
+$ tools/changed.sh [COMMIT]
+```
+
+Lists files changed since `COMMIT` (defaults to the previous commit).
+
+## xmllint.sh
+
+```
+$ tools/xmllint.sh [schema.xsd] file.xml
+```
+
+Validates `file.xml` using `xmllint` if installed, otherwise falls back to a
+basic Python parser.

--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -1,7 +1,86 @@
 #!/usr/bin/env python3
-"""Placeholder for bitfield_gen.py."""
+"""Generate C macros for simple bitfield definitions.
 
-def main() -> int:
+The script reads a YAML file describing named fields and their bit ranges
+and emits ``#define`` statements that encode masks and shift constants.
+
+The YAML format is a mapping of field names to ``[start, end]`` bit
+positions (inclusive).  The least significant bit is ``0``.
+
+Example
+-------
+
+.. code-block:: yaml
+
+   FIELD_A: [0, 3]
+   FIELD_B: [4, 7]
+
+Running ``bitfield_gen.py spec.yml`` will produce macros of the form::
+
+   #define FIELD_A_SHIFT 0
+   #define FIELD_A_MASK  0x0000000f
+
+   #define FIELD_B_SHIFT 4
+   #define FIELD_B_MASK  0x000000f0
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+def _load_spec(path: Path) -> Mapping[str, Sequence[int]]:
+    """Load the YAML specification from ``path``."""
+
+    with path.open("r", encoding="utf-8") as fh:
+        text = fh.read()
+    if yaml:
+        data = yaml.safe_load(text)
+    else:
+        import re
+
+        data = {}
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            name, rest = line.split(":", 1)
+            bits = [int(x) for x in re.findall(r"\d+", rest)]
+            data[name.strip()] = bits
+    if not isinstance(data, dict):
+        raise ValueError("Specification must be a mapping")
+    return data
+
+
+def _emit_macros(spec: Mapping[str, Sequence[int]]) -> str:
+    """Return C preprocessor definitions for ``spec``."""
+
+    lines = []
+    for name, (start, end) in spec.items():
+        width = end - start + 1
+        mask = ((1 << width) - 1) << start
+        lines.append(f"#define {name}_SHIFT {start}")
+        lines.append(f"#define {name}_MASK  0x{mask:08x}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for console use."""
+
+    argv = argv if argv is not None else sys.argv[1:]
+    if not argv or len(argv) != 1:
+        print("Usage: bitfield_gen.py <spec.yml>")
+        return 1
+    spec_path = Path(argv[0])
+    macros = _emit_macros(_load_spec(spec_path))
+    print(macros)
     return 0
 
 if __name__ == "__main__":

--- a/tools/changed.sh
+++ b/tools/changed.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
-# Placeholder for changed.sh
-exit 0
+# Simple helper printing files changed since a given git commit.
+
+set -euo pipefail
+
+base="${1:-HEAD^}"
+git diff --name-only "$base"

--- a/tools/condition.py
+++ b/tools/condition.py
@@ -1,7 +1,40 @@
 #!/usr/bin/env python3
-"""Placeholder for condition.py."""
+"""Utility functions to translate XML build conditions to C expressions."""
 
-def main() -> int:
+from __future__ import annotations
+
+import sys
+from xml.etree import ElementTree as ET
+
+
+def condition_to_cpp(elem: ET.Element) -> str:
+    """Convert an XML condition element to a C preprocessor expression."""
+
+    tag = elem.tag
+    if tag == "config":
+        var = elem.attrib["var"]
+        return f"defined({var})"
+    if tag == "and":
+        parts = [condition_to_cpp(child) for child in elem]
+        return "(" + " && ".join(parts) + ")"
+    if tag == "or":
+        parts = [condition_to_cpp(child) for child in elem]
+        return "(" + " || ".join(parts) + ")"
+    if tag == "not":
+        child, = list(elem)
+        return "!" + condition_to_cpp(child)
+    raise ValueError(f"Unsupported condition tag: {tag}")
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI for converting a single condition element."""
+
+    argv = argv if argv is not None else sys.argv[1:]
+    if len(argv) != 1:
+        print("Usage: condition.py <condition.xml>")
+        return 1
+    tree = ET.parse(argv[0])
+    root = tree.getroot()
+    print(condition_to_cpp(root))
     return 0
 
 if __name__ == "__main__":

--- a/tools/invocation_header_gen.py
+++ b/tools/invocation_header_gen.py
@@ -1,7 +1,65 @@
 #!/usr/bin/env python3
-"""Placeholder for invocation_header_gen.py."""
+"""Generate a minimal C header declaring syscall stubs.
 
-def main() -> int:
+This script parses ``engine/api/syscall.xml`` and emits a header with
+``static inline`` prototypes for each syscall.  It is a very small subset
+of the original tooling used by the kernel but suffices for unit tests and
+examples.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+sys.path.append(str(Path(__file__).resolve().parent))
+from condition import condition_to_cpp
+
+API_XML = Path("engine/api/syscall.xml")
+
+
+def _iter_syscalls(xml: Path) -> list[tuple[str, str | None]]:
+    """Return ``[(name, condition)]`` pairs from *xml*."""
+
+    tree = ET.parse(xml)
+    root = tree.getroot()
+    pairs: list[tuple[str, str | None]] = []
+    for config in root.findall(".//config"):
+        cond_elem = config.find("condition")
+        condition = None
+        if cond_elem is not None and len(cond_elem):
+            condition = condition_to_cpp(cond_elem[0])
+        for sc in config.findall("syscall"):
+            name = sc.attrib["name"]
+            pairs.append((name, condition))
+    return pairs
+
+
+def _generate_header(syscalls: list[tuple[str, str | None]]) -> str:
+    lines = [
+        "/* Auto-generated syscall prototypes */",
+        "#pragma once",
+        "",
+    ]
+    for name, cond in syscalls:
+        if cond:
+            lines.append(f"#if {cond}")
+        lines.append(f"static inline int seL4_{name}(void);")
+        if cond:
+            lines.append("#endif")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    out = Path(argv[0]) if argv else None
+    syscalls = _iter_syscalls(API_XML)
+    header = _generate_header(syscalls)
+    if out:
+        out.write_text(header, encoding="utf-8")
+    else:
+        print(header)
     return 0
 
 if __name__ == "__main__":

--- a/tools/syscall_header_gen.py
+++ b/tools/syscall_header_gen.py
@@ -1,7 +1,62 @@
 #!/usr/bin/env python3
-"""Placeholder for syscall_header_gen.py."""
+"""Generate a header defining syscall numbers.
 
-def main() -> int:
+The script parses ``engine/api/syscall.xml`` and produces ``#define``
+statements assigning incremental numbers to each syscall.  Conditional
+syscalls are wrapped in preprocessor guards derived from the condition
+expressions in the XML.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+sys.path.append(str(Path(__file__).resolve().parent))
+from condition import condition_to_cpp
+
+API_XML = Path("engine/api/syscall.xml")
+
+
+def _iter_syscalls(xml: Path) -> list[tuple[str, str | None]]:
+    tree = ET.parse(xml)
+    root = tree.getroot()
+    pairs: list[tuple[str, str | None]] = []
+    for config in root.findall(".//config"):
+        cond_elem = config.find("condition")
+        condition = None
+        if cond_elem is not None and len(cond_elem):
+            condition = condition_to_cpp(cond_elem[0])
+        for sc in config.findall("syscall"):
+            name = sc.attrib["name"]
+            pairs.append((name, condition))
+    return pairs
+
+
+def _generate_header(syscalls: list[tuple[str, str | None]]) -> str:
+    lines = ["/* Auto-generated syscall numbers */", "#pragma once", ""]
+    counter = 0
+    for name, cond in syscalls:
+        if cond:
+            lines.append(f"#if {cond}")
+        lines.append(f"#define SYSCALL_{name.upper():<24} {counter}")
+        counter += 1
+        if cond:
+            lines.append("#endif")
+    lines.append(f"#define SYSCALL_MAX {counter}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    out = Path(argv[0]) if argv else None
+    syscalls = _iter_syscalls(API_XML)
+    header = _generate_header(syscalls)
+    if out:
+        out.write_text(header, encoding="utf-8")
+    else:
+        print(header)
     return 0
 
 if __name__ == "__main__":

--- a/tools/xmllint.sh
+++ b/tools/xmllint.sh
@@ -1,3 +1,45 @@
 #!/usr/bin/env bash
-# Placeholder for xmllint.sh
-exit 0
+# Validate XML using xmllint if available, otherwise fall back to Python.
+
+set -euo pipefail
+
+schema=""
+file=""
+if [ "$#" -eq 2 ]; then
+    schema="$1"
+    file="$2"
+elif [ "$#" -eq 1 ]; then
+    file="$1"
+else
+    echo "Usage: xmllint.sh [schema.xsd] file.xml" >&2
+    exit 1
+fi
+
+if command -v xmllint >/dev/null 2>&1; then
+    if [ -n "$schema" ]; then
+        xmllint --noout --schema "$schema" "$file"
+    else
+        xmllint --noout "$file"
+    fi
+else
+    if [ -n "$schema" ]; then
+        python3 - <<'EOF' "$schema" "$file"
+import sys
+from xml.etree import ElementTree as ET
+
+schema = sys.argv[1] if len(sys.argv) == 3 else None
+file = sys.argv[-1]
+ET.parse(file)  # raises on invalid XML
+if schema:
+    print('Warning: schema validation skipped (xmllint not available)')
+EOF
+    else
+        python3 - <<'EOF' "$file"
+import sys
+from xml.etree import ElementTree as ET
+
+file = sys.argv[1]
+ET.parse(file)
+EOF
+    fi
+fi


### PR DESCRIPTION
## Summary
- implement python and shell scripts under `tools/`
- document tool usage
- add unit tests for new scripts

## Testing
- `pytest -q`
- `ctest --output-on-failure`
- `shellcheck .codex/setup.sh` *(fails: command not found)*
- `shellcheck setup.sh` *(fails: command not found)*