### PR TITLE
Update standard flags to C17/C++17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ else
 endif
 
 # Default compilation flags for C and C++ files.
-CFLAGS ?= -std=c2x
-CXXFLAGS ?= -std=c++23
+CFLAGS ?= -std=c17
+CXXFLAGS ?= -std=c++17
 # Optimize for the native CPU.
 CPU_CFLAGS ?= -march=native
 

--- a/engine/include/kernel 2/Mk/Makeconf
+++ b/engine/include/kernel 2/Mk/Makeconf
@@ -175,7 +175,7 @@ CCFLAGS += -fno-rtti -fno-builtin  -fomit-frame-pointer -fno-exceptions \
           $(CFLAGS_$(ARCH)) $(CFLAGS_$(CPU)) $(CFLAGS_$(PLATFORM))
 
 # C++ compiler flags build on C compiler flags and set the C++ standard
-CXXFLAGS += $(CCFLAGS) -std=c++23
+CXXFLAGS += $(CCFLAGS) -std=c++17
 CXXFLAGS += -Werror
 
 ifeq ("$(CC_VERSION)", "4")

--- a/engine/include/tests/test_attributes.py
+++ b/engine/include/tests/test_attributes.py
@@ -31,7 +31,7 @@ class CompilerAttributeTest(unittest.TestCase):
         try:
             subprocess.run([
                 compiler,
-                '-std=c++23',
+                '-std=c++17',
                 '-Werror',
                 '-Wno-attributes',
                 '-Iuser/include',

--- a/engine/include/tests/test_i16_build.py
+++ b/engine/include/tests/test_i16_build.py
@@ -19,7 +19,7 @@ class I16CompilationTest(unittest.TestCase):
             cmd = [
                 compiler,
                 "-m16",
-                "-std=c++23",
+                "-std=c++17",
                 "-Werror",
                 "-I",
                 str(ROOT / "user/include"),

--- a/engine/include/tests/test_ipc_helpers.py
+++ b/engine/include/tests/test_ipc_helpers.py
@@ -23,7 +23,7 @@ class IpcHelpersBuildTest(unittest.TestCase):
             compiler = os.getenv("CXX", "clang++")
             cmd = [
                 compiler,
-                "-std=c++23",
+                "-std=c++17",
                 "-I",
                 str(ROOT / "user/include"),
                 "-c",

--- a/engine/include/tests/test_memparse_tool.py
+++ b/engine/include/tests/test_memparse_tool.py
@@ -18,7 +18,7 @@ class MemparseToolTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             binary = Path(td) / "memparse"
             compiler = os.getenv("CXX", "clang++")
-            cmd = [compiler, "-std=c++23", str(SOURCE), "-o", str(binary)]
+            cmd = [compiler, "-std=c++17", str(SOURCE), "-o", str(binary)]
             try:
                 subprocess.check_output(cmd, stderr=subprocess.STDOUT)
             except (subprocess.CalledProcessError, FileNotFoundError) as exc:

--- a/engine/include/tests/test_mlp_scheduler_build.py
+++ b/engine/include/tests/test_mlp_scheduler_build.py
@@ -25,7 +25,7 @@ class MlpSchedulerBuildTest(unittest.TestCase):
             compiler = os.getenv("CXX", "clang++")
             cmd = [
                 compiler,
-                "-std=c++23",
+                "-std=c++17",
                 "-I",
                 str(ROOT / "user/include"),
                 "-I",

--- a/engine/include/tests/test_self_ipc.py
+++ b/engine/include/tests/test_self_ipc.py
@@ -20,7 +20,7 @@ class SelfIpcBuildTest(unittest.TestCase):
             compiler = os.getenv("CXX", "clang++")
             cmd = [
                 compiler,
-                "-std=c++23",
+                "-std=c++17",
                 "-I",
                 str(ROOT / "user/include"),
                 "-I",

--- a/engine/include/tests/test_typed_channel.py
+++ b/engine/include/tests/test_typed_channel.py
@@ -20,7 +20,7 @@ class TypedChannelBuildTest(unittest.TestCase):
             compiler = os.getenv("CXX", "clang++")
             cmd = [
                 compiler,
-                "-std=c++23",
+                "-std=c++17",
                 "-I",
                 str(ROOT / "user/include"),
                 "-I",

--- a/engine/include/tests/test_types_size.py
+++ b/engine/include/tests/test_types_size.py
@@ -22,7 +22,7 @@ class TypeSizeCompilationTest(unittest.TestCase):
             cmd = [
                 compiler,
                 flag,
-                "-std=c++23",
+                "-std=c++17",
                 "-Werror",
                 "-I",
                 str(ROOT / "user/include"),

--- a/engine/include/user/compile_commands.json
+++ b/engine/include/user/compile_commands.json
@@ -1,77 +1,77 @@
 [
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi-loader.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi-loader.cc",
     "file": "/workspace/pistachio/user/util/kickstart/mbi-loader.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/ia32.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/ia32.cc",
     "file": "/workspace/pistachio/user/util/kickstart/ia32.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/powerpc.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/powerpc.cc",
     "file": "/workspace/pistachio/user/util/kickstart/powerpc.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/fdt-loader.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/fdt-loader.cc",
     "file": "/workspace/pistachio/user/util/kickstart/fdt-loader.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/fdt.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/fdt.cc",
     "file": "/workspace/pistachio/user/util/kickstart/fdt.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi-amd64.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi-amd64.cc",
     "file": "/workspace/pistachio/user/util/kickstart/mbi-amd64.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/kickstart.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/kickstart.cc",
     "file": "/workspace/pistachio/user/util/kickstart/kickstart.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi-ia32.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi-ia32.cc",
     "file": "/workspace/pistachio/user/util/kickstart/mbi-ia32.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/kipmgr.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/kipmgr.cc",
     "file": "/workspace/pistachio/user/util/kickstart/kipmgr.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/bootinfo.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/bootinfo.cc",
     "file": "/workspace/pistachio/user/util/kickstart/bootinfo.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/mbi.cc",
     "file": "/workspace/pistachio/user/util/kickstart/mbi.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/lib.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/lib.cc",
     "file": "/workspace/pistachio/user/util/kickstart/lib.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/fdt-powerpc.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/fdt-powerpc.cc",
     "file": "/workspace/pistachio/user/util/kickstart/fdt-powerpc.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/elf.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/elf.cc",
     "file": "/workspace/pistachio/user/util/kickstart/elf.cc"
   },
   {
     "directory": "/workspace/pistachio/user",
-    "command": "clang++ -std=c++23 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/amd64.cc",
+    "command": "clang++ -std=c++17 -Iinclude -Iutil/kickstart -Ilib/io -I. -DREVISION=0 -include config.h -c util/kickstart/amd64.cc",
     "file": "/workspace/pistachio/user/util/kickstart/amd64.cc"
   }
 ]

--- a/engine/include/user/config.mk
+++ b/engine/include/user/config.mk
@@ -48,9 +48,9 @@ SHELL=		/bin/sh
 CC=		cc
 CXX=		$(CC) -x c++
 AS=		$(CC)
-CFLAGS=		-std=c2x
+CFLAGS=		-std=c17
 CXXFLAGS=       $(CXXSTD) -fno-exceptions
-CXXSTD=	-std=c++23
+CXXSTD=	-std=c++17
 LDFLAGS=	
 CPPFLAGS= -I$(top_srcdir)/../third_party/eigen
 LGCC=		-lgcc

--- a/engine/include/user/configure.in
+++ b/engine/include/user/configure.in
@@ -160,17 +160,17 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
     [AC_MSG_FAILURE([$CC does not support -std=c2x])])
 CFLAGS="$save_CFLAGS"
 
-AC_MSG_CHECKING([whether $CC accepts -std=c++23])
+AC_MSG_CHECKING([whether $CC accepts -std=c++17])
 save_CFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS -x c++ -std=c++23"
+CFLAGS="$CFLAGS -x c++ -std=c++17"
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],
-    [ac_cxx23=yes],
-    [ac_cxx23=no])
+    [ac_cxx17=yes],
+    [ac_cxx17=no])
 CFLAGS="$save_CFLAGS"
-if test "$ac_cxx23" = yes; then
-  CXXSTD="-std=c++23"
+if test "$ac_cxx17" = yes; then
+  CXXSTD="-std=c++17"
 else
-  AC_MSG_FAILURE([$CC does not support -std=c++23])
+  AC_MSG_FAILURE([$CC does not support -std=c++17])
 fi
 AC_MSG_RESULT([$CXXSTD])
 AC_SUBST([CXXSTD])

--- a/engine/include/user/create_ccdb.py
+++ b/engine/include/user/create_ccdb.py
@@ -3,7 +3,7 @@ cc = []
 base_dir = os.getcwd()
 flags = [
     "clang++",
-    "-std=c++23",
+    "-std=c++17",
     "-Iinclude",
     "-Iutil/kickstart",
     "-Ilib/io",

--- a/engine/kernel/Mk/Makeconf
+++ b/engine/kernel/Mk/Makeconf
@@ -175,7 +175,7 @@ CCFLAGS += -fno-rtti -fno-builtin  -fomit-frame-pointer -fno-exceptions \
           $(CFLAGS_$(ARCH)) $(CFLAGS_$(CPU)) $(CFLAGS_$(PLATFORM))
 
 # C++ compiler flags build on C compiler flags and set the C++ standard
-CXXFLAGS += $(CCFLAGS) -std=c++23
+CXXFLAGS += $(CCFLAGS) -std=c++17
 CXXFLAGS += -Werror
 
 ifeq ("$(CC_VERSION)", "4")

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
+# Set the default language standards for C++ and C.
 project('pistachio_demos', ['cpp', 'c'],
-    default_options: ['cpp_std=c++23', 'c_std=c23'])
+    default_options: ['cpp_std=c++17', 'c_std=c17'])
 
 add_project_arguments('-Werror', language: ['c', 'cpp'])
 


### PR DESCRIPTION
## Summary
- switch Meson and Makefile defaults to C17 and C++17
- adjust kernel Makeconf and other helper scripts for C++17
- update tests expecting C++ standard flag

## Testing
- `pytest -q`
- `ctest --output-on-failure`
- `pre-commit run --files meson.build Makefile "engine/include/kernel 2/Mk/Makeconf" engine/include/user/create_ccdb.py engine/include/user/config.mk engine/include/user/configure.in engine/include/user/compile_commands.json engine/include/tests/test_attributes.py engine/include/tests/test_i16_build.py engine/include/tests/test_ipc_helpers.py engine/include/tests/test_memparse_tool.py engine/include/tests/test_mlp_scheduler_build.py engine/include/tests/test_self_ipc.py engine/include/tests/test_typed_channel.py engine/include/tests/test_types_size.py` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a1c32886c833188590df1197e800d