### PR TITLE
Improve unified build script compiler detection

### DIFF
--- a/README
+++ b/README
@@ -41,6 +41,9 @@ Requirements
 ------------
 Pistachio requires the LLVM toolchain with Clang and LLD providing
 C23 and C++23 support.  Clang 17 or newer is mandatory.
+The helper script `scripts/unified_build.sh` expects `clang` and
+`clang++` in `PATH`. When they are missing the script attempts to use
+`gcc` and `g++` instead, printing a diagnostic message.
 
 Building on i686 and x86_64 hosts
 --------------------------------

--- a/scripts/unified_build.sh
+++ b/scripts/unified_build.sh
@@ -1,8 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Simple wrapper to configure, build and test using CMake
+# Simple wrapper to configure, build and test using CMake.
 BUILD_DIR=${BUILD_DIR:-build}
+
+# Determine the compiler. Prefer Clang but gracefully fall back to GCC.
+if command -v clang >/dev/null 2>&1 && command -v clang++ >/dev/null 2>&1; then
+  # Use the Clang toolchain when available.
+  export CC=clang
+  export CXX=clang++
+elif command -v gcc >/dev/null 2>&1 && command -v g++ >/dev/null 2>&1; then
+  # Inform the user about the fallback to GCC.
+  echo "clang not found, falling back to gcc" >&2
+  export CC=gcc
+  export CXX=g++
+else
+  # Abort if no suitable compiler exists.
+  echo "error: clang/clang++ not found and gcc/g++ unavailable" >&2
+  exit 1
+fi
 
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"


### PR DESCRIPTION
## Summary
- enhance `scripts/unified_build.sh` to select clang or gcc
- document clang/gcc requirement in README

## Testing
- `pytest -q`
- `ctest --output-on-failure` *(no tests found)*
- `pre-commit` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bbfb621e08331acf3f074cfc2e29e