### PR TITLE
Fix allowed source message

### DIFF
--- a/tools/check_allowed_sources.py
+++ b/tools/check_allowed_sources.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Pre-commit hook to ensure only permitted source languages are used."""
+"""Pre-commit hook to ensure only permitted source languages are used.
+
+This script rejects staged files with extensions other than the allowed C23,
+C++23, and assembly source types. It can also check an explicit list of files
+passed as command line arguments.
+"""
 
 from __future__ import annotations
 
@@ -7,7 +12,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Allowed file extensions for C and assembly sources
+# Allowed file extensions for C23, C++23, and assembly sources
 ALLOWED_EXTS = {
     ".c",
     ".cc",
@@ -22,8 +27,17 @@ ALLOWED_EXTS = {
     ".asm",
 }
 
+
 def main(argv: list[str] | None = None) -> int:
+    """Entry point for the hook.
+
+    If ``argv`` is provided, those filenames are checked directly. Otherwise the
+    script examines the staged git diff and checks the listed files.
+    """
+
     argv = argv or []
+
+    # Determine which files to inspect
     if argv:
         files = argv
     else:
@@ -35,14 +49,19 @@ def main(argv: list[str] | None = None) -> int:
         )
         files = result.stdout.splitlines()
 
+    # Filter out files with extensions not in the allowed set
     disallowed = [f for f in files if Path(f).suffix not in ALLOWED_EXTS]
+
     if disallowed:
-        print("Disallowed file types detected. Only C/C++23 and assembly sources "
-              "are permitted:")
+        print(
+            "Disallowed file types detected. Only C23, C++23, and assembly sources"
+            " are permitted:"
+        )
         for f in disallowed:
             print(f"  {f}")
         return 1
     return 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- clarify the pre-commit hook message in `check_allowed_sources.py`

## Testing
- `black tools/check_allowed_sources.py`
- `ruff check tools/check_allowed_sources.py`
- `pytest -q`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_683bbfd228508331bd5b2ca6bf3fe523