### PR TITLE
Add yield_to syscall with quantum transfer

### DIFF
--- a/engine/include/schedule.h
+++ b/engine/include/schedule.h
@@ -178,6 +178,28 @@ void dispatch_thread(tcb_t * tcb);
 
 tcb_t * parse_wakeup_queue(dword_t current_prio, qword_t current_time);
 
+/**
+ * System call to switch to a target thread immediately.
+ *
+ * @param tid  target thread identifier
+ */
+void sys_thread_switch(l4_threadid_t tid);
+
+/**
+ * System call to donate time slice to a target thread.
+ *
+ * @param tid  target thread identifier
+ */
+void sys_yield_to(l4_threadid_t tid);
+
+/**
+ * Modify scheduling parameters of a thread.
+ *
+ * @param param scheduling parameters
+ * @param tid   target thread identifier
+ */
+void sys_schedule(schedule_param_t param, l4_threadid_t tid);
+
 /*
  * time
  */

--- a/engine/include/tracepoint_list.h
+++ b/engine/include/tracepoint_list.h
@@ -15,6 +15,7 @@
 DEFINE_TP(SYS_IPC, 		"sys_ipc(src=%x, dest=%x)")
 DEFINE_TP(SYS_SCHEDULE,		"sys_schedule")
 DEFINE_TP(SYS_THREAD_SWITCH, 	"sys_thread_switch(dest=%x)")
+DEFINE_TP(SYS_YIELD_TO,         "sys_yield_to(dest=%x)")
 DEFINE_TP(SYS_LTHREAD_EX_REGS,	"sys_lthread_ex_regs")
 DEFINE_TP(SYS_TASK_NEW,		"sys_task_new(tid=%x, pager=%x)")
 DEFINE_TP(SYS_ID_NEAREST, 	"sys_id_nearest(tid=%x, uip=%x)")

--- a/engine/include/x86/init.h
+++ b/engine/include/x86/init.h
@@ -57,6 +57,7 @@ extern "C" void int_51();
 extern "C" void int_52();
 extern "C" void int_53();
 extern "C" void int_54();
+extern "C" void int_55();
 
 extern "C" void timer_irq();
 

--- a/engine/src/x86/exception.S
+++ b/engine/src/x86/exception.S
@@ -24,6 +24,7 @@
 # define SYS_LTHREAD_EX_REGS	_Z19sys_lthread_ex_regsjjj13l4_threadid_t
 # define SYS_SCHEDULE		_Z12sys_schedule16schedule_param_t13l4_threadid_t
 # define SYS_THREAD_SWITCH	_Z17sys_thread_switch13l4_threadid_t
+# define SYS_YIELD_TO         _Z12sys_yield_to13l4_threadid_t
 # define SYS_TASK_NEW		_Z12sys_task_new13l4_threadid_tjS_jj
 # define SYS_FPAGE_UNMAP	_Z15sys_fpage_unmap7fpage_tj
 
@@ -52,6 +53,7 @@
 # define SYS_LTHREAD_EX_REGS	sys_lthread_ex_regs__FUiUiUiG13l4_threadid_t
 # define SYS_SCHEDULE		sys_schedule__FG16schedule_param_tG13l4_threadid_t
 # define SYS_THREAD_SWITCH	sys_thread_switch__FG13l4_threadid_t
+# define SYS_YIELD_TO         sys_yield_to__FG13l4_threadid_t
 # define SYS_TASK_NEW		sys_task_new__FG13l4_threadid_tUiT0UiUi
 # define SYS_FPAGE_UNMAP	sys_fpage_unmap__FG7fpage_tUi		
 
@@ -1051,6 +1053,13 @@ ENTRY(int_54)
 	pushl	%esi
 	set_kds(eax)
 	call	SYS_TASK_NEW
+ENTRY(int_55)
+        pushl   %esi
+        set_kds(eax)
+        call    SYS_YIELD_TO
+        ke("sys_yield_to returned")
+        # does not return
+
 
 	
 		

--- a/engine/src/x86/init.c
+++ b/engine/src/x86/init.c
@@ -686,6 +686,7 @@ void setup_idt()
     add_syscall_gate(53, int_53);
     add_syscall_gate(54, int_54);
 
+    add_syscall_gate(55, int_55);
 #ifdef CONFIG_X86_APIC
     add_int_gate(APIC_LINT0_INT_VECTOR, apic_lint0);
     add_int_gate(APIC_LINT1_INT_VECTOR, apic_lint1);


### PR DESCRIPTION
## Summary
- support new `yield_to()` syscall for scheduler
- donate remaining timeslice to chosen thread if it is runnable
- wire up new system call in x86 exception handler and IDT
- expose tracing and headers for the new API

## Testing
- `pre-commit run --files engine/include/schedule.h engine/include/tracepoint_list.h engine/include/x86/init.h engine/src/schedule.c engine/src/x86/exception.S engine/src/x86/init.c` *(fails: command not found)*
- `pytest -q`
- `ctest --output-on-failure` *(produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_684e0e8ffbec8331be338e9e94370c53