### PR TITLE
Update compiler documentation

### DIFF
--- a/README
+++ b/README
@@ -26,21 +26,21 @@ operation and super-fast IPC.
 Building with modern compilers
 ==============================
 
-The build system expects C23 and C++23 capable compilers. The
+The build system expects C17 and C++17 capable compilers. The
 LLVM toolchain with Clang 17 or newer is required. Autoconf 2.69 or
 later is needed only when regenerating the legacy `configure` script.
 Detailed instructions, including cross‑compilation tips, are available in the
 [`docs/building.md`](docs/building.md#cross-compilation) guide. Legacy design
 notes have been moved under `docs/legacy/`.
 
-Only C++23 and platform‑agnostic assembly sources are permitted in the tree.
+Only C++17 and platform‑agnostic assembly sources are permitted in the tree.
 Other languages must be transpiled or otherwise converted before inclusion.
 
 
 Requirements
 ------------
 Pistachio requires the LLVM toolchain with Clang and LLD providing
-C23 and C++23 support.  Clang 17 or newer is mandatory.
+C17 and C++17 support.  Clang 17 or newer is mandatory.
 
 Building on i686 and x86_64 hosts
 --------------------------------
@@ -109,7 +109,7 @@ hooks manually if desired::
 With the hooks installed, each commit will automatically format and
 lint changed files.  Run `pre-commit` manually to check all files or
 `pre-commit autoupdate` to refresh hook versions.
-An additional hook rejects any staged files that are not C++23 or
+An additional hook rejects any staged files that are not C++17 or
 assembly sources, ensuring the repository remains language limited.
 
 Running clang-tidy

--- a/docs/building.md
+++ b/docs/building.md
@@ -17,8 +17,9 @@ $ scripts/unified_build.sh
 
 ```bash
 $ mkdir build && cd build
-$ cmake ..
+$ cmake -G Ninja ..
 $ cmake --build .
+$ ctest --output-on-failure
 ```
 
 The default target compiles the example `string.o` object, builds the
@@ -56,7 +57,6 @@ $ cmake --build .
 
 Adjust the values for your toolchain and desired target.
 
-=======
 # Building Pistachio
 
 This guide summarises how to build the kernel and user land using the
@@ -207,7 +207,7 @@ $ make CPU_CFLAGS="-march=power9"
 
 The `contrib/include` directory also provides `svr4_machdep.hpp`, a
 header that translates the historic SVR4 machine dependencies into a
-typed C++23 interface.  A short usage sample lives in
+typed C++17 interface.  A short usage sample lives in
 `docs/svr4_machdep_cpp23.cpp`.
 
 ### Calling conventions

--- a/docs/exokernel_migration.md
+++ b/docs/exokernel_migration.md
@@ -3,7 +3,7 @@
 This document sketches the high level plan for transforming Pistachio's existing microkernel into a more minimal exokernel. The intent is to keep the kernel as small as possible while still supplying enough hooks to implement system functionality in user space.
 
 The source tree uses modern language features.  All C++ code now targets the
-C++23 standard.
+C++17 standard.
 
 ## Goals
 


### PR DESCRIPTION
## Summary
- document use of C17/C++17 compilers
- update exokernel migration notes
- show final build command with Ninja and tests

## Testing
- `pytest -q`
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_683bbfd6e650833184ea2b5f768ea0f2