### PR TITLE
Fix PQCrypto setup and clang-format hook

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -15,10 +15,12 @@ apt-get install -y --no-install-recommends \
 # Work around Debian's PEP 668 restrictions by allowing pip to alter
 # the system installation when creating the development environment.
 python3 -m pip install --upgrade --break-system-packages \
-    pre-commit compiledb 
-export PATH="$(python3 -m site --user-base)/bin:$PATH"
+    pre-commit compiledb pqcrypto
+PATH_ADDITION="$(python3 -m site --user-base)/bin"
+export PATH="$PATH_ADDITION:$PATH"
 pre-commit --version >/dev/null
 compiledb --help >/dev/null
+python3 -c "import pqcrypto" >/dev/null
 
 # Invoke repository root setup script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
         entry: clang-format -i
         language: system
         files: \.(c|cc|cpp|cxx|h|hpp)$
+        stages: [commit]
       - id: clang-tidy
         name: clang-tidy
         entry: clang-tidy -p user

--- a/setup.sh
+++ b/setup.sh
@@ -263,7 +263,8 @@ for pip_pkg in \
 	pytest \
 	pyyaml \
 	pylint \
-	pyfuzz; do
+        pyfuzz \
+        pqcrypto; do
 	pip3 install ${PIP_FLAGS:-} -U "$pip_pkg" || echo "pip install $pip_pkg failed" | tee -a "$FAIL_LOG"
 done
 if ! python3 -m pre_commit --version >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add pqcrypto install to setup scripts
- update PATH handling in `.codex/setup.sh`
- add clang-format commit stage to pre-commit config

## Testing
- `shellcheck .codex/setup.sh`
- `shellcheck setup.sh`
- `pytest -q`
- `ctest --output-on-failure`
- `pre-commit run --files .codex/setup.sh .pre-commit-config.yaml setup.sh` *(fails: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_e_684e0e9999d483319a2e96d7123af501