### PR TITLE
auto-heal setup.sh

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Auto-heal: ensure strict mode and invoke repo setup
 
 # Install core build tools and helpers
 apt-get update -y

--- a/setup.sh
+++ b/setup.sh
@@ -246,11 +246,11 @@ fi
 
 if [ "$OFFLINE" -eq 1 ]; then
   echo "Installing packages from offline_packages directory" | tee -a "$FAIL_LOG"
-  if ls offline_packages/*.deb >/dev/null 2>&1; then
-    dpkg -i offline_packages/*.deb || echo "dpkg install issues" | tee -a "$FAIL_LOG"
-  else
-    echo "No .deb packages found in offline_packages" | tee -a "$FAIL_LOG"
-  fi
+if compgen -G "offline_packages/*.deb" >/dev/null; then
+  dpkg -i offline_packages/*.deb || echo "dpkg install issues" | tee -a "$FAIL_LOG"
+else
+  echo "No .deb packages found in offline_packages" | tee -a "$FAIL_LOG"
+fi
 fi
 
 # Ensure critical Python tooling is present even if package installs were skipped


### PR DESCRIPTION
## Summary
- fix offline package check in `setup.sh`
- add auto-heal comment in `.codex/setup.sh`

## Testing
- `pytest -q`
- `ctest --output-on-failure` *(no tests found)*
- `pre-commit` *(failed: command not found)*
- `shellcheck` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a272d93c883319d8ce3f402d19a40