### PR TITLE
Fix build Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,63 @@
+# Use ccache if available to speed up rebuilds.
 CCWRAP := $(shell command -v ccache)
+
 ifdef CCWRAP
-CC ?= $(CCWRAP) clang
-CXX ?= $(CCWRAP) clang++
+    # Prepend ccache to the compiler command when found.
+    CC ?= $(CCWRAP) clang
+    CXX ?= $(CCWRAP) clang++
 else
-CC ?= clang
-CXX ?= clang++
+    # Fallback to plain clang when ccache is not installed.
+    CC ?= clang
+    CXX ?= clang++
 endif
 
+# Default compilation flags for C and C++ files.
 CFLAGS ?= -std=c2x
 CXXFLAGS ?= -std=c++23
+# Optimize for the native CPU.
 CPU_CFLAGS ?= -march=native
+
+# Apply common flags to both C and C++ builds.
 CFLAGS += $(CPU_CFLAGS)
 CXXFLAGS += $(CPU_CFLAGS)
 CFLAGS += -Werror
 CXXFLAGS += -Werror
 
-build/string.o: user/contrib/elf-loader/platform/amd64-pc99/string.cc
-        echo Building string.o
-        mkdir -p build
-        $(CXX) $(CXXFLAGS) -Iuser/include -Iuser/contrib/elf-loader/include -c $< -o $@
+# Build the C++ string implementation used by the bootstrap loader.
+build/string.o: engine/include/user/contrib/elf-loader/platform/amd64-pc99/string.cc
+	echo Building string.o
+	mkdir -p build
+	$(CXX) $(CXXFLAGS) -Iengine/include/user/include -Iengine/include/user/contrib/elf-loader/include -c $< -o $@
 
 all: build/string.o
 
 .PHONY: all clean check tests
 
+# Directory for compiled test binaries.
 build/tests:
 	mkdir -p build/tests
 
+# Directory for POSIX compatibility tests.
 build/tests/posix:
 	mkdir -p build/tests/posix
 
-build/tests/spinlock_fairness: tests/spinlock_fairness.c | build/tests
+# Build the spinlock fairness benchmark used for performance regression tests.
+build/tests/spinlock_fairness: engine/include/tests/spinlock_fairness.c | build/tests
+	# Compile the spinlock benchmark using pthreads support.
 	$(CC) $(CFLAGS) -pthread $< -o $@
-build/tests/posix/test_file: tests/posix/test_file.c | build/tests/posix
+	# Verify correct file handling operations on a POSIX-like environment.
+build/tests/posix/test_file: engine/include/tests/posix/test_file.c | build/tests/posix
+	# Build the POSIX file operation test program.
 	$(CC) $(CFLAGS) $< -o $@
-build/tests/posix/test_process: tests/posix/test_process.c | build/tests/posix
+	# Check fork and exec behaviour for basic process management.
+build/tests/posix/test_process: engine/include/tests/posix/test_process.c | build/tests/posix
+	# Compile the basic fork/exec behaviour checker.
 	$(CC) $(CFLAGS) $< -o $@
-build/tests/posix/dirlist: user/apps/dirlist.c | build/tests/posix
+	# Build a directory listing utility for tests.
+build/tests/posix/dirlist: engine/include/user/apps/dirlist.c | build/tests/posix
+	# Compile a simple directory listing utility used by tests.
 	$(CC) $(CFLAGS) $< -o $@
+# Aggregate all test binaries into the "tests" target
 tests: build/tests/spinlock_fairness build/tests/posix/test_file build/tests/posix/test_process build/tests/posix/dirlist
 clean:
 	rm -rf build


### PR DESCRIPTION
## Summary
- fix test build paths in Makefile
- add descriptive comments to build rules

## Testing
- `pytest -q`
- `ctest --output-on-failure`
- `make`
- `make tests`

This environment doesn't have network access after setup, so Codex couldn't run certain commands.